### PR TITLE
Resolve trash to invalid automagically

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -1,18 +1,27 @@
 {
   "arisa": {
     "issues": {
-      "projects": ["MC", "MCTEST", "MCPE", "MCAPI", "MCL", "MCD", "MCE", "BDS", "REALMS", "WEB"],
+      "projects": [
+        "MC",
+        "MCTEST",
+        "MCPE",
+        "MCAPI",
+        "MCL",
+        "MCD",
+        "MCE",
+        "BDS",
+        "REALMS",
+        "WEB"
+      ],
       "url": "https://bugs.mojang.com/",
       "checkInterval": 10
     },
-
     "customFields": {
       "chkField": "customfield_10701",
       "confirmationField": "customfield_10500",
       "mojangPriorityField": "customfield_12200",
       "triagedTimeField": "customfield_12201"
     },
-
     "privateSecurityLevel": {
       "default": "10318",
       "special": {
@@ -20,7 +29,6 @@
         "MCAPI": "10313"
       }
     },
-
     "modules": {
       "attachment": {
         "resolutions": [
@@ -35,9 +43,17 @@
           "Won't Fix",
           "Works As Intended"
         ],
-        "extensionBlacklist": ["jar", "exe", "com", "bat", "msi", "run", "lnk", "dmg"]
+        "extensionBlacklist": [
+          "jar",
+          "exe",
+          "com",
+          "bat",
+          "msi",
+          "run",
+          "lnk",
+          "dmg"
+        ]
       },
-
       "piracy": {
         "message": "*Thank you for your report!*\nHowever, this issue is {color:#FF5722}*Invalid*{color}.\n\nYou are currently using a *non-authorized* version of Minecraft. If you wish to purchase the full game, please visit the [Minecraft Store|https://www.minecraft.net/store/minecraft-java-edition].\nWe will not provide support for pirated versions of the game, these versions are modified and may contain malware.\n\n\n*Quick Links*:\n\uD83D\uDCD3 [Issue Guidelines|https://bugs.mojang.com/projects/MC/summary] -- \uD83D\uDCAC [Community Support|https://discord.gg/58Sxm23] -- \uD83D\uDCE7 [Customer Support|https://help.minecraft.net/hc/en-us/requests/new] -- \uD83D\uDCD6 [Game Wiki|https://minecraft.gamepedia.com/Minecraft_Wiki]\n~{color:#888}-- I am a bot. This action was performed automagically! Please report any issues in [Discord|https://discordapp.com/invite/rpCyfKV] or [Reddit|https://www.reddit.com/r/Mojira/]{color}~",
         "piracySignatures": [
@@ -72,43 +88,54 @@
           "Titan"
         ]
       },
-
       "removeTriagedMeqs": {
-        "meqsTags": ["MEQS_WAI", "MEQS_WONTFIX"],
+        "meqsTags": [
+          "MEQS_WAI",
+          "MEQS_WONTFIX"
+        ],
         "removalReason": "Ticket has been triaged."
       },
-
       "futureVersion": {
         "message": "{panel:borderColor=orange}(!) Please do not mark _Unreleased Versions_ as affected. You don't have access to them yet.{panel}\n~{color:#888}-- I am a bot. This action was performed automagically! Please report any issues in [Discord|https://discordapp.com/invite/rpCyfKV] or [Reddit|https://www.reddit.com/r/Mojira/]{color}~"
       },
-
       "chk": {
-        "whitelist": ["MC", "MCL", "MCPE"]
+        "whitelist": [
+          "MC",
+          "MCL",
+          "MCPE"
+        ]
       },
-
       "reopenAwaiting": {
-        "resolutions": ["Awaiting Response"]
+        "resolutions": [
+          "Awaiting Response"
+        ]
       },
-
       "removeNonStaffMeqs": {
         "removalReason": "Comment was not properly staff-restricted."
       },
-
       "empty": {
         "message": "*Thank you for your report!*\nHowever, this issue is {color:#FF5722}*Incomplete*{color}.\n\nYour report does not contain enough information. As such, we're unable to understand or reproduce the problem.\nPlease review the guidelines linked below before making further reports.\n\nIn case of a game crash, be sure to attach the crashlog from {{[minecraft/crash-reports/crash-<DATE>-client.txt|https://minecrafthopper.net/help/guides/finding-minecraft-data-folder/]}}.\n\n*Quick Links*:\n\uD83D\uDCD3 [Issue Guidelines|https://bugs.mojang.com/projects/MC/summary] -- \uD83D\uDCAC [Community Support|https://discord.gg/58Sxm23] -- \uD83D\uDCE7 [Customer Support|https://help.minecraft.net/hc/en-us/requests/new] -- \uD83D\uDCD6 [Game Wiki|https://minecraft.gamepedia.com/Minecraft_Wiki]\n~{color:#888}-- I am a bot. This action was performed automagically! Please report any issues in [Discord|https://discordapp.com/invite/rpCyfKV] or [Reddit|https://www.reddit.com/r/Mojira/]{color}~"
       },
-
       "crash": {
         "maxAttachmentAge": 30,
-        "crashExtensions": ["txt", "log"],
+        "crashExtensions": [
+          "txt",
+          "log"
+        ],
         "duplicateMessage": "*Thank you for your report!*\nWe're actually already tracking this issue in *%s*, so I've resolved and linked this ticket as a duplicate.\n\nPlease take a look at the linked ticket and see if there is any fix available.\n\nIf you need additional help with a technical problem, please visit [Community Support|https://discord.gg/58Sxm23].\n\n*Quick Links*:\n\uD83D\uDCD3 [Issue Guidelines|https://bugs.mojang.com/projects/MC/summary] -- \uD83D\uDCAC [Community Support|https://discord.gg/58Sxm23] -- \uD83D\uDCE7 [Customer Support|https://help.minecraft.net/hc/en-us/requests/new] -- \uD83D\uDCD6 [Game Wiki|https://minecraft.gamepedia.com/Minecraft_Wiki]~{color:#888}-- I am a bot. This action was performed automagically! Please report any issues in [Discord|https://discordapp.com/invite/rpCyfKV] or [Reddit|https://www.reddit.com/r/Mojira/]{color}~",
         "moddedMessage": "*Thank you for your report!*\nHowever, this issue is {color:#FF5722}*Invalid*{color}.\n\nYour game, launcher or server is modified.\nIf you can reproduce the issue in a vanilla environment, please recreate the issue.\n\n* Any non-standard client/server/launcher build needs to be taken up with the appropriate team, not Mojang.\n* Any plugin issues need to be addressed to the creator of the plugin or resource pack.\n* If you have problems on large servers, such as The Hive and Hypixel, please contact them first as they run modified server software.\n\n\n*Quick Links*:\n\uD83D\uDCD3 [Issue Guidelines|https://bugs.mojang.com/projects/MC/summary] -- \uD83D\uDCAC [Community Support|https://discord.gg/58Sxm23] -- \uD83D\uDCE7 [Customer Support|https://help.minecraft.net/hc/en-us/requests/new] -- \uD83D\uDCD6 [Game Wiki|https://minecraft.gamepedia.com/Minecraft_Wiki]\n~{color:#888}-- I am a bot. This action was performed automagically! Please report any issues in [Discord|https://discordapp.com/invite/rpCyfKV] or [Reddit|https://www.reddit.com/r/Mojira/]{color}~"
       },
-
       "revokeConfirmation": {
-        "whitelist": ["MC", "MCL", "MCPE", "BDS", "MCTEST", "MCD", "MCE"]
+        "whitelist": [
+          "MC",
+          "MCL",
+          "MCPE",
+          "BDS",
+          "MCTEST",
+          "MCD",
+          "MCE"
+        ]
       },
-
       "keepPrivate": {
         "resolutions": [
           "Awaiting Response",
@@ -125,8 +152,15 @@
         "tag": "MEQS_KEEP_PRIVATE",
         "message": "{panel:borderColor=orange}(!) Please do not unmark issues from _private_ after a moderator had set it that way{panel}\n~{color:#888}-- I am a bot. This action was performed automagically! Please report any issues in [Discord|https://discordapp.com/invite/rpCyfKV] or [Reddit|https://www.reddit.com/r/Mojira/]{color}~"
       },
-
-      "hideImpostors": {}
+      "hideImpostors": {},
+      "resolveTrash": {
+        "resolutions": [
+          "Unresolved"
+        ],
+        "whitelist": [
+          "TRASH"
+        ]
+      }
     }
   }
 }

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
@@ -34,6 +34,7 @@ import io.github.mojira.arisa.modules.PiracyModule
 import io.github.mojira.arisa.modules.RemoveNonStaffMeqsModule
 import io.github.mojira.arisa.modules.RemoveTriagedMeqsModule
 import io.github.mojira.arisa.modules.ReopenAwaitingModule
+import io.github.mojira.arisa.modules.ResolveTrashModule
 import io.github.mojira.arisa.modules.RevokeConfirmationModule
 import net.rcarz.jiraclient.ChangeLogEntry
 import net.rcarz.jiraclient.Issue
@@ -69,6 +70,7 @@ class ModuleExecutor(
     )
     private val reopenAwaitingModule: ReopenAwaitingModule = ReopenAwaitingModule()
     private val revokeConfirmationModule: RevokeConfirmationModule = RevokeConfirmationModule()
+    private val resolveTrash: ResolveTrashModule = ResolveTrashModule()
 
     fun execute(lastRun: Long): Boolean {
         var allModulesSuccessful = true
@@ -266,6 +268,14 @@ class ModuleExecutor(
                                 }
                         },
                     ::updateConfirmation.partially1(issue).partially1(config[Arisa.CustomFields.confirmationField])
+                )
+            )
+        }
+        exec(Arisa.Modules.ResolveTrash) { issue ->
+            "ResolveTrash" to resolveTrash(
+                ResolveTrashModule.Request(
+                    issue.project.key,
+                    ::resolveAs.partially1(issue).partially1("Invalid")
                 )
             )
         }

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
@@ -81,6 +81,8 @@ object Arisa : ConfigSpec() {
         }
 
         object HideImpostors : ModuleConfigSpec()
