### PR TITLE
Filter projects after caching

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -74,19 +74,16 @@
       },
 
       "removeTriagedMeqs": {
-        "jql": "(cf[12200] != EMPTY OR cf[12201] != EMPTY) AND (comment ~ MEQS_WAI OR comment ~ MEQS_WONTFIX)",
         "meqsTags": ["MEQS_WAI", "MEQS_WONTFIX"],
         "removalReason": "Ticket has been triaged."
       },
 
       "futureVersion": {
-        "jql": "affectedVersion in unreleasedVersions() AND updated > -1d",
         "message": "{panel:borderColor=orange}(!) Please do not mark _Unreleased Versions_ as affected. You don't have access to them yet.{panel}\n~{color:#888}-- I am a bot. This action was performed automagically! Please report any issues in [Discord|https://discordapp.com/invite/rpCyfKV] or [Reddit|https://www.reddit.com/r/Mojira/]{color}~"
       },
 
       "chk": {
-        "whitelist": ["MC", "MCL", "MCPE"],
-        "jql": "resolution = Unresolved AND cf[10500] != unconfirmed AND CHK = EMPTY"
+        "whitelist": ["MC", "MCL", "MCPE"]
       },
 
       "reopenAwaiting": {
@@ -125,7 +122,6 @@
           "Won't Fix",
           "Works As Intended"
         ],
-        "jql": "comment ~ MEQS_KEEP_PRIVATE AND level = EMPTY",
         "tag": "MEQS_KEEP_PRIVATE",
         "message": "{panel:borderColor=orange}(!) Please do not unmark issues from _private_ after a moderator had set it that way{panel}\n~{color:#888}-- I am a bot. This action was performed automagically! Please report any issues in [Discord|https://discordapp.com/invite/rpCyfKV] or [Reddit|https://www.reddit.com/r/Mojira/]{color}~"
       },

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
@@ -296,7 +296,7 @@ class ModuleExecutor(
 
         issues
             .filter { it.project.key in projects }
-            .filter { it.resolution?.name ?: "unresolved" in resolutions }
+            .filter { it.resolution?.name?.toLowerCase() ?: "unresolved" in resolutions }
             .map { it.key to executeModule(it) }
             .forEach { (issue, response) ->
                 response.second.fold({

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
@@ -282,21 +282,21 @@ class ModuleExecutor(
         executeModule: (Issue) -> Pair<String, Either<ModuleError, ModuleResponse>>
     ) {
         val projects = (config[moduleConfig.whitelist] ?: config[Arisa.Issues.projects])
-        val resolutions = config[moduleConfig.resolutions].joinToString(",") { "\"$it\"" }
+        val resolutions = config[moduleConfig.resolutions].map { it.toLowerCase() }
 
-        val combinedJql =
-            "resolution in ($resolutions) AND (${config[moduleConfig.jql].format(lastRun)})"
+        val jql = config[moduleConfig.jql].format(lastRun)
 
-        val issues = cache.getQuery(combinedJql) ?: jiraClient
-            .searchIssues(combinedJql)
+        val issues = cache.getQuery(jql) ?: jiraClient
+            .searchIssues(jql)
             .issues
             .map { jiraClient.getIssue(it.key, "*all", "changelog") } // Get issues again to retrieve all fields
             .filter(::lastActionWasAResolve)
 
-        cache.addQuery(combinedJql, issues)
+        cache.addQuery(jql, issues)
 
         issues
             .filter { it.project.key in projects }
+            .filter { it.resolution?.name ?: "Unresolved" in resolutions }
             .map { it.key to executeModule(it) }
             .forEach { (issue, response) ->
                 response.second.fold({

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
@@ -282,7 +282,7 @@ class ModuleExecutor(
         executeModule: (Issue) -> Pair<String, Either<ModuleError, ModuleResponse>>
     ) {
         val projects = (config[moduleConfig.whitelist] ?: config[Arisa.Issues.projects])
-        val resolutions = config[moduleConfig.resolutions].map { it.toLowerCase() }
+        val resolutions = config[moduleConfig.resolutions].map(String::toLowerCase)
 
         val jql = config[moduleConfig.jql].format(lastRun)
 
@@ -296,7 +296,7 @@ class ModuleExecutor(
 
         issues
             .filter { it.project.key in projects }
-            .filter { it.resolution?.name ?: "Unresolved" in resolutions }
+            .filter { it.resolution?.name ?: "unresolved" in resolutions }
             .map { it.key to executeModule(it) }
             .forEach { (issue, response) ->
                 response.second.fold({


### PR DESCRIPTION
## Purpose
Filter projects after caching the issues to avoid having to call jira multiple times

## Approach
Cache without filtering by projects, then filter on each module

#### Checklist
- [x] Included tests
- [x] Tested in MCTEST-xxx
