### PR TITLE
Fixes crash module extension detection and resolveAs method

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/Jira.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/Jira.kt
@@ -9,6 +9,7 @@ import net.rcarz.jiraclient.Field
 import net.rcarz.jiraclient.Issue
 import net.rcarz.jiraclient.JiraClient
 import net.rcarz.jiraclient.Version
+import net.sf.json.JSONObject
 import java.net.URI
 import java.time.Instant
 
@@ -48,8 +49,11 @@ fun addComment(issue: Issue, comment: String) = runBlocking {
 
 fun resolveAs(issue: Issue, resolution: String) = runBlocking {
     Either.catch {
+        val resolutionJson = JSONObject()
+        resolutionJson["name"] = resolution
+
         issue.transition()
-            .field(Field.RESOLUTION, resolution)
+            .field(Field.RESOLUTION, resolutionJson)
             .execute("Resolve Issue")
     }
 }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/CrashModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/CrashModule.kt
@@ -56,7 +56,7 @@ class CrashModule(
     }
 
     private fun isCrashAttachment(attachment: Attachment) =
-        crashReportExtensions.any { it == attachment.mimeType }
+        crashReportExtensions.any { it == attachment.fileName.substring(attachment.fileName.lastIndexOf(".") + 1) }
 
     private fun isTextDocumentRecent(textDocument: TextDocument): Boolean {
         val calendar = Calendar.getInstance()

--- a/src/test/kotlin/io/github/mojira/arisa/modules/CrashModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/CrashModuleTest.kt
@@ -592,9 +592,8 @@ class CrashModuleTest : StringSpec({
 
 private fun mockAttachment(name: String, created: Date, content: ByteArray): Attachment {
     val attachment = mockk<Attachment>()
-    every { attachment.contentUrl } returns name
+    every { attachment.fileName } returns name
     every { attachment.createdDate } returns created
-    every { attachment.mimeType } returns name.substring(name.lastIndexOf('.') + 1)
     every { attachment.download() } returns content
     return attachment
 }


### PR DESCRIPTION
I just ran a test in MCTEST with the crash module active and noticed 2 bugs.

1. The attachment's mimeType is not the extension, but something like `plain/Text` and thus does not equal `.txt` for crash reports.
2. The `resolveAs` method did not work. This was because the API expects a JSON object containing a key with either `id` or `name` and a respective value. The used library does not know which of these it is given, so it must be specified.
