### PR TITLE
fix crash module using whitelist from empty module

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/ArisaMain.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ArisaMain.kt
@@ -243,7 +243,7 @@ fun initModules(config: Config, jiraClient: JiraClient): (Issue) -> Map<String, 
                     )
                 )
             },
-            "Crash" to runIfWhitelisted(issue, config[Arisa.Modules.Empty.whitelist]) {
+            "Crash" to runIfWhitelisted(issue, config[Arisa.Modules.Crash.whitelist]) {
                 crashModule(
                     CrashModuleRequest(
                         issue.attachments,


### PR DESCRIPTION
Whoops.
Totally not my fault 😛 