### PR TITLE
Fix #127

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModule.kt
@@ -25,7 +25,7 @@ class RevokeConfirmationModule : Module<RevokeConfirmationModule.Request> {
                 .filter(::isConfirmationChange)
                 .filter(::changedByVolunteer)
                 .lastOrNull()
-                ?.newValue ?: "Unconfirmed"
+                ?.newValue.getOrDefault("Unconfirmed")
 
             assertNotEquals(confirmationStatus, volunteerConfirmation).bind()
             setConfirmationStatus(volunteerConfirmation).toFailedModuleEither().bind()
@@ -42,4 +42,10 @@ class RevokeConfirmationModule : Module<RevokeConfirmationModule.Request> {
         .created
         .plus(1, ChronoUnit.DAYS)
         .isAfter(Instant.now())
+
+    private fun String?.getOrDefault(default: String) =
+        if (isNullOrBlank())
+            default
+        else
+            this!!
 }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModule.kt
@@ -27,7 +27,7 @@ class RevokeConfirmationModule : Module<RevokeConfirmationModule.Request> {
                 .lastOrNull()
                 ?.newValue.getOrDefault("Unconfirmed")
 
-            assertNotEquals(confirmationStatus, volunteerConfirmation).bind()
+            assertNotEquals(confirmationStatus.getOrDefault("Unconfirmed"), volunteerConfirmation).bind()
             setConfirmationStatus(volunteerConfirmation).toFailedModuleEither().bind()
         }
     }

--- a/src/test/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationTest.kt
@@ -94,6 +94,28 @@ class RevokeConfirmationTest : StringSpec({
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
+    "should return OperationNotNeededModuleResponse when confirmation status is null and was unset" {
+        val module = RevokeConfirmationModule()
+        val volunteerChange = ChangeLogItem("Confirmation Status", "Confirmed", Instant.now(), listOf("staff"))
+        val otherVolunteerChange = ChangeLogItem("Confirmation Status", "", Instant.now(), listOf("helper"))
+        val request = Request(null, listOf(volunteerChange, otherVolunteerChange)) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when confirmation status is empty and was unset" {
+        val module = RevokeConfirmationModule()
+        val volunteerChange = ChangeLogItem("Confirmation Status", "Confirmed", Instant.now(), listOf("staff"))
+        val otherVolunteerChange = ChangeLogItem("Confirmation Status", "", Instant.now(), listOf("helper"))
+        val request = Request("", listOf(volunteerChange, otherVolunteerChange)) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
     "should set to Unconfirmed when ticket was created Confirmed" {
         var changedConfirmation = ""
 
@@ -125,21 +147,6 @@ class RevokeConfirmationTest : StringSpec({
         val module = RevokeConfirmationModule()
         val changeLogItem = ChangeLogItem("Confirmation Status", "Confirmed", Instant.now(), emptyList())
         val request = Request("Confirmed", listOf(changeLogItem)) { changedConfirmation = it; Unit.right() }
-
-        val result = module(request)
-
-        result.shouldBeRight(ModuleResponse)
-        changedConfirmation.shouldBe("Unconfirmed")
-    }
-
-    "should set to Unconfirmed when last volunteer action was setting the confirmation status to empty, and a user changed the confirmation afterwards" {
-        var changedConfirmation = ""
-
-        val module = RevokeConfirmationModule()
-        val volunteerChange = ChangeLogItem("Confirmation Status", "Confirmed", Instant.now(), listOf("staff"))
-        val otherVolunteerChange = ChangeLogItem("Confirmation Status", "", Instant.now(), listOf("helper"))
-        val userChange = ChangeLogItem("Confirmation Status", "Confirmed", Instant.now(), emptyList())
-        val request = Request("Confirmed", listOf(volunteerChange, otherVolunteerChange, userChange)) { changedConfirmation = it; Unit.right() }
 
         val result = module(request)
 


### PR DESCRIPTION
## Purpose
Fixes #127

## Approach
Any confirmation status that's returned empty or null will now be treated as "Unconfirmed"

#### Checklist
- [x] Included tests
- [x] Tested in MCPE-69864
