### PR TITLE
Add .url to attachment extension blacklist

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -52,7 +52,8 @@
           "msi",
           "run",
           "lnk",
-          "dmg"
+          "dmg",
+          "url"
         ]
       },
       "piracy": {


### PR DESCRIPTION
Very minor change, but I've noticed a bunch of `.url` tickets attached to tickets on the tracker. These files usually are not, but can be harmful, but they are not useful at all. Therefore Arisa should probably remove them.