### PR TITLE
No longer replace links with query parameters

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -274,7 +274,6 @@
         "resolutions": [ "Duplicate" ]
       },
       "replaceText": {
-        "whitelist" : [],
         "resolutions": [
           "Awaiting Response",
           "Cannot Reproduce",

--- a/src/main/kotlin/io/github/mojira/arisa/modules/ReplaceTextModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ReplaceTextModule.kt
@@ -5,10 +5,10 @@ import arrow.core.extensions.fx
 
 class ReplaceTextModule(
     private val replacements: List<Pair> = listOf(
-        Pair("""\[([A-Z]+-\d+)\|https?://bugs\.mojang\.com/browse/\1(?:\?[\w%=&]*)?\]""".toRegex()),
-        Pair("""\[([A-Z]+-\d+)\|https?://bugs\.mojang\.com/projects/[A-Z]+/issues/\1(?:\?[\w%=&]*)?\]""".toRegex()),
-        Pair("""(?<=[^\|])https?://bugs\.mojang\.com/browse/([A-Z]+-\d+)(?:\?[\w%=&]*)?""".toRegex()),
-        Pair("""(?<=[^\|])https?://bugs\.mojang\.com/projects/[A-Z]+/issues/([A-Z]+-\d+)(?:\?[\w%=&]*)?""".toRegex())
+        Pair("""\[([A-Z]+-\d+)\|https?://bugs\.mojang\.com/browse/\1/?(?![\d\?/#])\]""".toRegex()),
+        Pair("""\[([A-Z]+-\d+)\|https?://bugs\.mojang\.com/projects/[A-Z]+/issues/\1/?(?![\d\?/#])\]""".toRegex()),
+        Pair("""(?<!\|)https?://bugs\.mojang\.com/browse/([A-Z]+-\d+)/?(?![\d\?/#])""".toRegex()),
+        Pair("""(?<!\|)https?://bugs\.mojang\.com/projects/[A-Z]+/issues/([A-Z]+-\d+)/?(?![\d\?/#])""".toRegex())
     )
 ) : Module<ReplaceTextModule.Request> {
     data class Pair(

--- a/src/test/kotlin/io/github/mojira/arisa/modules/ReplaceTextModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/ReplaceTextModuleTest.kt
@@ -92,6 +92,48 @@ class ReplaceTextModuleTest : StringSpec({
 
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
+    "should return OperationNotNeededModuleResponse for /browse links with query in comments" {
+        val request = Request(
+            42L,
+            null,
+            listOf(
+                Comment(100L,
+                    "Duplicates https://bugs.mojang.com/browse/MCPE-38374?focusedCommentId=555054&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-555054"
+                ) { Unit.right() }
+            )
+        ) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+    "should return OperationNotNeededModuleResponse for /projects links with query in comments" {
+        val request = Request(
+            42L,
+            null,
+            listOf(
+                Comment(
+                    100L,
+                    "Duplicates https://bugs.mojang.com/projects/MC/issues/MC-4?focusedCommentId=555054&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-555054"
+                ) { Unit.right() }
+            )
+        ) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+    "should return OperationNotNeededModuleResponse for /browse links with query in description" {
+        val request = Request(
+            42L,
+            "Duplicates https://bugs.mojang.com/browse/MCPE-38374?focusedCommentId=555054&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-555054",
+            emptyList()
+        ) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
     "should replace /browse links in comments" {
         var replacedCommentBody: String? = null
 
@@ -119,47 +161,6 @@ class ReplaceTextModuleTest : StringSpec({
             null,
             listOf(
                 Comment(100L, "Duplicates https://bugs.mojang.com/projects/MC/issues/MC-4") {
-                    replacedCommentBody = it
-                    Unit.right()
-                }
-            )
-        ) { Unit.right() }
-
-        val result = module(request)
-
-        result.shouldBeRight(ModuleResponse)
-        replacedCommentBody shouldBe "Duplicates MC-4"
-    }
-    "should replace /browse links with query in comments" {
-        var replacedCommentBody: String? = null
-
-        val request = Request(
-            42L,
-            null,
-            listOf(
-                Comment(100L, "Duplicates https://bugs.mojang.com/browse/MC-4?jql=votes%3E0") {
-                    replacedCommentBody = it
-                    Unit.right()
-                }
-            )
-        ) { Unit.right() }
-
-        val result = module(request)
-
-        result.shouldBeRight(ModuleResponse)
-        replacedCommentBody shouldBe "Duplicates MC-4"
-    }
-    "should replace /projects links with query in comments" {
-        var replacedCommentBody: String? = null
-
-        val request = Request(
-            42L,
-            null,
-            listOf(
-                Comment(
-                    100L,
-                    "Duplicates https://bugs.mojang.com/projects/MC/issues/MC-4?jql=votes%3E0"
-                ) {
                     replacedCommentBody = it
                     Unit.right()
                 }

--- a/src/test/kotlin/io/github/mojira/arisa/modules/ReplaceTextModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/ReplaceTextModuleTest.kt
@@ -92,7 +92,7 @@ class ReplaceTextModuleTest : StringSpec({
 
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
-    "should return OperationNotNeededModuleResponse for /browse links with query in comments" {
+    "should return OperationNotNeededModuleResponse for /browse links with query paramerters in comments" {
         val request = Request(
             42L,
             null,
@@ -107,7 +107,7 @@ class ReplaceTextModuleTest : StringSpec({
 
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
-    "should return OperationNotNeededModuleResponse for /projects links with query in comments" {
+    "should return OperationNotNeededModuleResponse for /projects links with query paramerters in comments" {
         val request = Request(
             42L,
             null,
@@ -115,6 +115,37 @@ class ReplaceTextModuleTest : StringSpec({
                 Comment(
                     100L,
                     "Duplicates https://bugs.mojang.com/projects/MC/issues/MC-4?focusedCommentId=555054&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-555054"
+                ) { Unit.right() }
+            )
+        ) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+    "should return OperationNotNeededModuleResponse for /browse links which ends in a slash with query paramerters in comments" {
+        val request = Request(
+            42L,
+            null,
+            listOf(
+                Comment(100L,
+                    "Duplicates https://bugs.mojang.com/browse/MCPE-38374/?focusedCommentId=555054&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-555054"
+                ) { Unit.right() }
+            )
+        ) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+    "should return OperationNotNeededModuleResponse for /projects links which ends in a slash with query paramerters in comments" {
+        val request = Request(
+            42L,
+            null,
+            listOf(
+                Comment(
+                    100L,
+                    "Duplicates https://bugs.mojang.com/projects/MC/issues/MC-4/?focusedCommentId=555054&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-555054"
                 ) { Unit.right() }
             )
         ) { Unit.right() }
@@ -171,6 +202,120 @@ class ReplaceTextModuleTest : StringSpec({
 
         result.shouldBeRight(ModuleResponse)
         replacedCommentBody shouldBe "Duplicates MC-4"
+    }
+    "should replace /browse links with two-digit ticket key in comments" {
+        var replacedCommentBody: String? = null
+
+        val request = Request(
+            42L,
+            null,
+            listOf(
+                Comment(100L, "Duplicates https://bugs.mojang.com/browse/MC-44") {
+                    replacedCommentBody = it
+                    Unit.right()
+                }
+            )
+        ) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeRight(ModuleResponse)
+        replacedCommentBody shouldBe "Duplicates MC-44"
+    }
+    "should replace /projects links with two-digit ticket key in comments" {
+        var replacedCommentBody: String? = null
+
+        val request = Request(
+            42L,
+            null,
+            listOf(
+                Comment(100L, "Duplicates https://bugs.mojang.com/projects/MC/issues/MC-44") {
+                    replacedCommentBody = it
+                    Unit.right()
+                }
+            )
+        ) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeRight(ModuleResponse)
+        replacedCommentBody shouldBe "Duplicates MC-44"
+    }
+    "should replace /browse links which ends with a slash in comments" {
+        var replacedCommentBody: String? = null
+
+        val request = Request(
+            42L,
+            null,
+            listOf(
+                Comment(100L, "Duplicates https://bugs.mojang.com/browse/MC-4/") {
+                    replacedCommentBody = it
+                    Unit.right()
+                }
+            )
+        ) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeRight(ModuleResponse)
+        replacedCommentBody shouldBe "Duplicates MC-4"
+    }
+    "should replace /projects links which ends with a slash in comments" {
+        var replacedCommentBody: String? = null
+
+        val request = Request(
+            42L,
+            null,
+            listOf(
+                Comment(100L, "Duplicates https://bugs.mojang.com/projects/MC/issues/MC-4/") {
+                    replacedCommentBody = it
+                    Unit.right()
+                }
+            )
+        ) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeRight(ModuleResponse)
+        replacedCommentBody shouldBe "Duplicates MC-4"
+    }
+    "should replace /browse links with two-digit ticket key which ends with a slash in comments" {
+        var replacedCommentBody: String? = null
+
+        val request = Request(
+            42L,
+            null,
+            listOf(
+                Comment(100L, "Duplicates https://bugs.mojang.com/browse/MC-44/") {
+                    replacedCommentBody = it
+                    Unit.right()
+                }
+            )
+        ) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeRight(ModuleResponse)
+        replacedCommentBody shouldBe "Duplicates MC-44"
+    }
+    "should replace /projects links with two-digit ticket key which ends with a slash in comments" {
+        var replacedCommentBody: String? = null
+
+        val request = Request(
+            42L,
+            null,
+            listOf(
+                Comment(100L, "Duplicates https://bugs.mojang.com/projects/MC/issues/MC-44/") {
+                    replacedCommentBody = it
+                    Unit.right()
+                }
+            )
+        ) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeRight(ModuleResponse)
+        replacedCommentBody shouldBe "Duplicates MC-44"
     }
     "should replace titled /browse links in comments" {
         var replacedCommentBody: String? = null


### PR DESCRIPTION
## Purpose
Fix #159.
## Approach
Added a zero-width negative lookahead assertation for any numbers (in case the Regex engine goes back several characters so the assertation could pass), `?`, `#`, and `/` (also in case the Regex engine goes back).
#### Checklist
- [x] Included tests
- [ ] Tested in MCTEST-xxx
