### PR TITLE
Allow Modules to see isues that have been resolved or reopened as last action.

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -325,6 +325,16 @@ class ModuleRegistry(jiraClient: JiraClient, private val config: Config) {
                             c.createdDate.toInstant().toEpochMilli()
                         )
                     },
+                issue.changeLog.entries
+                    .flatMap { e ->
+                        e.items
+                            .map { i ->
+                                ReopenAwaitingModule.ChangeLogItem(
+                                    e.created.toInstant().toEpochMilli(),
+                                    i.toString
+                                )
+                            }
+                    },
                 ::reopenIssue.partially1(issue)
             )
         }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/LanguageModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/LanguageModule.kt
@@ -10,6 +10,8 @@ class LanguageModule(
 ) : Module<LanguageModule.Request> {
 
     data class Request(
+        val created: Long,
+        val lastRun: Long,
         val summary: String?,
         val description: String?,
         val securityLevel: String?,
@@ -21,6 +23,7 @@ class LanguageModule(
 
     override fun invoke(request: Request): Either<ModuleError, ModuleResponse> = with(request) {
         Either.fx {
+            assertGreaterThan(created, lastRun).bind()
             assertIsPublic(securityLevel, privateLevel).bind()
 
             val detectedLanguage = getDetectedLanguage(getLanguage, request.summary, request.description)

--- a/src/main/kotlin/io/github/mojira/arisa/modules/Module.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/Module.kt
@@ -60,3 +60,9 @@ fun <T> assertNotEquals(o1: T, o2: T) = if (o1 == o2) {
 } else {
     Unit.right()
 }
+
+fun <T: Comparable<T>> assertGreaterThan(o1: T, o2: T) = if(o1 > o2) {
+    Unit.right()
+} else {
+    OperationNotNeededModuleResponse.left()
+}

--- a/src/main/kotlin/io/github/mojira/arisa/modules/Module.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/Module.kt
@@ -61,7 +61,7 @@ fun <T> assertNotEquals(o1: T, o2: T) = if (o1 == o2) {
     Unit.right()
 }
 
-fun <T: Comparable<T>> assertGreaterThan(o1: T, o2: T) = if(o1 > o2) {
+fun <T : Comparable<T>> assertGreaterThan(o1: T, o2: T) = if (o1 > o2) {
     Unit.right()
 } else {
     OperationNotNeededModuleResponse.left()

--- a/src/test/kotlin/io/github/mojira/arisa/modules/EmptyModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/EmptyModuleTest.kt
@@ -10,9 +10,34 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 class EmptyModuleTest : StringSpec({
+    "should return OperationNotNeededModuleResponse when ticket was created before the last run" {
+        val module = EmptyModule()
+        val request = Request(
+            0,
+            1,
+            0,
+            null,
+            null,
+            { Unit.right() },
+            { Unit.right() }
+        )
+
+        val result = module(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
     "should return OperationNotNeededModuleResponse when there is a attachment and desc and env are correct" {
         val module = EmptyModule()
-        val request = Request(1, "asddsa", "asddsa", { Unit.right() }, { Unit.right() })
+        val request = Request(
+            1,
+            0,
+            1,
+            "asddsa",
+            "asddsa",
+            { Unit.right() },
+            { Unit.right() }
+        )
 
         val result = module(request)
 
@@ -21,7 +46,15 @@ class EmptyModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when there is no attachment and desc and env are correct" {
         val module = EmptyModule()
-        val request = Request(0, "asddsa", "asddsa", { Unit.right() }, { Unit.right() })
+        val request = Request(
+            1,
+            0,
+            0,
+            "asddsa",
+            "asddsa",
+            { Unit.right() },
+            { Unit.right() }
+        )
 
         val result = module(request)
 
@@ -30,7 +63,15 @@ class EmptyModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when there is a attachment and no desc or env" {
         val module = EmptyModule()
-        val request = Request(1, null, null, { Unit.right() }, { Unit.right() })
+        val request = Request(
+            1,
+            0,
+            1,
+            null,
+            null,
+            { Unit.right() },
+            { Unit.right() }
+        )
 
         val result = module(request)
 
@@ -39,7 +80,15 @@ class EmptyModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when there is no attachment and no desc and env is correct" {
         val module = EmptyModule()
-        val request = Request(0, null, "asddsa", { Unit.right() }, { Unit.right() })
+        val request = Request(
+            1,
+            0,
+            0,
+            null,
+            "asddsa",
+            { Unit.right() },
+            { Unit.right() }
+        )
 
         val result = module(request)
 
@@ -48,7 +97,15 @@ class EmptyModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when there is no attachment and desc is correct and no env" {
         val module = EmptyModule()
-        val request = Request(0, "asdasd", null, { Unit.right() }, { Unit.right() })
+        val request = Request(
+            1,
+            0,
+            0,
+            "asdasd",
+            null,
+            { Unit.right() },
+            { Unit.right() }
+        )
 
         val result = module(request)
 
@@ -57,7 +114,15 @@ class EmptyModuleTest : StringSpec({
 
     "should resolve as invalid when there is no attachment and no desc or env" {
         val module = EmptyModule()
-        val request = Request(0, null, null, { Unit.right() }, { Unit.right() })
+        val request = Request(
+            1,
+            0,
+            0,
+            null,
+            null,
+            { Unit.right() },
+            { Unit.right() }
+        )
 
         val result = module(request)
 
@@ -66,7 +131,15 @@ class EmptyModuleTest : StringSpec({
 
     "should resolve as invalid when there is no attachment and desc is default and env is empty" {
         val module = EmptyModule()
-        val request = Request(0, DESCDEFAULT, null, { Unit.right() }, { Unit.right() })
+        val request = Request(
+            1,
+            0,
+            0,
+            DESC_DEFAULT,
+            null,
+            { Unit.right() },
+            { Unit.right() }
+        )
 
         val result = module(request)
 
@@ -75,7 +148,15 @@ class EmptyModuleTest : StringSpec({
 
     "should resolve as invalid when there is no attachment and desc is empty and env is default" {
         val module = EmptyModule()
-        val request = Request(0, null, ENVDEFAULT, { Unit.right() }, { Unit.right() })
+        val request = Request(
+            1,
+            0,
+            0,
+            null,
+            ENV_DEFAULT,
+            { Unit.right() },
+            { Unit.right() }
+        )
 
         val result = module(request)
 
@@ -84,7 +165,15 @@ class EmptyModuleTest : StringSpec({
 
     "should resolve as invalid when there is no attachment and desc is too short and env is too short" {
         val module = EmptyModule()
-        val request = Request(0, "asd", "asd", { Unit.right() }, { Unit.right() })
+        val request = Request(
+            1,
+            0,
+            0,
+            "asd",
+            "asd",
+            { Unit.right() },
+            { Unit.right() }
+        )
 
         val result = module(request)
 
@@ -93,7 +182,15 @@ class EmptyModuleTest : StringSpec({
 
     "should return FailedModuleResponse when resolving fails" {
         val module = EmptyModule()
-        val request = Request(0, "asd", "asd", { RuntimeException().left() }, { Unit.right() })
+        val request = Request(
+            1,
+            0,
+            0,
+            "asd",
+            "asd",
+            { RuntimeException().left() },
+            { Unit.right() }
+        )
 
         val result = module(request)
 
@@ -104,7 +201,15 @@ class EmptyModuleTest : StringSpec({
 
     "should return FailedModuleResponse when adding comment fails" {
         val module = EmptyModule()
-        val request = Request(0, "asd", "asd", { Unit.right() }, { RuntimeException().left() })
+        val request = Request(
+            1,
+            0,
+            0,
+            "asd",
+            "asd",
+            { Unit.right() },
+            { RuntimeException().left() }
+        )
 
         val result = module(request)
 

--- a/src/test/kotlin/io/github/mojira/arisa/modules/LanguageModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/LanguageModuleTest.kt
@@ -88,6 +88,8 @@ class LanguageModuleTest : StringSpec({
             lengthThreshold = 100
         )
         val request = Request(
+            1,
+            0,
             "?",
             "Villagers can open iron doors",
             "not private",

--- a/src/test/kotlin/io/github/mojira/arisa/modules/LanguageModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/LanguageModuleTest.kt
@@ -10,9 +10,30 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 class LanguageModuleTest : StringSpec({
+    "should return OperationNotNeededModuleResponse when ticket was created before the last run" {
+        val module = LanguageModule()
+        val request = Request(
+            0,
+            1,
+            "Ich habe einen seltsamen Fehler gefunden",
+            "Es gibt einen Fehler im Minecraft. Bitte schnell beheben!",
+            "not private",
+            "private",
+            { mapOf("de" to 1.0).right() },
+            { Unit.right() },
+            { Unit.right() }
+        )
+
+        val result = module(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
     "should return OperationNotNeededModuleResponse when there is no description, summary or environment" {
         val module = LanguageModule()
         val request = Request(
+            1,
+            0,
             null,
             null,
             "not private",
@@ -29,6 +50,8 @@ class LanguageModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse when description, summary and environment are empty" {
         val module = LanguageModule()
         val request = Request(
+            1,
+            0,
             "",
             "",
             "not private",
@@ -45,6 +68,8 @@ class LanguageModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse when no language matches" {
         val module = LanguageModule()
         val request = Request(
+            1,
+            0,
             "",
             "",
             "not private",
@@ -61,6 +86,8 @@ class LanguageModuleTest : StringSpec({
     "should resolve as invalid if ticket is not in English" {
         val module = LanguageModule()
         val request = Request(
+            1,
+            0,
             "Ich habe einen seltsamen Fehler gefunden",
             "Es gibt einen Fehler im Minecraft. Bitte schnell beheben!",
             "not private",
@@ -78,6 +105,8 @@ class LanguageModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse if ticket is in English" {
         val module = LanguageModule()
         val request = Request(
+            1,
+            0,
             "I found a strange bug",
             "There is an issue in Minecraft. Please fix it as soon as possible",
             "not private",
@@ -95,6 +124,8 @@ class LanguageModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse if ticket is mostly in English" {
         val module = LanguageModule()
         val request = Request(
+            1,
+            0,
             "Coarse Dirt is translated incorrectly in Russian",
             "The translation for Acacia slab in Russian is 'Алмазный блок' instead of 'Каменистая земля'.",
             "not private",
@@ -112,6 +143,8 @@ class LanguageModuleTest : StringSpec({
     "should resolve as invalid if ticket is mostly not in English" {
         val module = LanguageModule()
         val request = Request(
+            1,
+            0,
             "Wenn ich ein Minecart auf eine Activator Rail setze, wird der Player aus dem Minecart geworfen",
             "Im Creative Mode wirft eine Activator Rail den Player aus dem Minecart, ich dachte, dass die Rail das Minecart boostet.",
             "not private",
@@ -129,6 +162,8 @@ class LanguageModuleTest : StringSpec({
     "should return OperationNotNeeded if ticket is private" {
         val module = LanguageModule()
         val request = Request(
+            1,
+            0,
             "Wenn ich ein Minecart auf eine Activator Rail setze, wird der Player aus dem Minecart geworfen",
             "Im Creative Mode wirft eine Activator Rail den Player aus dem Minecart, ich dachte, dass die Rail das Minecart boostet.",
             "private",
@@ -146,6 +181,8 @@ class LanguageModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse if ticket contains only a crash report" {
         val module = LanguageModule()
         val request = Request(
+            1,
+            0,
             "java.lang.IllegalArgumentException: bound must be positive",
             """
             java.lang.IllegalArgumentException: bound must be positive
@@ -187,6 +224,8 @@ class LanguageModuleTest : StringSpec({
     "should return FailedModuleResponse when resolving as invalid fails" {
         val module = LanguageModule(emptyList())
         val request = Request(
+            1,
+            0,
             "Bonjour",
             "",
             "not private",
@@ -205,6 +244,8 @@ class LanguageModuleTest : StringSpec({
     "should return FailedModuleResponse when adding comment fails" {
         val module = LanguageModule(emptyList())
         val request = Request(
+            1,
+            0,
             "Salut",
             "",
             "not private",

--- a/src/test/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModuleTest.kt
@@ -2,6 +2,7 @@ package io.github.mojira.arisa.modules
 
 import arrow.core.left
 import arrow.core.right
+import io.github.mojira.arisa.modules.ReopenAwaitingModule.ChangeLogItem
 import io.github.mojira.arisa.modules.ReopenAwaitingModule.Comment
 import io.github.mojira.arisa.modules.ReopenAwaitingModule.Request
 import io.kotest.assertions.arrow.either.shouldBeLeft
@@ -12,12 +13,13 @@ import io.kotest.matchers.shouldBe
 import java.time.Instant
 
 class ReopenAwaitingModuleTest : StringSpec({
+    val NOW = Instant.now()
+    val COMMENT = Comment(NOW.toEpochMilli(), NOW.toEpochMilli())
+    val AWAITING_RESOLVE = ChangeLogItem(NOW.minusSeconds(10).toEpochMilli(), "Awaiting Response")
     "should return OperationNotNeededModuleResponse when there is no resolution" {
         val module = ReopenAwaitingModule()
-        val now = Instant.now()
-        val updated = Instant.now().plusSeconds(3)
-        val comment = Comment(now.toEpochMilli(), now.toEpochMilli())
-        val request = Request(null, now, updated, listOf(comment)) { Unit.right() }
+        val updated = NOW.plusSeconds(3)
+        val request = Request(null, NOW, updated, listOf(COMMENT), listOf(AWAITING_RESOLVE)) { Unit.right() }
 
         val result = module(request)
 
@@ -26,10 +28,8 @@ class ReopenAwaitingModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when ticket is not in awaiting response" {
         val module = ReopenAwaitingModule()
-        val now = Instant.now()
-        val updated = Instant.now().plusSeconds(3)
-        val comment = Comment(now.toEpochMilli(), now.toEpochMilli())
-        val request = Request("Test", now, updated, listOf(comment)) { Unit.right() }
+        val updated = NOW.plusSeconds(3)
+        val request = Request("Test", NOW, updated, listOf(COMMENT), listOf(AWAITING_RESOLVE)) { Unit.right() }
 
         val result = module(request)
 
@@ -38,10 +38,8 @@ class ReopenAwaitingModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when ticket is less than 2 seconds old" {
         val module = ReopenAwaitingModule()
-        val now = Instant.now()
-        val updated = Instant.now().plusSeconds(1)
-        val comment = Comment(now.toEpochMilli(), now.toEpochMilli())
-        val request = Request("Awaiting Response", now, updated, listOf(comment)) { Unit.right() }
+        val updated = NOW.plusSeconds(1)
+        val request = Request("Awaiting Response", NOW, updated, listOf(COMMENT), listOf(AWAITING_RESOLVE)) { Unit.right() }
 
         val result = module(request)
 
@@ -50,9 +48,31 @@ class ReopenAwaitingModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when there are no comments" {
         val module = ReopenAwaitingModule()
-        val now = Instant.now()
-        val updated = Instant.now().plusSeconds(3)
-        val request = Request("Awaiting Response", now, updated, emptyList()) { Unit.right() }
+        val updated = NOW.plusSeconds(3)
+        val request = Request("Awaiting Response", NOW, updated, emptyList(), listOf(AWAITING_RESOLVE)) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when there is only a comment from before the resolve" {
+        val module = ReopenAwaitingModule()
+        val updated = NOW.plusSeconds(3)
+        val comment = Comment(NOW.minusSeconds(20).toEpochMilli(), NOW.minusSeconds(20).toEpochMilli())
+        val request = Request("Awaiting Response", NOW, updated, listOf(comment), listOf(AWAITING_RESOLVE)) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when there were multiple resolves, but no comment after the last resolve." {
+        val module = ReopenAwaitingModule()
+        val updated = NOW.plusSeconds(3)
+        val oldResolve = ChangeLogItem(NOW.minusSeconds(30).toEpochMilli(), "Awaiting Response")
+        val comment = Comment(NOW.minusSeconds(20).toEpochMilli(), NOW.minusSeconds(20).toEpochMilli())
+        val request = Request("Awaiting Response", NOW, updated, listOf(comment), listOf(oldResolve, AWAITING_RESOLVE)) { Unit.right() }
 
         val result = module(request)
 
@@ -61,10 +81,9 @@ class ReopenAwaitingModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when just the comment was updated" {
         val module = ReopenAwaitingModule()
-        val now = Instant.now()
-        val comment = Comment(now.plusSeconds(3).toEpochMilli(), now.toEpochMilli())
-        val updated = Instant.now().plusSeconds(3)
-        val request = Request("Awaiting Response", now, updated, listOf(comment)) { Unit.right() }
+        val comment = Comment(NOW.plusSeconds(3).toEpochMilli(), NOW.toEpochMilli())
+        val updated = NOW.plusSeconds(3)
+        val request = Request("Awaiting Response", NOW, updated, listOf(comment), listOf(AWAITING_RESOLVE)) { Unit.right() }
 
         val result = module(request)
 
@@ -73,23 +92,31 @@ class ReopenAwaitingModuleTest : StringSpec({
 
     "should grab the last comment" {
         val module = ReopenAwaitingModule()
-        val now = Instant.now()
-        val updated = Instant.now().plusSeconds(3)
-        val commentFail = Comment(now.plusSeconds(3).toEpochMilli(), now.toEpochMilli())
-        val commentSuccess = Comment(now.toEpochMilli(), now.toEpochMilli())
-        val request = Request("Awaiting Response", now, updated, listOf(commentSuccess, commentFail)) { Unit.right() }
+        val updated = NOW.plusSeconds(3)
+        val commentFail = Comment(NOW.plusSeconds(3).toEpochMilli(), NOW.toEpochMilli())
+        val commentSuccess = Comment(NOW.toEpochMilli(), NOW.toEpochMilli())
+        val request = Request("Awaiting Response", NOW, updated, listOf(commentSuccess, commentFail), listOf(AWAITING_RESOLVE)) { Unit.right() }
 
         val result = module(request)
 
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
+    "should ignore changes that are not a resolve" {
+        val module = ReopenAwaitingModule()
+        val updated = NOW.plusSeconds(3)
+        val change = ChangeLogItem(NOW.plusSeconds(3).toEpochMilli(), "Confirmed")
+        val request = Request("Awaiting Response", NOW, updated, listOf(COMMENT), listOf(AWAITING_RESOLVE, change)) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeRight(ModuleResponse)
+    }
+
     "should return FailedModuleResponse with all exceptions when reopening fails" {
         val module = ReopenAwaitingModule()
-        val now = Instant.now()
-        val updated = Instant.now().plusSeconds(3)
-        val comment = Comment(now.toEpochMilli(), now.toEpochMilli())
-        val request = Request("Awaiting Response", now, updated, listOf(comment)) { RuntimeException().left() }
+        val updated = NOW.plusSeconds(3)
+        val request = Request("Awaiting Response", NOW, updated, listOf(COMMENT), listOf(AWAITING_RESOLVE)) { RuntimeException().left() }
 
         val result = module(request)
 
@@ -100,10 +127,8 @@ class ReopenAwaitingModuleTest : StringSpec({
 
     "should return ModuleResponse when ticket is reopened" {
         val module = ReopenAwaitingModule()
-        val now = Instant.now()
-        val updated = Instant.now().plusSeconds(3)
-        val comment = Comment(now.toEpochMilli(), now.toEpochMilli())
-        val request = Request("Awaiting Response", now, updated, listOf(comment)) { Unit.right() }
+        val updated = NOW.plusSeconds(3)
+        val request = Request("Awaiting Response", NOW, updated, listOf(COMMENT), listOf(AWAITING_RESOLVE)) { Unit.right() }
 
         val result = module(request)
 


### PR DESCRIPTION
## Purpose
Resolves #144 

## Approach
This mostly just removes the filter from `ModuleExecutor`.
Most modules have not been changed. Here is a list of all modules and my thoughts:

- **Attachment**: Should always see all issues and remove malicious attachments everywhere.
- **Crash**: I don't see a problem here. If an issue is reopened from AR, it should obviously be checked here. I don't really see this module mistriggering, and if it does, an issue should be opened.
- **Empty**: Empty has been changed to only resolve issues that were created after the last run.
- **FutureVersion**: Don't see it being relevant here.
- **HideImpostors**: Should always trigger on issues were impostors post.
- **KeepPrivate**: Should always trigger on all issues that are to be kept private.
- **Language**: LanguageModule has been changed to only resolve issues that were created after the last run.
- **Piracy**: If there is a misstrigger, I guess that could become an issue, maybe a check that the latest change was not a reopen should be included?
- **RemoveNonStaffMeqs**: Should always see all issues and remove comments from regular users trying to add MEQS tags.
- **RemoveTriagedMeqs**: In case the issue is opened after the triage, for example because it had a REVIEW tag, the module should see this issue.
- **ReopenAwaiting**: Now requires the last comment to be after the latest AR resolve.
- **ResolveTrash**: Don't see it being relevant here, only sees Unreaolved tickets anyways.
- **RevokeConfirmation**: Don't see it being relevant here.
- **UpdateLinked**: Don't see it being relevant here.

Besides that the architecture was slightly adjusted to support passing the `lastRun` time can to modules.

#### Checklist
- [x] Included tests
- [ ] Tested in MCTEST-xxx
