### PR TITLE
Feature/dont reopen after staff edit

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -112,6 +112,15 @@
       "reopenAwaiting": {
         "resolutions": [
           "Awaiting Response"
+        ],
+        "blacklistedRoles": [
+          "staff",
+          "global-moderators"
+        ],
+        "blacklistedRestrictions": [
+          "helper",
+          "staff",
+          "global-moderators"
         ]
       },
       "removeNonStaffMeqs": {

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
@@ -64,7 +64,10 @@ object Arisa : ConfigSpec() {
 
         object CHK : ModuleConfigSpec()
 
-        object ReopenAwaiting : ModuleConfigSpec()
+        object ReopenAwaiting : ModuleConfigSpec() {
+            val blacklistedRoles by optional(emptyList<String>(), description = "Comments that were posted by someone who is member of this role should be ignored.")
+            val blacklistedVisibilities by optional(emptyList<String>(), description = "Comments that are restricted to one of these roles should be ignored")
+        }
 
         object RemoveNonStaffMeqs : ModuleConfigSpec() {
             val removalReason by required<String>(description = "Reason Arisa should add to the edited comment for removing the tag. Default is no reason.")

--- a/src/main/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModule.kt
@@ -7,8 +7,8 @@ import arrow.core.right
 import java.time.Instant
 
 class ReopenAwaitingModule(
-    private val blacklistedRoles : List<String>,
-    private val blacklistedVisibilities : List<String>
+    private val blacklistedRoles: List<String>,
+    private val blacklistedVisibilities: List<String>
 ) : Module<ReopenAwaitingModule.Request> {
     data class Comment(
         val updated: Long,

--- a/src/main/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModule.kt
@@ -6,10 +6,16 @@ import arrow.core.left
 import arrow.core.right
 import java.time.Instant
 
-class ReopenAwaitingModule : Module<ReopenAwaitingModule.Request> {
+class ReopenAwaitingModule(
+    private val blacklistedRoles : List<String>,
+    private val blacklistedVisibilities : List<String>
+) : Module<ReopenAwaitingModule.Request> {
     data class Comment(
         val updated: Long,
-        val created: Long
+        val created: Long,
+        val visibilityType: String?,
+        val visibilityValue: String?,
+        val authorGroups: List<String>?
     )
 
     data class Request(
@@ -29,20 +35,33 @@ class ReopenAwaitingModule : Module<ReopenAwaitingModule.Request> {
             assertUpdateWasNotCausedByEditingComment(
                 updated.toEpochMilli(), lastComment.updated, lastComment.created
             ).bind()
+            assertCommentWasNotAddedByABlacklistedRole(lastComment.authorGroups).bind()
+            assertCommentIsNotRestrictedToABlacklistedLevel(lastComment.visibilityType, lastComment.visibilityValue).bind()
+
             reopen().toFailedModuleEither().bind()
         }
     }
 
-    private fun assertCreationIsNotRecent(updated: Long, created: Long) = if ((updated - created) < 2000) {
-        OperationNotNeededModuleResponse.left()
-    } else {
-        Unit.right()
+    private fun assertCreationIsNotRecent(updated: Long, created: Long) = when {
+            (updated - created) < 2000 -> OperationNotNeededModuleResponse.left()
+            else -> Unit.right()
+        }
+
+    private fun assertUpdateWasNotCausedByEditingComment(updated: Long, commentUpdated: Long, commentCreated: Long) = when {
+        updated - commentUpdated >= 2000 -> Unit.right()
+        commentUpdated - commentCreated <= 2000 -> Unit.right()
+        else -> OperationNotNeededModuleResponse.left()
     }
 
-    private fun assertUpdateWasNotCausedByEditingComment(updated: Long, commentUpdated: Long, commentCreated: Long) =
-        if (updated - commentUpdated < 2000 && (commentUpdated - commentCreated) > 2000) {
-            OperationNotNeededModuleResponse.left()
-        } else {
-            Unit.right()
-        }
+    private fun assertCommentWasNotAddedByABlacklistedRole(roles: List<String>?) = when {
+        roles == null -> Unit.right()
+        roles.none { it in blacklistedRoles } -> Unit.right()
+        else -> OperationNotNeededModuleResponse.left()
+    }
+
+    private fun assertCommentIsNotRestrictedToABlacklistedLevel(visibilityType: String?, visibilityValue: String?) = when {
+        visibilityType != "group" -> Unit.right()
+        blacklistedVisibilities.none { it == visibilityValue } -> Unit.right()
+        else -> OperationNotNeededModuleResponse.left()
+    }
 }

--- a/src/test/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModuleTest.kt
@@ -16,7 +16,7 @@ class ReopenAwaitingModuleTest : StringSpec({
         listOf("staff", "global-moderators"),
         listOf("helper", "staff", "global-moderators")
     )
-    
+t push
     "should return OperationNotNeededModuleResponse when there is no resolution" {
         val now = Instant.now()
         val updated = Instant.now().plusSeconds(3)

--- a/src/test/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModuleTest.kt
@@ -12,100 +12,163 @@ import io.kotest.matchers.shouldBe
 import java.time.Instant
 
 class ReopenAwaitingModuleTest : StringSpec({
+    val MODULE = ReopenAwaitingModule(
+        listOf("staff", "global-moderators"),
+        listOf("helper", "staff", "global-moderators")
+    )
+    
     "should return OperationNotNeededModuleResponse when there is no resolution" {
-        val module = ReopenAwaitingModule()
         val now = Instant.now()
         val updated = Instant.now().plusSeconds(3)
-        val comment = Comment(now.toEpochMilli(), now.toEpochMilli())
+        val comment = Comment(now.toEpochMilli(), now.toEpochMilli(), null, null, null)
         val request = Request(null, now, updated, listOf(comment)) { Unit.right() }
 
-        val result = module(request)
+        val result = MODULE(request)
 
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
     "should return OperationNotNeededModuleResponse when ticket is not in awaiting response" {
-        val module = ReopenAwaitingModule()
         val now = Instant.now()
         val updated = Instant.now().plusSeconds(3)
-        val comment = Comment(now.toEpochMilli(), now.toEpochMilli())
+        val comment = Comment(now.toEpochMilli(), now.toEpochMilli(), null, null, null)
         val request = Request("Test", now, updated, listOf(comment)) { Unit.right() }
 
-        val result = module(request)
+        val result = MODULE(request)
 
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
     "should return OperationNotNeededModuleResponse when ticket is less than 2 seconds old" {
-        val module = ReopenAwaitingModule()
         val now = Instant.now()
         val updated = Instant.now().plusSeconds(1)
-        val comment = Comment(now.toEpochMilli(), now.toEpochMilli())
+        val comment = Comment(now.toEpochMilli(), now.toEpochMilli(), null, null, null)
         val request = Request("Awaiting Response", now, updated, listOf(comment)) { Unit.right() }
 
-        val result = module(request)
+        val result = MODULE(request)
 
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
     "should return OperationNotNeededModuleResponse when there are no comments" {
-        val module = ReopenAwaitingModule()
         val now = Instant.now()
         val updated = Instant.now().plusSeconds(3)
         val request = Request("Awaiting Response", now, updated, emptyList()) { Unit.right() }
 
-        val result = module(request)
+        val result = MODULE(request)
 
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
     "should return OperationNotNeededModuleResponse when just the comment was updated" {
-        val module = ReopenAwaitingModule()
         val now = Instant.now()
-        val comment = Comment(now.plusSeconds(3).toEpochMilli(), now.toEpochMilli())
+        val comment = Comment(now.plusSeconds(3).toEpochMilli(), now.toEpochMilli(), null, null, null)
         val updated = Instant.now().plusSeconds(3)
         val request = Request("Awaiting Response", now, updated, listOf(comment)) { Unit.right() }
 
-        val result = module(request)
+        val result = MODULE(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when comment is restricted" {
+        val now = Instant.now()
+        val comment = Comment(now.toEpochMilli(), now.toEpochMilli(), "group", "helper", null)
+        val updated = Instant.now().plusSeconds(3)
+        val request = Request("Awaiting Response", now, updated, listOf(comment)) { Unit.right() }
+
+        val result = MODULE(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when comment author is staff" {
+        val now = Instant.now()
+        val comment = Comment(now.toEpochMilli(), now.toEpochMilli(), null, null, listOf("staff"))
+        val updated = Instant.now().plusSeconds(3)
+        val request = Request("Awaiting Response", now, updated, listOf(comment)) { Unit.right() }
+
+        val result = MODULE(request)
 
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
     "should grab the last comment" {
-        val module = ReopenAwaitingModule()
         val now = Instant.now()
         val updated = Instant.now().plusSeconds(3)
-        val commentFail = Comment(now.plusSeconds(3).toEpochMilli(), now.toEpochMilli())
-        val commentSuccess = Comment(now.toEpochMilli(), now.toEpochMilli())
+        val commentFail = Comment(now.plusSeconds(3).toEpochMilli(), now.toEpochMilli(), null, null, null)
+        val commentSuccess = Comment(now.toEpochMilli(), now.toEpochMilli(), null, null, null)
         val request = Request("Awaiting Response", now, updated, listOf(commentSuccess, commentFail)) { Unit.right() }
 
-        val result = module(request)
+        val result = MODULE(request)
 
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
     "should return FailedModuleResponse with all exceptions when reopening fails" {
-        val module = ReopenAwaitingModule()
         val now = Instant.now()
         val updated = Instant.now().plusSeconds(3)
-        val comment = Comment(now.toEpochMilli(), now.toEpochMilli())
+        val comment = Comment(now.toEpochMilli(), now.toEpochMilli(), null, null, null)
         val request = Request("Awaiting Response", now, updated, listOf(comment)) { RuntimeException().left() }
 
-        val result = module(request)
+        val result = MODULE(request)
 
         result.shouldBeLeft()
         result.a should { it is FailedModuleResponse }
         (result.a as FailedModuleResponse).exceptions.size shouldBe 1
     }
 
-    "should return ModuleResponse when ticket is reopened" {
-        val module = ReopenAwaitingModule()
+    "should reopen when someone answered" {
         val now = Instant.now()
         val updated = Instant.now().plusSeconds(3)
-        val comment = Comment(now.toEpochMilli(), now.toEpochMilli())
+        val comment = Comment(now.toEpochMilli(), now.toEpochMilli(), null, null, null)
         val request = Request("Awaiting Response", now, updated, listOf(comment)) { Unit.right() }
 
-        val result = module(request)
+        val result = MODULE(request)
+
+        result.shouldBeRight(ModuleResponse)
+    }
+
+    "should reopen when comment is restricted, but not to a group" {
+        val now = Instant.now()
+        val updated = Instant.now().plusSeconds(3)
+        val comment = Comment(now.toEpochMilli(), now.toEpochMilli(), "not-a-group", "helper", null)
+        val request = Request("Awaiting Response", now, updated, listOf(comment)) { Unit.right() }
+
+        val result = MODULE(request)
+
+        result.shouldBeRight(ModuleResponse)
+    }
+
+    "should reopen when comment is restricted, but not to a blacklisted group" {
+        val now = Instant.now()
+        val updated = Instant.now().plusSeconds(3)
+        val comment = Comment(now.toEpochMilli(), now.toEpochMilli(), "group", "users", null)
+        val request = Request("Awaiting Response", now, updated, listOf(comment)) { Unit.right() }
+
+        val result = MODULE(request)
+
+        result.shouldBeRight(ModuleResponse)
+    }
+
+    "should reopen when comment author has no groups" {
+        val now = Instant.now()
+        val updated = Instant.now().plusSeconds(3)
+        val comment = Comment(now.toEpochMilli(), now.toEpochMilli(), null, null, emptyList())
+        val request = Request("Awaiting Response", now, updated, listOf(comment)) { Unit.right() }
+
+        val result = MODULE(request)
+
+        result.shouldBeRight(ModuleResponse)
+    }
+
+    "should reopen when comment author has no blacklisted groups" {
+        val now = Instant.now()
+        val updated = Instant.now().plusSeconds(3)
+        val comment = Comment(now.toEpochMilli(), now.toEpochMilli(), null, null, listOf("Users"))
+        val request = Request("Awaiting Response", now, updated, listOf(comment)) { Unit.right() }
+
+        val result = MODULE(request)
 
         result.shouldBeRight(ModuleResponse)
     }

--- a/src/test/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModuleTest.kt
@@ -16,7 +16,7 @@ class ReopenAwaitingModuleTest : StringSpec({
         listOf("staff", "global-moderators"),
         listOf("helper", "staff", "global-moderators")
     )
-t push
+
     "should return OperationNotNeededModuleResponse when there is no resolution" {
         val now = Instant.now()
         val updated = Instant.now().plusSeconds(3)


### PR DESCRIPTION
## Purpose
Fixes #117 
Makes #56 obsolete 

## Approach
With this change, Arisa will not reopen a ticket when the last comment was from a staff member or is restricted to volunteers.

#### Checklist
- [x] Included tests
- [ ] Tested in MCTEST-xxx
