### PR TITLE
Removed capital letter for 'LauncherFenix'

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -83,7 +83,7 @@
           "Launcher X",
           "PHVL",
           "Pre-Launcher v6",
-          "LauncherFEnix",
+          "LauncherFenix",
           "TLauncher",
           "Titan"
         ]


### PR DESCRIPTION
Was 'LauncherFEnix', now is 'LauncherFenix

## Purpose
To fix detection of launcherfenix

## Approach
Removed capital letter

## Future work

_If applicable, work referenced here that will be done in the future_

#### Checklist
- [X] Included tests
- [X] Tested in MCTEST-xxx
