### PR TITLE
Fix arisa getting stuck

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
@@ -428,7 +428,7 @@ class ModuleExecutor(
         val searchResult = jiraClient
             .searchIssues(jql, "*all", "changelog", MAX_RESULTS, startAt)
 
-        if (searchResult.start + searchResult.max < searchResult.total)
+        if (startAt + searchResult.max < searchResult.total)
             onQueryPaginated()
 
         return searchResult


### PR DESCRIPTION
## Purpose
Arisa gets stuck because `result.start` is 0, when we overflow. With multiple jql queries, arisa gets stuck at the end, because one of them has results after the first page. This fixes this.
