### PR TITLE
Stability

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/ArisaMain.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ArisaMain.kt
@@ -48,12 +48,14 @@ fun main() {
     while (true) {
         // save time before run, so nothing happening during the run is missed
         val curRunTime = Instant.now().toEpochMilli()
+        val success = moduleExecutor.execute(lastRunTime)
 
-        moduleExecutor.execute(lastRunTime)
-        val failed = cache.getFailedTickets().joinToString{ ",$it" } // even first entry should start with a comma
+        if (success) {
+            val failed = cache.getFailedTickets().joinToString { ",$it" } // even first entry should start with a comma
 
-        lastRunFile.writeText("$curRunTime$failed")
-        lastRunTime = curRunTime
+            lastRunFile.writeText("$curRunTime$failed")
+            lastRunTime = curRunTime
+        }
 
         TimeUnit.SECONDS.sleep(config[Arisa.Issues.checkInterval])
     }

--- a/src/main/kotlin/io/github/mojira/arisa/ArisaMain.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ArisaMain.kt
@@ -51,7 +51,7 @@ fun main() {
         val success = moduleExecutor.execute(lastRunTime)
 
         if (success) {
-            val failed = cache.getFailedTickets().joinToString { ",$it" } // even first entry should start with a comma
+            val failed = cache.getFailedTickets().joinToString("") { ",$it" } // even first entry should start with a comma
 
             lastRunFile.writeText("$curRunTime$failed")
             lastRunTime = curRunTime

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
@@ -324,7 +324,7 @@ class ModuleExecutor(
             cache.updatedFailedTickets()
 
             return true
-        } catch(ex: Throwable) {
+        } catch (ex: Throwable) {
             log.error("Failed to execute modules", ex)
             return false
         }
@@ -419,7 +419,7 @@ class ModuleExecutor(
 
     private fun tryExecuteModule(executeModule: () -> Either<ModuleError, ModuleResponse>) = try {
         executeModule()
-    } catch (e :Throwable) {
+    } catch (e: Throwable) {
         FailedModuleResponse(listOf(e)).left()
     }
 }

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
@@ -342,7 +342,7 @@ class ModuleExecutor(
         val resolutions = config[moduleConfig.resolutions].map(String::toLowerCase)
         val failedTicketsJQL = with(cache.getFailedTickets()) {
             if (isNotEmpty())
-                "key in ${joinToString(",")} OR "
+                "key in (${joinToString(",")}) OR "
             else ""
         }
 

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
@@ -386,25 +386,25 @@ class ModuleExecutor(
 
         return searchResult
             .issues
-            .filter(::lastActionWasAResolve)
+            .filter(::lastActionWasNotAResolve)
     }
 
-    private fun lastActionWasAResolve(issue: Issue): Boolean {
+    private fun lastActionWasNotAResolve(issue: Issue): Boolean {
         val latestChange = issue.changeLog.entries.lastOrNull()
 
         return latestChange == null ||
-                latestChange.isATransition() ||
-                latestChange.wasNotDoneByTheBot() ||
-                latestChange.noCommentAfterIt(issue)
+                latestChange.isNotATransition() ||
+                latestChange.wasDoneByTheBot() ||
+                latestChange.commentAfterIt(issue)
     }
 
-    private fun ChangeLogEntry.noCommentAfterIt(issue: Issue) =
+    private fun ChangeLogEntry.commentAfterIt(issue: Issue) =
         (issue.comments.isNotEmpty() && issue.comments.last().updatedDate > created)
 
-    private fun ChangeLogEntry.wasNotDoneByTheBot() =
+    private fun ChangeLogEntry.wasDoneByTheBot() =
         author.name == config[Arisa.Credentials.username]
 
-    private fun ChangeLogEntry.isATransition() =
+    private fun ChangeLogEntry.isNotATransition() =
         !items.any { it.field == "resolution" }
 
     private fun String.toInstant() = isoFormat.parse(this).toInstant()

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/Cache.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/Cache.kt
@@ -2,13 +2,27 @@ package io.github.mojira.arisa.infrastructure
 
 import net.rcarz.jiraclient.Issue
 
-class Cache {
+class Cache(
+    private var failedTickets: Set<String>
+) {
     private val queryCache = mutableMapOf<String, List<Issue>>()
+    private val failedTicketsCurRun = mutableSetOf<String>()
 
     fun getQuery(combinedJql: String) = queryCache.getOrDefault(combinedJql, null)
     fun addQuery(combinedJql: String, issues: List<Issue>) {
         queryCache[combinedJql] = issues
     }
+
+    fun updatedFailedTickets() {
+        failedTickets = failedTicketsCurRun
+    }
+
+    fun addFailedTicket(ticket: String) {
+        failedTicketsCurRun.add(ticket)
+    }
+
+    fun getFailedTickets(): Set<String> =
+        failedTickets
 
     fun clearQueryCache() {
         queryCache.clear()


### PR DESCRIPTION
## Purpose
This pull request aims at making the ModuleExecutor more stable and prevent any crashes.

## Approach
All modules now invoke `tryExecuteModule` which wraps any `Throwable` into a `FailedModuleResponse`. While the modules itself are not throwing errors, it is possible that the function constructing the request in `ModuleExecutor#execute` itself throws an error (mainly because of interacting wrongly with the jira API)

Furthermore, if executing modules fail not because of a single execution attempt, but because something else either in `executeModule` or in `execute` throws an error, that error is now caught and reported in the log.

Furthermore, in case a module fails while trying to execute an issue, the execute module now does return true, indicating a successful execution, and instead failed issues are stored in the cache, and the ModuleExecutor will attempt to re-run all modules on issues that failed in addition to the reults of the normal query.

`last-run` is now a csv file, where the first value still indicates the last successful run, and any further value is an issue key of an issue where the module execution failed. This ensures that upon a redeploy or restart, the bot not only tries to go over all newly updated issues, but also issues that failed to execute before.

#### Checklist
- [x] Tested
