### PR TITLE
Change author name rquirements for HideImpostors

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/HideImpostorsModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/HideImpostorsModule.kt
@@ -37,7 +37,7 @@ class HideImpostorsModule : Module<HideImpostorsModule.Request> {
         .isAfter(Instant.now())
 
     private fun userContainsBrackets(comment: Comment) = with(comment.authorDisplayName) {
-        contains("[") && contains("]")
+        matches("""\[(?:\p{L}|\p{N}|\s)+\]\s.+""".toRegex())
     }
 
     private fun userIsNotVolunteer(comment: Comment) =

--- a/src/test/kotlin/io/github/mojira/arisa/modules/HideImpostorsTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/HideImpostorsTest.kt
@@ -24,7 +24,7 @@ class HideImpostorsTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when user doesnt contain [ but contains ]" {
         val module = HideImpostorsModule()
-        val comment = Comment("test]", emptyList(), Instant.now(), null, null) { Unit.right() }
+        val comment = Comment("test] test", emptyList(), Instant.now(), null, null) { Unit.right() }
         val request = Request(listOf(comment))
 
         val result = module(request)
@@ -34,7 +34,37 @@ class HideImpostorsTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when user doesnt contain ] but contains [" {
         val module = HideImpostorsModule()
-        val comment = Comment("[test", emptyList(), Instant.now(), null, null) { Unit.right() }
+        val comment = Comment("[test test", emptyList(), Instant.now(), null, null) { Unit.right() }
+        val request = Request(listOf(comment))
+
+        val result = module(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when user contains invalid characters in the tag" {
+        val module = HideImpostorsModule()
+        val comment = Comment("[}[{]] test", emptyList(), Instant.now(), null, null) { Unit.right() }
+        val request = Request(listOf(comment))
+
+        val result = module(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when user is only the tag" {
+        val module = HideImpostorsModule()
+        val comment = Comment("[test]", emptyList(), Instant.now(), null, null) { Unit.right() }
+        val request = Request(listOf(comment))
+
+        val result = module(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when tag is not at the beginning" {
+        val module = HideImpostorsModule()
+        val comment = Comment("test [test]", emptyList(), Instant.now(), null, null) { Unit.right() }
         val request = Request(listOf(comment))
 
         val result = module(request)
@@ -92,9 +122,39 @@ class HideImpostorsTest : StringSpec({
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
-    "should hide comment when user contains [] but is not of a permission group" {
+    "should hide comment when user starts with a valid tag but is not of a permission group" {
         val module = HideImpostorsModule()
         val comment = Comment("[test] test", emptyList(), Instant.now(), null, null) { Unit.right() }
+        val request = Request(listOf(comment))
+
+        val result = module(request)
+
+        result.shouldBeRight(ModuleResponse)
+    }
+
+    "should hide comment when tag contains numbers" {
+        val module = HideImpostorsModule()
+        val comment = Comment("[t3st] test", emptyList(), Instant.now(), null, null) { Unit.right() }
+        val request = Request(listOf(comment))
+
+        val result = module(request)
+
+        result.shouldBeRight(ModuleResponse)
+    }
+
+    "should hide comment when tag contains accented letter" {
+        val module = HideImpostorsModule()
+        val comment = Comment("[tést] test", emptyList(), Instant.now(), null, null) { Unit.right() }
+        val request = Request(listOf(comment))
+
+        val result = module(request)
+
+        result.shouldBeRight(ModuleResponse)
+    }
+
+    "should hide comment when tag contains spaces" {
+        val module = HideImpostorsModule()
+        val comment = Comment("[Mojang Overlord] test", emptyList(), Instant.now(), null, null) { Unit.right() }
         val request = Request(listOf(comment))
 
         val result = module(request)


### PR DESCRIPTION
## Purpose
Fix #130 

## Approach
The name now must match the regex `\[(?:\p{L}|\p{N}|\s)+\]\s.+` for the module to trigger.

#### Checklist
- [x] Included tests
- [ ] Tested in MCTEST-xxx
