### PR TITLE
Add ConfirmParentModule

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -109,6 +109,15 @@
           "MCPE"
         ]
       },
+      "confirmParent": {
+        "confirmationStatusWhitelist": ["Unconfirmed", "Plausible"],
+        "targetConfirmationStatus": ["Community Consensus"],
+        "whitelist": [
+          "MC",
+          "MCL",
+          "MCPE"
+        ]
+      },
       "reopenAwaiting": {
         "resolutions": [
           "Awaiting Response"

--- a/arisa.json
+++ b/arisa.json
@@ -112,6 +112,9 @@
       "confirmParent": {
         "confirmationStatusWhitelist": ["Unconfirmed", "Plausible"],
         "targetConfirmationStatus": ["Community Consensus"],
+        "resolutions": [
+          "Unresolved"
+        ],
         "whitelist": [
           "MC",
           "MCL",

--- a/arisa.json
+++ b/arisa.json
@@ -112,9 +112,7 @@
       "confirmParent": {
         "confirmationStatusWhitelist": ["Unconfirmed", "Plausible"],
         "targetConfirmationStatus": ["Community Consensus"],
-        "resolutions": [
-          "Unresolved"
-        ],
+        "linkedThreshold": 3.0,
         "whitelist": [
           "MC",
           "MCL",

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
@@ -1,56 +1,17 @@
 package io.github.mojira.arisa
 
 import arrow.core.Either
-import arrow.core.left
-import arrow.core.right
-import arrow.syntax.function.partially1
-import arrow.syntax.function.partially2
 import com.uchuhimo.konf.Config
 import io.github.mojira.arisa.infrastructure.Cache
-import io.github.mojira.arisa.infrastructure.addAffectedVersion
-import io.github.mojira.arisa.infrastructure.addComment
-import io.github.mojira.arisa.infrastructure.addRestrictedComment
 import io.github.mojira.arisa.infrastructure.config.Arisa
-import io.github.mojira.arisa.infrastructure.deleteAttachment
-import io.github.mojira.arisa.infrastructure.getGroups
-import io.github.mojira.arisa.infrastructure.getLanguage
-import io.github.mojira.arisa.infrastructure.link
-import io.github.mojira.arisa.infrastructure.removeAffectedVersion
-import io.github.mojira.arisa.infrastructure.reopenIssue
-import io.github.mojira.arisa.infrastructure.resolveAs
-import io.github.mojira.arisa.infrastructure.restrictCommentToGroup
-import io.github.mojira.arisa.infrastructure.updateCHK
-import io.github.mojira.arisa.infrastructure.updateCommentBody
-import io.github.mojira.arisa.infrastructure.updateConfirmation
-import io.github.mojira.arisa.infrastructure.updateLinked
-import io.github.mojira.arisa.infrastructure.updateSecurity
-import io.github.mojira.arisa.modules.AttachmentModule
-import io.github.mojira.arisa.modules.CHKModule
-import io.github.mojira.arisa.modules.CrashModule
-import io.github.mojira.arisa.modules.EmptyModule
 import io.github.mojira.arisa.modules.FailedModuleResponse
-import io.github.mojira.arisa.modules.FutureVersionModule
-import io.github.mojira.arisa.modules.HideImpostorsModule
-import io.github.mojira.arisa.modules.KeepPrivateModule
-import io.github.mojira.arisa.modules.LanguageModule
 import io.github.mojira.arisa.modules.ModuleError
 import io.github.mojira.arisa.modules.ModuleResponse
 import io.github.mojira.arisa.modules.OperationNotNeededModuleResponse
-import io.github.mojira.arisa.modules.PiracyModule
-import io.github.mojira.arisa.modules.RemoveNonStaffMeqsModule
-import io.github.mojira.arisa.modules.RemoveTriagedMeqsModule
-import io.github.mojira.arisa.modules.ReopenAwaitingModule
-import io.github.mojira.arisa.modules.ResolveTrashModule
-import io.github.mojira.arisa.modules.RevokeConfirmationModule
-import io.github.mojira.arisa.modules.UpdateLinkedModule
-import me.urielsalis.mccrashlib.CrashReader
 import net.rcarz.jiraclient.ChangeLogEntry
 import net.rcarz.jiraclient.Issue
 import net.rcarz.jiraclient.JiraClient
-import net.sf.json.JSONObject
-import java.text.SimpleDateFormat
 
-private val isoFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
 private const val MAX_RESULTS = 50
 
 class ModuleExecutor(
@@ -58,31 +19,7 @@ class ModuleExecutor(
     private val config: Config,
     private val cache: Cache
 ) {
-    private val attachmentModule =
-        AttachmentModule(config[Arisa.Modules.Attachment.extensionBlacklist])
-    private val chkModule = CHKModule()
-    private val crashModule = CrashModule(
-        config[Arisa.Modules.Crash.crashExtensions],
-        config[Arisa.Modules.Crash.duplicates],
-        config[Arisa.Modules.Crash.maxAttachmentAge],
-        CrashReader()
-    )
-    private val emptyModule = EmptyModule()
-    private val futureVersionModule = FutureVersionModule()
-    private val hideImpostorsModule = HideImpostorsModule()
-    private val piracyModule = PiracyModule(config[Arisa.Modules.Piracy.piracySignatures])
-    private val keepPrivateModule = KeepPrivateModule(config[Arisa.Modules.KeepPrivate.tag])
-    private val languageModule: LanguageModule = LanguageModule()
-    private val removeNonStaffMeqsModule =
-        RemoveNonStaffMeqsModule(config[Arisa.Modules.RemoveNonStaffMeqs.removalReason])
-    private val removeTriagedMeqsModule = RemoveTriagedMeqsModule(
-        config[Arisa.Modules.RemoveTriagedMeqs.meqsTags],
-        config[Arisa.Modules.RemoveTriagedMeqs.removalReason]
-    )
-    private val reopenAwaitingModule = ReopenAwaitingModule()
-    private val revokeConfirmationModule = RevokeConfirmationModule()
-    private val resolveTrashModule = ResolveTrashModule()
-    private val updateLinkedModule = UpdateLinkedModule()
+    private val registry = ModuleRegistry(jiraClient, config)
 
     fun execute(lastRun: Long): Boolean {
         try {
@@ -91,276 +28,16 @@ class ModuleExecutor(
 
             do {
                 missingResultsPage = false
-                val exec = ::executeModule
-                    .partially2(cache)
-                    .partially2(lastRun)
-                    .partially2(startAt)
-                    .partially2 { missingResultsPage = true }
 
-                exec(Arisa.Modules.Attachment) { issue ->
-                    "Attachment" to tryExecuteModule {
-                        attachmentModule(
-                            AttachmentModule.Request(
-                                issue
-                                    .attachments
-                                    .map { a ->
-                                        AttachmentModule.Attachment(
-                                            a.fileName,
-                                            ::deleteAttachment.partially1(jiraClient).partially1(a)
-                                        )
-                                    }
-                            )
-                        )
-                    }
-                }
-                exec(Arisa.Modules.CHK) { issue ->
-                    "CHK" to tryExecuteModule {
-                        chkModule(
-                            CHKModule.Request(
-                                issue.getFieldAsString(config[Arisa.CustomFields.chkField]),
-                                issue.getCustomField(config[Arisa.CustomFields.confirmationField]),
-                                ::updateCHK.partially1(issue).partially1(config[Arisa.CustomFields.chkField])
-                            )
-                        )
-                    }
-                }
-                exec(Arisa.Modules.Crash) { issue ->
-                    "Crash" to tryExecuteModule {
-                        crashModule(
-                            CrashModule.Request(
-                                issue.attachments
-                                    .map { a -> CrashModule.Attachment(a.fileName, a.createdDate, a.download()) },
-                                issue.description,
-                                issue.createdDate,
-                                issue.getCustomField(config[Arisa.CustomFields.confirmationField]),
-                                issue.getCustomField(config[Arisa.CustomFields.mojangPriorityField]),
-                                ::resolveAs.partially1(issue).partially1("Invalid"),
-                                ::resolveAs.partially1(issue).partially1("Duplicate"),
-                                ::link.partially1(issue).partially1("Duplicate"),
-                                ::addComment.partially1(issue).partially1(config[Arisa.Modules.Crash.moddedMessage]),
-                                { key ->
-                                    addComment(
-                                        issue,
-                                        config[Arisa.Modules.Crash.duplicateMessage].format(key)
-                                    )
-                                }
-                            )
-                        )
-                    }
-                }
-                exec(Arisa.Modules.Empty) { issue ->
-                    "Empty" to tryExecuteModule {
-                        emptyModule(
-                            EmptyModule.Request(
-                                issue.attachments.size,
-                                issue.description,
-                                issue.getFieldAsString("environment"),
-                                ::resolveAs.partially1(issue).partially1("Incomplete"),
-                                ::addComment.partially1(issue).partially1(config[Arisa.Modules.Empty.message])
-                            )
-                        )
-                    }
-                }
-                exec(Arisa.Modules.FutureVersion) { issue ->
-                    "FutureVersion" to tryExecuteModule {
-                        val project = jiraClient.getProject(issue.project.key)
-
-                        futureVersionModule(
-                            FutureVersionModule.Request(
-                                issue.versions
-                                    .map { v ->
-                                        FutureVersionModule.Version(
-                                            v.isReleased,
-                                            v.isArchived,
-                                            ::removeAffectedVersion.partially1(issue).partially1(v)
-                                        )
-                                    },
-                                project?.versions
-                                    ?.map { v ->
-                                        FutureVersionModule.Version(
-                                            v.isReleased,
-                                            v.isArchived,
-                                            ::addAffectedVersion.partially1(issue).partially1(v)
-                                        )
-                                    },
-                                ::addComment.partially1(issue).partially1(config[Arisa.Modules.FutureVersion.message])
-                            )
-                        )
-                    }
-                }
-                exec(Arisa.Modules.HideImpostors) { issue ->
-                    "HideImpostors" to tryExecuteModule {
-                        hideImpostorsModule(
-                            HideImpostorsModule.Request(
-                                issue.comments
-                                    .map { c ->
-                                        HideImpostorsModule.Comment(
-                                            c.author.displayName,
-                                            getGroups(
-                                                jiraClient,
-                                                c.author.name
-                                            ).fold({ null }, { it }),
-                                            c.updatedDate.toInstant(),
-                                            c.visibility?.type,
-                                            c.visibility?.value,
-                                            ::restrictCommentToGroup.partially1(c).partially1("staff").partially1(null)
-                                        )
-                                    }
-                            )
-                        )
-                    }
-                }
-                exec(Arisa.Modules.KeepPrivate) { issue ->
-                    "KeepPrivate" to tryExecuteModule {
-                        keepPrivateModule(
-                            KeepPrivateModule.Request(
-                                issue.security?.id,
-                                getSecurityLevelId(issue.project.key),
-                                issue.comments.map { c -> c.body },
-                                ::updateSecurity.partially1(issue).partially1(getSecurityLevelId(issue.project.key)),
-                                ::addComment.partially1(issue).partially1(config[Arisa.Modules.KeepPrivate.message])
-                            )
-                        )
-                    }
-                }
-                exec(Arisa.Modules.Piracy) { issue ->
-                    "Piracy" to tryExecuteModule {
-                        piracyModule(
-                            PiracyModule.Request(
-                                issue.getFieldAsString("environment"),
-                                issue.summary,
-                                issue.description,
-                                ::resolveAs.partially1(issue).partially1("Invalid"),
-                                ::addComment.partially1(issue).partially1(config[Arisa.Modules.Piracy.message])
-                            )
-                        )
-                    }
-                }
-                exec(Arisa.Modules.Language) { issue ->
-                    "Language" to tryExecuteModule {
-                        languageModule(
-                            LanguageModule.Request(
-                                issue.summary,
-                                issue.description,
-                                issue.security?.id,
-                                getSecurityLevelId(issue.project.key),
-                                ::getLanguage.partially1(config[Arisa.Credentials.dandelionToken]),
-                                { Unit.right() }, // ::resolveAs.partially1(issue).partially1("Invalid"),
-                                { language ->
-                                    val translatedMessage = config[Arisa.Modules.Language.messages][language]
-                                    val defaultMessage = config[Arisa.Modules.Language.defaultMessage]
-                                    val text =
-                                        if (translatedMessage != null) config[Arisa.Modules.Language.messageFormat].format(
-                                            translatedMessage,
-                                            defaultMessage
-                                        ) else defaultMessage
-
-                                    addRestrictedComment(issue, text, "helper")
-                                }
-                            )
-                        )
-                    }
-                }
-                exec(Arisa.Modules.RemoveNonStaffMeqs) { issue ->
-                    "RemoveNonStaffMeqs" to tryExecuteModule {
-                        removeNonStaffMeqsModule(
-                            RemoveNonStaffMeqsModule.Request(
-                                issue.comments
-                                    .map { c ->
-                                        RemoveNonStaffMeqsModule.Comment(
-                                            c.body,
-                                            c.visibility?.type,
-                                            c.visibility?.value,
-                                            ::restrictCommentToGroup.partially1(c).partially1("staff")
-                                        )
-                                    }
-                            )
-                        )
-                    }
-                }
-                exec(Arisa.Modules.RemoveTriagedMeqs) {
-                    "RemoveTriagedMeqs" to tryExecuteModule {
-                        removeTriagedMeqsModule(
-                            RemoveTriagedMeqsModule.Request(
-                                it.getCustomField(config[Arisa.CustomFields.mojangPriorityField]),
-                                it.getFieldAsString(config[Arisa.CustomFields.triagedTimeField]),
-                                it.comments
-                                    .map { c ->
-                                        RemoveTriagedMeqsModule.Comment(
-                                            c.body,
-                                            ::updateCommentBody.partially1(c)
-                                        )
-                                    }
-                            )
-                        )
-                    }
-                }
-                exec(Arisa.Modules.ReopenAwaiting) { issue ->
-                    "ReopenAwaiting" to tryExecuteModule {
-                        reopenAwaitingModule(
-                            ReopenAwaitingModule.Request(
-                                issue.resolution?.name,
-                                (issue.getFieldAsString("created"))!!.toInstant(),
-                                (issue.getFieldAsString("updated"))!!.toInstant(),
-                                issue.comments
-                                    .map { c ->
-                                        ReopenAwaitingModule.Comment(
-                                            c.updatedDate.toInstant().toEpochMilli(),
-                                            c.createdDate.toInstant().toEpochMilli()
-                                        )
-                                    },
-                                ::reopenIssue.partially1(issue)
-                            )
-                        )
-                    }
-                }
-                exec(Arisa.Modules.RevokeConfirmation) { issue ->
-                    "RevokeConfirmation" to tryExecuteModule {
-                        revokeConfirmationModule(
-                            RevokeConfirmationModule.Request(
-                                issue.getCustomField(config[Arisa.CustomFields.confirmationField]),
-                                issue.changeLog.entries
-                                    .flatMap { e ->
-                                        e.items
-                                            .map { i ->
-                                                RevokeConfirmationModule.ChangeLogItem(
-                                                    i.field,
-                                                    i.toString,
-                                                    e.created.toInstant(),
-                                                    getGroups(
-                                                        jiraClient,
-                                                        e.author.name
-                                                    ).fold({ null }, { it })
-                                                )
-                                            }
-                                    },
-                                ::updateConfirmation.partially1(issue)
-                                    .partially1(config[Arisa.CustomFields.confirmationField])
-                            )
-                        )
-                    }
-                }
-                exec(Arisa.Modules.ResolveTrash) { issue ->
-                    "ResolveTrash" to tryExecuteModule {
-                        resolveTrashModule(
-                            ResolveTrashModule.Request(
-                                issue.project.key,
-                                ::resolveAs.partially1(issue).partially1("Invalid")
-                            )
-                        )
-                    }
-                }
-                exec(Arisa.Modules.UpdateLinked) { issue ->
-                    "UpdateLinked" to tryExecuteModule {
-                        updateLinkedModule(
-                            UpdateLinkedModule.Request(
-                                issue.issueLinks
-                                    .map { it.type.name },
-                                issue.getField(config[Arisa.CustomFields.linked]) as? Double?,
-                                ::updateLinked.partially1(issue).partially1(config[Arisa.CustomFields.linked])
-                            )
-                        )
-                    }
+                registry.getModules().forEach { (config, exec) ->
+                    executeModule(
+                        config,
+                        cache,
+                        lastRun,
+                        startAt,
+                        { missingResultsPage = true },
+                        exec
+                    )
                 }
 
                 cache.clearQueryCache()
@@ -453,20 +130,4 @@ class ModuleExecutor(
 
     private fun ChangeLogEntry.isNotATransition() =
         !items.any { it.field == "resolution" }
-
-    private fun String.toInstant() = isoFormat.parse(this).toInstant()
-
-    private fun Issue.getFieldAsString(field: String) = this.getField(field) as? String?
-
-    private fun Issue.getCustomField(customField: String): String? =
-        ((getField(customField)) as? JSONObject)?.get("value") as? String?
-
-    private fun getSecurityLevelId(project: String) =
-        config[Arisa.PrivateSecurityLevel.special][project] ?: config[Arisa.PrivateSecurityLevel.default]
-
-    private fun tryExecuteModule(executeModule: () -> Either<ModuleError, ModuleResponse>) = try {
-        executeModule()
-    } catch (e: Throwable) {
-        FailedModuleResponse(listOf(e)).left()
-    }
 }

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -30,6 +30,7 @@ import io.github.mojira.arisa.infrastructure.updateLinked
 import io.github.mojira.arisa.infrastructure.updateSecurity
 import io.github.mojira.arisa.modules.AttachmentModule
 import io.github.mojira.arisa.modules.CHKModule
+import io.github.mojira.arisa.modules.ConfirmParentModule
 import io.github.mojira.arisa.modules.CrashModule
 import io.github.mojira.arisa.modules.EmptyModule
 import io.github.mojira.arisa.modules.FailedModuleResponse
@@ -115,6 +116,23 @@ class ModuleRegistry(jiraClient: JiraClient, private val config: Config) {
                 issue.getFieldAsString(config[CustomFields.chkField]),
                 issue.getCustomField(config[CustomFields.confirmationField]),
                 ::updateCHK.partially1(issue).partially1(config[CustomFields.chkField])
+            )
+        }
+
+        register(
+            "ConfirmParent",
+            Modules.ConfirmParent,
+            ConfirmParentModule(
+                config[Modules.ConfirmParent.confirmationStatusWhitelist],
+                config[Modules.ConfirmParent.targetConfirmationStatus]
+            )
+        ) { issue ->
+            ConfirmParentModule.Request(
+                issue.getCustomField(config[CustomFields.confirmationField]),
+                issue.getField(config[CustomFields.linked]) as? Int?,
+                ::updateConfirmation
+                    .partially1(issue)
+                    .partially1(config[CustomFields.confirmationField])
             )
         }
 

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -124,7 +124,8 @@ class ModuleRegistry(jiraClient: JiraClient, private val config: Config) {
             Modules.ConfirmParent,
             ConfirmParentModule(
                 config[Modules.ConfirmParent.confirmationStatusWhitelist],
-                config[Modules.ConfirmParent.targetConfirmationStatus]
+                config[Modules.ConfirmParent.targetConfirmationStatus],
+                config[Modules.ConfirmParent.linkedThreshold]
             )
         ) { issue ->
             ConfirmParentModule.Request(

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -1,0 +1,379 @@
+package io.github.mojira.arisa
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import arrow.syntax.function.partially1
+import arrow.syntax.function.pipe
+import arrow.syntax.function.pipe2
+import com.uchuhimo.konf.Config
+import io.github.mojira.arisa.infrastructure.addAffectedVersion
+import io.github.mojira.arisa.infrastructure.addComment
+import io.github.mojira.arisa.infrastructure.addRestrictedComment
+import io.github.mojira.arisa.infrastructure.config.Arisa.Credentials
+import io.github.mojira.arisa.infrastructure.config.Arisa.CustomFields
+import io.github.mojira.arisa.infrastructure.config.Arisa.Modules
+import io.github.mojira.arisa.infrastructure.config.Arisa.Modules.ModuleConfigSpec
+import io.github.mojira.arisa.infrastructure.config.Arisa.PrivateSecurityLevel
+import io.github.mojira.arisa.infrastructure.deleteAttachment
+import io.github.mojira.arisa.infrastructure.getGroups
+import io.github.mojira.arisa.infrastructure.getLanguage
+import io.github.mojira.arisa.infrastructure.link
+import io.github.mojira.arisa.infrastructure.removeAffectedVersion
+import io.github.mojira.arisa.infrastructure.reopenIssue
+import io.github.mojira.arisa.infrastructure.resolveAs
+import io.github.mojira.arisa.infrastructure.restrictCommentToGroup
+import io.github.mojira.arisa.infrastructure.updateCHK
+import io.github.mojira.arisa.infrastructure.updateCommentBody
+import io.github.mojira.arisa.infrastructure.updateConfirmation
+import io.github.mojira.arisa.infrastructure.updateLinked
+import io.github.mojira.arisa.infrastructure.updateSecurity
+import io.github.mojira.arisa.modules.AttachmentModule
+import io.github.mojira.arisa.modules.CHKModule
+import io.github.mojira.arisa.modules.CrashModule
+import io.github.mojira.arisa.modules.EmptyModule
+import io.github.mojira.arisa.modules.FailedModuleResponse
+import io.github.mojira.arisa.modules.FutureVersionModule
+import io.github.mojira.arisa.modules.HideImpostorsModule
+import io.github.mojira.arisa.modules.KeepPrivateModule
+import io.github.mojira.arisa.modules.LanguageModule
+import io.github.mojira.arisa.modules.Module
+import io.github.mojira.arisa.modules.ModuleError
+import io.github.mojira.arisa.modules.ModuleResponse
+import io.github.mojira.arisa.modules.PiracyModule
+import io.github.mojira.arisa.modules.RemoveNonStaffMeqsModule
+import io.github.mojira.arisa.modules.RemoveTriagedMeqsModule
+import io.github.mojira.arisa.modules.ReopenAwaitingModule
+import io.github.mojira.arisa.modules.ResolveTrashModule
+import io.github.mojira.arisa.modules.RevokeConfirmationModule
+import io.github.mojira.arisa.modules.UpdateLinkedModule
+import me.urielsalis.mccrashlib.CrashReader
+import net.rcarz.jiraclient.Issue
+import net.rcarz.jiraclient.JiraClient
+import net.sf.json.JSONObject
+import java.text.SimpleDateFormat
+
+class ModuleRegistry(jiraClient: JiraClient, private val config: Config) {
+    data class Entry(
+        val config: ModuleConfigSpec,
+        val execute: (Issue) -> Pair<String, Either<ModuleError, ModuleResponse>>
+    )
+
+    private val modules = mutableListOf<Entry>()
+
+    fun getModules(): List<Entry> =
+        modules
+
+    private fun <T> register(
+        name: String,
+        config: ModuleConfigSpec,
+        module: Module<T>,
+        requestCreator: (Issue) -> T
+    ) = { issue: Issue ->
+        name to ({ issue pipe requestCreator pipe module::invoke } pipe ::tryExecuteModule)
+    } pipe (config pipe2 ModuleRegistry::Entry) pipe modules::add
+
+    private fun tryExecuteModule(executeModule: () -> Either<ModuleError, ModuleResponse>) = try {
+        executeModule()
+    } catch (e: Throwable) {
+        FailedModuleResponse(listOf(e)).left()
+    }
+
+    private val isoFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+    private fun String.toInstant() = isoFormat.parse(this).toInstant()
+
+    private fun Issue.getFieldAsString(field: String) = this.getField(field) as? String?
+
+    private fun Issue.getCustomField(customField: String): String? =
+        ((getField(customField)) as? JSONObject)?.get("value") as? String?
+
+    private fun getSecurityLevelId(project: String) =
+        config[PrivateSecurityLevel.special][project] ?: config[PrivateSecurityLevel.default]
+
+    init {
+        register(
+            "Attachment",
+            Modules.Attachment,
+            AttachmentModule(config[Modules.Attachment.extensionBlacklist])
+        ) { issue ->
+            AttachmentModule.Request(
+                issue.attachments.map { a ->
+                    AttachmentModule.Attachment(
+                        a.fileName,
+                        ::deleteAttachment.partially1(jiraClient).partially1(a)
+                    )
+                }
+            )
+        }
+
+        register(
+            "CHK",
+            Modules.CHK,
+            CHKModule()
+        ) { issue ->
+            CHKModule.Request(
+                issue.getFieldAsString(config[CustomFields.chkField]),
+                issue.getCustomField(config[CustomFields.confirmationField]),
+                ::updateCHK.partially1(issue).partially1(config[CustomFields.chkField])
+            )
+        }
+
+        register(
+            "Crash",
+            Modules.Crash,
+            CrashModule(
+                config[Modules.Crash.crashExtensions],
+                config[Modules.Crash.duplicates],
+                config[Modules.Crash.maxAttachmentAge],
+                CrashReader()
+            )
+        ) { issue ->
+            CrashModule.Request(
+                issue.attachments
+                    .map { a -> CrashModule.Attachment(a.fileName, a.createdDate, a.download()) },
+                issue.description,
+                issue.createdDate,
+                issue.getCustomField(config[CustomFields.confirmationField]),
+                issue.getCustomField(config[CustomFields.mojangPriorityField]),
+                ::resolveAs.partially1(issue).partially1("Invalid"),
+                ::resolveAs.partially1(issue).partially1("Duplicate"),
+                ::link.partially1(issue).partially1("Duplicate"),
+                ::addComment.partially1(issue).partially1(config[Modules.Crash.moddedMessage]),
+                { key ->
+                    addComment(
+                        issue,
+                        config[Modules.Crash.duplicateMessage].format(key)
+                    )
+                }
+            )
+        }
+
+        register(
+            "Empty",
+            Modules.Empty,
+            EmptyModule()
+        ) { issue ->
+            EmptyModule.Request(
+                issue.attachments.size,
+                issue.description,
+                issue.getFieldAsString("environment"),
+                ::resolveAs.partially1(issue).partially1("Incomplete"),
+                ::addComment.partially1(issue).partially1(config[Modules.Empty.message])
+            )
+        }
+
+        register(
+            "FutureVersion",
+            Modules.FutureVersion,
+            FutureVersionModule()
+        ) { issue ->
+            val project = jiraClient.getProject(issue.project.key)
+            FutureVersionModule.Request(
+                issue.versions
+                    .map { v ->
+                        FutureVersionModule.Version(
+                            v.isReleased,
+                            v.isArchived,
+                            ::removeAffectedVersion.partially1(issue).partially1(v)
+                        )
+                    },
+                project?.versions
+                    ?.map { v ->
+                        FutureVersionModule.Version(
+                            v.isReleased,
+                            v.isArchived,
+                            ::addAffectedVersion.partially1(issue).partially1(v)
+                        )
+                    },
+                ::addComment.partially1(issue).partially1(config[Modules.FutureVersion.message])
+            )
+        }
+
+        register(
+            "HideImpostors",
+            Modules.HideImpostors,
+            HideImpostorsModule()
+        ) { issue ->
+            HideImpostorsModule.Request(
+                issue.comments
+                    .map { c ->
+                        HideImpostorsModule.Comment(
+                            c.author.displayName,
+                            getGroups(
+                                jiraClient,
+                                c.author.name
+                            ).fold({ null }, { it }),
+                            c.updatedDate.toInstant(),
+                            c.visibility?.type,
+                            c.visibility?.value,
+                            ::restrictCommentToGroup.partially1(c).partially1("staff").partially1(null)
+                        )
+                    }
+            )
+        }
+
+        register(
+            "KeepPrivate",
+            Modules.KeepPrivate,
+            KeepPrivateModule(config[Modules.KeepPrivate.tag])
+        ) { issue ->
+            KeepPrivateModule.Request(
+                issue.security?.id,
+                getSecurityLevelId(issue.project.key),
+                issue.comments.map { c -> c.body },
+                ::updateSecurity.partially1(issue).partially1(getSecurityLevelId(issue.project.key)),
+                ::addComment.partially1(issue).partially1(config[Modules.KeepPrivate.message])
+            )
+        }
+
+        register(
+            "Piracy",
+            Modules.Piracy,
+            PiracyModule(config[Modules.Piracy.piracySignatures])
+        ) { issue ->
+            PiracyModule.Request(
+                issue.getFieldAsString("environment"),
+                issue.summary,
+                issue.description,
+                ::resolveAs.partially1(issue).partially1("Invalid"),
+                ::addComment.partially1(issue).partially1(config[Modules.Piracy.message])
+            )
+        }
+
+        register(
+            "Language",
+            Modules.Language,
+            LanguageModule()
+        ) { issue ->
+            LanguageModule.Request(
+                issue.summary,
+                issue.description,
+                issue.security?.id,
+                getSecurityLevelId(issue.project.key),
+                ::getLanguage.partially1(config[Credentials.dandelionToken]),
+                { Unit.right() }, // ::resolveAs.partially1(issue).partially1("Invalid"),
+                { language ->
+                    val translatedMessage = config[Modules.Language.messages][language]
+                    val defaultMessage = config[Modules.Language.defaultMessage]
+                    val text =
+                        if (translatedMessage != null) config[Modules.Language.messageFormat].format(
+                            translatedMessage,
+                            defaultMessage
+                        ) else defaultMessage
+
+                    addRestrictedComment(issue, text, "helper")
+                }
+            )
+        }
+
+        register(
+            "RemoveNonStaffMeqs",
+            Modules.RemoveNonStaffMeqs,
+            RemoveNonStaffMeqsModule(config[Modules.RemoveNonStaffMeqs.removalReason])
+        ) { issue ->
+            RemoveNonStaffMeqsModule.Request(
+                issue.comments
+                    .map { c ->
+                        RemoveNonStaffMeqsModule.Comment(
+                            c.body,
+                            c.visibility?.type,
+                            c.visibility?.value,
+                            ::restrictCommentToGroup.partially1(c).partially1("staff")
+                        )
+                    }
+            )
+        }
+
+        register(
+            "RemoveTriagedMeqs",
+            Modules.RemoveTriagedMeqs,
+            RemoveTriagedMeqsModule(
+                config[Modules.RemoveTriagedMeqs.meqsTags],
+                config[Modules.RemoveTriagedMeqs.removalReason]
+            )
+        ) { issue ->
+            RemoveTriagedMeqsModule.Request(
+                issue.getCustomField(config[CustomFields.mojangPriorityField]),
+                issue.getFieldAsString(config[CustomFields.triagedTimeField]),
+                issue.comments
+                    .map { c ->
+                        RemoveTriagedMeqsModule.Comment(
+                            c.body,
+                            ::updateCommentBody.partially1(c)
+                        )
+                    }
+            )
+        }
+
+        register(
+            "ReopenAwaiting",
+            Modules.ReopenAwaiting,
+            ReopenAwaitingModule()
+        ) { issue ->
+            ReopenAwaitingModule.Request(
+                issue.resolution?.name,
+                (issue.getFieldAsString("created"))!!.toInstant(),
+                (issue.getFieldAsString("updated"))!!.toInstant(),
+                issue.comments
+                    .map { c ->
+                        ReopenAwaitingModule.Comment(
+                            c.updatedDate.toInstant().toEpochMilli(),
+                            c.createdDate.toInstant().toEpochMilli()
+                        )
+                    },
+                ::reopenIssue.partially1(issue)
+            )
+        }
+
+        register(
+            "RevokeConfirmation",
+            Modules.RevokeConfirmation,
+            RevokeConfirmationModule()
+        ) { issue ->
+            RevokeConfirmationModule.Request(
+                issue.getCustomField(config[CustomFields.confirmationField]),
+                issue.changeLog.entries
+                    .flatMap { e ->
+                        e.items
+                            .map { i ->
+                                RevokeConfirmationModule.ChangeLogItem(
+                                    i.field,
+                                    i.toString,
+                                    e.created.toInstant(),
+                                    getGroups(
+                                        jiraClient,
+                                        e.author.name
+                                    ).fold({ null }, { it })
+                                )
+                            }
+                    },
+                ::updateConfirmation.partially1(issue)
+                    .partially1(config[CustomFields.confirmationField])
+            )
+        }
+
+        register(
+            "ResolveTrash",
+            Modules.ResolveTrash,
+            ResolveTrashModule()
+        ) { issue ->
+            ResolveTrashModule.Request(
+                issue.project.key,
+                ::resolveAs.partially1(issue).partially1("Invalid")
+            )
+        }
+
+        register(
+            "UpdateLinked",
+            Modules.UpdateLinked,
+            UpdateLinkedModule()
+        ) { issue ->
+            UpdateLinkedModule.Request(
+                issue.issueLinks
+                    .map { it.type.name },
+                issue.getField(config[CustomFields.linked]) as? Double?,
+                ::updateLinked.partially1(issue).partially1(config[CustomFields.linked])
+            )
+        }
+    }
+}

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -129,7 +129,7 @@ class ModuleRegistry(jiraClient: JiraClient, private val config: Config) {
         ) { issue ->
             ConfirmParentModule.Request(
                 issue.getCustomField(config[CustomFields.confirmationField]),
-                issue.getField(config[CustomFields.linked]) as? Int?,
+                issue.getField(config[CustomFields.linked]) as? Double?,
                 ::updateConfirmation
                     .partially1(issue)
                     .partially1(config[CustomFields.confirmationField])

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
@@ -65,8 +65,9 @@ object Arisa : ConfigSpec() {
         object CHK : ModuleConfigSpec()
 
         object ConfirmParent : ModuleConfigSpec() {
-            val confirmationStatusWhitelist by optional(emptyList<String>(), description = "List of confirmation status that can be replaced by the target status if Linked is greater than 0.")
-            val targetConfirmationStatus by optional("", description = "The target confirmation status for tickets whose Linked is greater than 0.")
+            val confirmationStatusWhitelist by optional(emptyList<String>(), description = "List of confirmation status that can be replaced by the target status if Linked is greater than or equal to the threshold.")
+            val targetConfirmationStatus by optional("", description = "The target confirmation status for tickets whose Linked is greater than or equal to the threshold.")
+            val linkedThreshold by optional(0.0, description = "The threshold of the Linked field for the ticket to be confirmed")
         }
 
         object ReopenAwaiting : ModuleConfigSpec()

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
@@ -64,6 +64,11 @@ object Arisa : ConfigSpec() {
 
         object CHK : ModuleConfigSpec()
 
+        object ConfirmParent : ModuleConfigSpec() {
+            val confirmationStatusWhitelist by optional(emptyList<String>(), description = "List of confirmation status that can be replaced by the target status if Linked is greater than 0.")
+            val targetConfirmationStatus by optional("", description = "The target confirmation status for tickets whose Linked is greater than 0.")
+        }
+
         object ReopenAwaiting : ModuleConfigSpec()
 
         object RemoveNonStaffMeqs : ModuleConfigSpec() {

--- a/src/main/kotlin/io/github/mojira/arisa/modules/ConfirmParentModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ConfirmParentModule.kt
@@ -11,7 +11,7 @@ class ConfirmParentModule(
 ) : Module<ConfirmParentModule.Request> {
     data class Request(
         val confirmationStatus: String?,
-        val linked: Int?,
+        val linked: Double?,
         val setConfirmationStatus: (String) -> Either<Throwable, Unit>
     )
 
@@ -23,7 +23,7 @@ class ConfirmParentModule(
         }
     }
 
-    private fun assertLinkedMoreThanZero(linked: Int?) = if ((linked ?: 0) > 0) {
+    private fun assertLinkedMoreThanZero(linked: Double?) = if ((linked ?: 0.0) > 0.0) {
             Unit.right()
         } else {
             OperationNotNeededModuleResponse.left()

--- a/src/main/kotlin/io/github/mojira/arisa/modules/ConfirmParentModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ConfirmParentModule.kt
@@ -7,7 +7,8 @@ import arrow.core.right
 
 class ConfirmParentModule(
     private val confirmationStatusWhitelist: List<String>,
-    private val targetConfirmationStatus: String
+    private val targetConfirmationStatus: String,
+    private val linkedThreshold: Double
 ) : Module<ConfirmParentModule.Request> {
     data class Request(
         val confirmationStatus: String?,
@@ -23,16 +24,22 @@ class ConfirmParentModule(
         }
     }
 
-    private fun assertLinkedMoreThanZero(linked: Double?) = if ((linked ?: 0.0) > 0.0) {
+    private fun assertLinkedMoreThanZero(linked: Double?) = if ((linked ?: 0.0) >= linkedThreshold) {
             Unit.right()
         } else {
             OperationNotNeededModuleResponse.left()
         }
 
     private fun assertConfirmationStatusWhitelisted(status: String?, whitelist: List<String>) =
-        if ((status ?: "Unconfirmed") in whitelist) {
+        if ((status.getOrDefault("Unconfirmed")) in whitelist) {
             Unit.right()
         } else {
             OperationNotNeededModuleResponse.left()
         }
+
+    private fun String?.getOrDefault(default: String) =
+        if (isNullOrBlank())
+            default
+        else
+            this!!
 }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/ConfirmParentModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ConfirmParentModule.kt
@@ -1,0 +1,38 @@
+package io.github.mojira.arisa.modules
+
+import arrow.core.Either
+import arrow.core.extensions.fx
+import arrow.core.left
+import arrow.core.right
+
+class ConfirmParentModule(
+    private val confirmationStatusWhitelist: List<String>,
+    private val targetConfirmationStatus: String
+) : Module<ConfirmParentModule.Request> {
+    data class Request(
+        val confirmationStatus: String?,
+        val linked: Int?,
+        val setConfirmationStatus: (String) -> Either<Throwable, Unit>
+    )
+
+    override fun invoke(request: ConfirmParentModule.Request): Either<ModuleError, ModuleResponse> = with(request) {
+        Either.fx {
+            assertLinkedMoreThanZero(linked).bind()
+            assertConfirmationStatusWhitelisted(confirmationStatus, confirmationStatusWhitelist).bind()
+            setConfirmationStatus(targetConfirmationStatus).toFailedModuleEither().bind()
+        }
+    }
+
+    private fun assertLinkedMoreThanZero(linked: Int?) = if ((linked ?: 0) > 0) {
+            Unit.right()
+        } else {
+            OperationNotNeededModuleResponse.left()
+        }
+
+    private fun assertConfirmationStatusWhitelisted(status: String?, whitelist: List<String>) =
+        if ((status ?: "Unconfirmed") in whitelist) {
+            Unit.right()
+        } else {
+            OperationNotNeededModuleResponse.left()
+        }
+}

--- a/src/main/kotlin/io/github/mojira/arisa/modules/ConfirmParentModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ConfirmParentModule.kt
@@ -18,13 +18,13 @@ class ConfirmParentModule(
 
     override fun invoke(request: ConfirmParentModule.Request): Either<ModuleError, ModuleResponse> = with(request) {
         Either.fx {
-            assertLinkedMoreThanZero(linked).bind()
+            assertLinkedMoreThanThreshold(linked).bind()
             assertConfirmationStatusWhitelisted(confirmationStatus, confirmationStatusWhitelist).bind()
             setConfirmationStatus(targetConfirmationStatus).toFailedModuleEither().bind()
         }
     }
 
-    private fun assertLinkedMoreThanZero(linked: Double?) = if ((linked ?: 0.0) >= linkedThreshold) {
+    private fun assertLinkedMoreThanThreshold(linked: Double?) = if ((linked ?: 0.0) >= linkedThreshold) {
             Unit.right()
         } else {
             OperationNotNeededModuleResponse.left()

--- a/src/test/kotlin/io/github/mojira/arisa/modules/ConfirmParentModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/ConfirmParentModuleTest.kt
@@ -1,0 +1,90 @@
+package io.github.mojira.arisa.modules
+
+import arrow.core.right
+import io.kotest.assertions.arrow.either.shouldBeLeft
+import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class ConfirmParentModuleTest : StringSpec({
+    "should return OperationNotNeededModuleResponse when Linked is null" {
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus")
+        val request = ConfirmParentModule.Request("Unconfirmed", null) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when Linked is 0" {
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus")
+        val request = ConfirmParentModule.Request("Unconfirmed", 0) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should set to Community Consensus when Confirmation Status is unset and Linked is 1" {
+        var changedConfirmation = ""
+
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus")
+        val request = ConfirmParentModule.Request(null, 1) {
+            changedConfirmation = it
+            Unit.right()
+        }
+
+        val result = module(request)
+
+        result.shouldBeRight(ModuleResponse)
+        changedConfirmation.shouldBe("Community Consensus")
+    }
+
+    "should set to Community Consensus when Confirmation Status is Unconfirmed and Linked is 1" {
+        var changedConfirmation = ""
+
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus")
+        val request = ConfirmParentModule.Request("Unconfirmed", 1) {
+            changedConfirmation = it
+            Unit.right()
+        }
+
+        val result = module(request)
+
+        result.shouldBeRight(ModuleResponse)
+        changedConfirmation.shouldBe("Community Consensus")
+    }
+
+    "should set to Community Consensus when Confirmation Status is Plausible and Linked is 1" {
+        var changedConfirmation = ""
+
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus")
+        val request = ConfirmParentModule.Request("Plausible", 1) {
+            changedConfirmation = it
+            Unit.right()
+        }
+
+        val result = module(request)
+
+        result.shouldBeRight(ModuleResponse)
+        changedConfirmation.shouldBe("Community Consensus")
+    }
+
+    "should return OperationNotNeededModuleResponse when Confirmation Status is Community Consensus and Linked is 1" {
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus")
+        val request = ConfirmParentModule.Request("Community Consensus", 1) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when Confirmation Status is Confirmed and Linked is 1" {
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus")
+        val request = ConfirmParentModule.Request("Community Consensus", 1) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+})

--- a/src/test/kotlin/io/github/mojira/arisa/modules/ConfirmParentModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/ConfirmParentModuleTest.kt
@@ -8,7 +8,7 @@ import io.kotest.matchers.shouldBe
 
 class ConfirmParentModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse when Linked is null" {
-        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus")
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 1.0)
         val request = ConfirmParentModule.Request("Unconfirmed", null) { Unit.right() }
 
         val result = module(request)
@@ -17,7 +17,7 @@ class ConfirmParentModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse when Linked is 0" {
-        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus")
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 1.0)
         val request = ConfirmParentModule.Request("Unconfirmed", 0.0) { Unit.right() }
 
         val result = module(request)
@@ -25,11 +25,44 @@ class ConfirmParentModuleTest : StringSpec({
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
-    "should set to Community Consensus when Confirmation Status is unset and Linked is 1" {
+    "should return OperationNotNeededModuleResponse when Confirmation Status is Community Consensus and Linked is 1" {
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 1.0)
+        val request = ConfirmParentModule.Request("Community Consensus", 1.0) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when Confirmation Status is Confirmed and Linked is 1" {
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 1.0)
+        val request = ConfirmParentModule.Request("Community Consensus", 1.0) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should set to Community Consensus when Confirmation Status is null and Linked is 1" {
         var changedConfirmation = ""
 
-        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus")
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 1.0)
         val request = ConfirmParentModule.Request(null, 1.0) {
+            changedConfirmation = it
+            Unit.right()
+        }
+
+        val result = module(request)
+
+        result.shouldBeRight(ModuleResponse)
+        changedConfirmation.shouldBe("Community Consensus")
+    }
+
+    "should set to Community Consensus when Confirmation Status is empty and Linked is 1" {
+        var changedConfirmation = ""
+
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 1.0)
+        val request = ConfirmParentModule.Request("", 1.0) {
             changedConfirmation = it
             Unit.right()
         }
@@ -43,7 +76,7 @@ class ConfirmParentModuleTest : StringSpec({
     "should set to Community Consensus when Confirmation Status is Unconfirmed and Linked is 1" {
         var changedConfirmation = ""
 
-        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus")
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 1.0)
         val request = ConfirmParentModule.Request("Unconfirmed", 1.0) {
             changedConfirmation = it
             Unit.right()
@@ -58,7 +91,7 @@ class ConfirmParentModuleTest : StringSpec({
     "should set to Community Consensus when Confirmation Status is Plausible and Linked is 1" {
         var changedConfirmation = ""
 
-        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus")
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 1.0)
         val request = ConfirmParentModule.Request("Plausible", 1.0) {
             changedConfirmation = it
             Unit.right()
@@ -68,23 +101,5 @@ class ConfirmParentModuleTest : StringSpec({
 
         result.shouldBeRight(ModuleResponse)
         changedConfirmation.shouldBe("Community Consensus")
-    }
-
-    "should return OperationNotNeededModuleResponse when Confirmation Status is Community Consensus and Linked is 1" {
-        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus")
-        val request = ConfirmParentModule.Request("Community Consensus", 1.0) { Unit.right() }
-
-        val result = module(request)
-
-        result.shouldBeLeft(OperationNotNeededModuleResponse)
-    }
-
-    "should return OperationNotNeededModuleResponse when Confirmation Status is Confirmed and Linked is 1" {
-        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus")
-        val request = ConfirmParentModule.Request("Community Consensus", 1.0) { Unit.right() }
-
-        val result = module(request)
-
-        result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 })

--- a/src/test/kotlin/io/github/mojira/arisa/modules/ConfirmParentModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/ConfirmParentModuleTest.kt
@@ -18,7 +18,7 @@ class ConfirmParentModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when Linked is 0" {
         val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus")
-        val request = ConfirmParentModule.Request("Unconfirmed", 0) { Unit.right() }
+        val request = ConfirmParentModule.Request("Unconfirmed", 0.0) { Unit.right() }
 
         val result = module(request)
 
@@ -29,7 +29,7 @@ class ConfirmParentModuleTest : StringSpec({
         var changedConfirmation = ""
 
         val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus")
-        val request = ConfirmParentModule.Request(null, 1) {
+        val request = ConfirmParentModule.Request(null, 1.0) {
             changedConfirmation = it
             Unit.right()
         }
@@ -44,7 +44,7 @@ class ConfirmParentModuleTest : StringSpec({
         var changedConfirmation = ""
 
         val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus")
-        val request = ConfirmParentModule.Request("Unconfirmed", 1) {
+        val request = ConfirmParentModule.Request("Unconfirmed", 1.0) {
             changedConfirmation = it
             Unit.right()
         }
@@ -59,7 +59,7 @@ class ConfirmParentModuleTest : StringSpec({
         var changedConfirmation = ""
 
         val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus")
-        val request = ConfirmParentModule.Request("Plausible", 1) {
+        val request = ConfirmParentModule.Request("Plausible", 1.0) {
             changedConfirmation = it
             Unit.right()
         }
@@ -72,7 +72,7 @@ class ConfirmParentModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when Confirmation Status is Community Consensus and Linked is 1" {
         val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus")
-        val request = ConfirmParentModule.Request("Community Consensus", 1) { Unit.right() }
+        val request = ConfirmParentModule.Request("Community Consensus", 1.0) { Unit.right() }
 
         val result = module(request)
 
@@ -81,7 +81,7 @@ class ConfirmParentModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when Confirmation Status is Confirmed and Linked is 1" {
         val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus")
-        val request = ConfirmParentModule.Request("Community Consensus", 1) { Unit.right() }
+        val request = ConfirmParentModule.Request("Community Consensus", 1.0) { Unit.right() }
 
         val result = module(request)
 


### PR DESCRIPTION
## Purpose
Resolve #123

## Approach
Added a new ConfirmParentModule which will set the Confirmation Status of tickets whose Linked is greater than `linkedThreshold` and Confirmation Status exists in `confirmationStatusWhitelist` to the value specified in `targetConfirmationStatus`.

#### Checklist
- [x] Included tests
- [ ] Tested in MCTEST-xxx
