### PR TITLE
Fix HideImpostors failing when envoking the restrict comment method

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -206,7 +206,7 @@ class ModuleRegistry(jiraClient: JiraClient, private val config: Config) {
                             c.updatedDate.toInstant(),
                             c.visibility?.type,
                             c.visibility?.value,
-                            ::restrictCommentToGroup.partially1(c).partially1("staff").partially1(null)
+                            ::restrictCommentToGroup.partially1(c).partially1("staff").partially1(c.body)
                         )
                     }
             )

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/Jira.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/Jira.kt
@@ -109,7 +109,7 @@ fun updateCommentBody(comment: Comment, body: String) = runBlocking {
     }
 }
 
-fun restrictCommentToGroup(comment: Comment, group: String, body: String? = comment.body) = runBlocking {
+fun restrictCommentToGroup(comment: Comment, group: String, body: String = comment.body) = runBlocking {
     Either.catch {
         comment.update(body, "group", group)
         Unit


### PR DESCRIPTION
## Purpose
Fixes #129

## Approach
Explicitly filling the optional parameter in the partially.

#### Checklist
- [ ] Included tests
- [ ] Tested in MCTEST-xxx