+
+        object ResolveTrash : ModuleConfigSpec()
     }
 }
 

--- a/src/main/kotlin/io/github/mojira/arisa/modules/Module.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/Module.kt
@@ -44,12 +44,14 @@ fun tryRunAll(
     }
 }
 
-fun <T> assertEquals(o1: T, o2: T) = when (o1) {
-    o2 -> Unit.right()
-    else -> OperationNotNeededModuleResponse.left()
+fun <T> assertEquals(o1: T, o2: T) = if (o1 == o2) {
+    Unit.right()
+} else {
+    OperationNotNeededModuleResponse.left()
 }
 
-fun <T> assertNotEquals(o1: T, o2: T) = when (o1) {
-    o2 -> OperationNotNeededModuleResponse.left()
-    else -> Unit.right()
+fun <T> assertNotEquals(o1: T, o2: T) = if (o1 == o2) {
+    OperationNotNeededModuleResponse.left()
+} else {
+    Unit.right()
 }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/ResolveTrashModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ResolveTrashModule.kt
@@ -1,0 +1,18 @@
+package io.github.mojira.arisa.modules
+
+import arrow.core.Either
+import arrow.core.extensions.fx
+
+class ResolveTrashModule() : Module<ResolveTrashModule.Request> {
+    data class Request(
+        val projectKey: String,
+        val resolveAsInvalid: () -> Either<Throwable, Unit>
+    )
+
+    override fun invoke(request: Request): Either<ModuleError, ModuleResponse> = with(request) {
+        Either.fx {
+            assertEquals(projectKey, "TRASH").bind()
+            resolveAsInvalid().toFailedModuleEither().bind()
+        }
+    }
+}

--- a/src/test/kotlin/io/github/mojira/arisa/modules/ResolveTrashTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/ResolveTrashTest.kt
@@ -1,0 +1,41 @@
+package io.github.mojira.arisa.modules
+
+import arrow.core.left
+import arrow.core.right
+import io.github.mojira.arisa.modules.ResolveTrashModule.Request
+import io.kotest.assertions.arrow.either.shouldBeLeft
+import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+class ResolveTrashTest : StringSpec({
+    "should return OperationNotNeededModuleResponse when project is not TRASH" {
+        val module = ResolveTrashModule()
+        val request = Request("MC") { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should resolve as invalid when ticket when ticket was open" {
+        val module = ResolveTrashModule()
+        val request = Request("TRASH") { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeRight(ModuleResponse)
+    }
+
+    "should return FailedModuleResponse when resolving as invalid fails" {
+        val module = ResolveTrashModule()
+        val request = Request("TRASH") { RuntimeException().left() }
+
+        val result = module(request)
+
+        result.shouldBeLeft()
+        result.a should { it is FailedModuleResponse }
+        (result.a as FailedModuleResponse).exceptions.size shouldBe 1
+    }
+})


### PR DESCRIPTION
## Purpose
Resolve TRASHed tickets automatically to invalid if not done so
Fixes #58

## Approach
Filters to only TRASH and to only Unresolved in arisa.json, does a double check that its a TRASH ticket inside the module and then closes as invalid

#### Checklist
- [x] Included tests
- [x] Tested in TRASH-25123
