### PR TITLE
Iterate over all issues

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
@@ -301,10 +301,9 @@ class ModuleExecutor(
         val jql = config[moduleConfig.jql].format(lastRun)
 
         val issues = cache.getQuery(jql) ?: jiraClient
-            .searchIssues(jql)
+            .searchIssues(jql, "*all", "changelog", 1000, 0)
             .iterator()
             .asSequence()
-            .map { jiraClient.getIssue(it.key, "*all", "changelog") } // Get issues again to retrieve all fields
             .filter(::lastActionWasAResolve)
             .toList()
 

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
@@ -306,6 +306,7 @@ class ModuleExecutor(
             .asSequence()
             .map { jiraClient.getIssue(it.key, "*all", "changelog") } // Get issues again to retrieve all fields
             .filter(::lastActionWasAResolve)
+            .toList()
 
         cache.addQuery(jql, issues)
 

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
@@ -302,7 +302,8 @@ class ModuleExecutor(
 
         val issues = cache.getQuery(jql) ?: jiraClient
             .searchIssues(jql)
-            .issues
+            .iterator()
+            .asSequence()
             .map { jiraClient.getIssue(it.key, "*all", "changelog") } // Get issues again to retrieve all fields
             .filter(::lastActionWasAResolve)
 

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/Cache.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/Cache.kt
@@ -3,10 +3,10 @@ package io.github.mojira.arisa.infrastructure
 import net.rcarz.jiraclient.Issue
 
 class Cache {
-    private val queryCache = mutableMapOf<String, List<Issue>>()
+    private val queryCache = mutableMapOf<String, Sequence<Issue>>()
 
     fun getQuery(combinedJql: String) = queryCache.getOrDefault(combinedJql, null)
-    fun addQuery(combinedJql: String, issues: List<Issue>) {
+    fun addQuery(combinedJql: String, issues: Sequence<Issue>) {
         queryCache[combinedJql] = issues
     }
 

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/Cache.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/Cache.kt
@@ -3,10 +3,10 @@ package io.github.mojira.arisa.infrastructure
 import net.rcarz.jiraclient.Issue
 
 class Cache {
-    private val queryCache = mutableMapOf<String, Sequence<Issue>>()
+    private val queryCache = mutableMapOf<String, List<Issue>>()
 
     fun getQuery(combinedJql: String) = queryCache.getOrDefault(combinedJql, null)
-    fun addQuery(combinedJql: String, issues: Sequence<Issue>) {
+    fun addQuery(combinedJql: String, issues: List<Issue>) {
         queryCache[combinedJql] = issues
     }
 


### PR DESCRIPTION
## Purpose
When running a modified version of arisa to update the linked field, I noticed that only a handful of issues are updated.
The issue was, that the jira search client is paginated and only returns a page of 50 issues.

This especially causes issues after a downtime when trying to catch up again.

Utilizing the iterator, the SearchResult provides, the lib takes care of that and you actually do iterate over all issues.

## Approach
Using the lib's iterator (and converting it to a sequence)
Furthermore, it is possible to set the maxResults of a search query. Default is 50, and it is capped at 1,000. In this PR, I changed it to 1,000, and to reduce outgoing traffic more, it is also possible to specify fields and expand fields in the search request directly, so it is not needed to query every single issue again to get all fields.
This means almost always that every search query is only one API request now.

#### Checklist
- [ ] Included tests
- [x] Tested on a real search query with one module running
