### PR TITLE
Better presets

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,24 +7,8 @@ assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+## The Bug
 
-**Example**
-A ticket where we can see an example, If applicable
+## Example Ticket
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
-
-**Expected behavior**
-A clear and concise description of what you expected to happen.
-
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
-
-**Additional context**
-Add any other context about the problem here.
+## Expected behavior

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,6 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+## The Problem
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
-
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
-
-**Additional context**
-Add any other context or screenshots about the feature request here.
+## Possible Solution

--- a/.github/ISSUE_TEMPLATE/module-request.md
+++ b/.github/ISSUE_TEMPLATE/module-request.md
@@ -7,14 +7,6 @@ assignees: ''
 
 ---
 
-**What is the problem the module is aiming to solve? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+## The Problem
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
-
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
-
-**Additional context**
-Add any other context or screenshots about the feature request here.
+## Possible Implementation

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,8 @@
 ## Purpose
-_Describe the problem or feature in addition to a link to the issues._
 
 ## Approach
-_How does this change address the problem?_
 
 ## Future work
-
-_If applicable, work referenced here that will be done in the future_
 
 #### Checklist
 - [ ] Included tests


### PR DESCRIPTION
## Purpose
The issue presets in particular are more annoying than helpful and I find myself (and others) just deleting everything and writing issues without a preset most of the time

## Approach
This rewrites all issue presets to what I think would be more useful.
It also removes any descriptive texts of what you should put were, as I expect people who submit issues to a project related to a bug tracker, were mostly mods and helpers of said tracker post, to be knowing what they are doing.
With this, I hope not having to delete anything for most issues when trying to create one.