### PR TITLE
Require status "Open" or "Reopened" for parents in TransferVersions

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/Module.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/Module.kt
@@ -19,6 +19,18 @@ fun Either<Throwable, Unit>.toFailedModuleEither() = this.bimap(
     { ModuleResponse }
 )
 
+fun Collection<Either<Throwable, Any>>.toFailedModuleEither(): Either<ModuleError, ModuleResponse> {
+    val errors =
+        filter(Either<Throwable, Any>::isLeft)
+        .map { (it as Either.Left).a }
+
+    return if (errors.isEmpty()) {
+        ModuleResponse.right()
+    } else {
+        FailedModuleResponse(errors).left()
+    }
+}
+
 fun assertNotEmpty(c: Collection<*>) = when {
     c.isEmpty() -> OperationNotNeededModuleResponse.left()
     else -> Unit.right()

--- a/src/main/kotlin/io/github/mojira/arisa/modules/TransferVersionsModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/TransferVersionsModule.kt
@@ -3,20 +3,22 @@ package io.github.mojira.arisa.modules
 import arrow.core.Either
 import arrow.core.extensions.fx
 import arrow.core.left
+import arrow.core.right
 import arrow.syntax.function.partially1
 import arrow.syntax.function.partially2
 
 class TransferVersionsModule : Module<TransferVersionsModule.Request> {
     data class LinkedIssue(
-        val versions: List<String>,
-        val addVersion: (String) -> Either<Throwable, Unit>
+        val key: String,
+        val status: String,
+        val addVersion: (key: String) -> Either<Throwable, Unit>,
+        val getAffectedVersions: () -> Either<Throwable, List<String>>
     )
 
     data class Link(
         val type: String,
         val outwards: Boolean,
-        val issueKey: String,
-        val getLinkedIssue: () -> Either<Throwable, LinkedIssue>
+        val issue: LinkedIssue
     )
 
     data class Request(
@@ -27,39 +29,51 @@ class TransferVersionsModule : Module<TransferVersionsModule.Request> {
 
     override fun invoke(request: Request): Either<ModuleError, ModuleResponse> = with(request) {
         Either.fx {
-            val parentLinks = links
+            val relevantParents = links
                 .filter(::isDuplicatesLink)
+                .map { it.issue }
                 .filter(::isSameProject.partially2(key))
+                .filter(::isUnresolved)
+            assertGreaterThan(relevantParents.size, 0).bind()
 
-            assertGreaterThan(parentLinks.size, 0).bind()
-            val parents = parentLinks
-                .map { it.getLinkedIssue() }
+            val parentEithers = relevantParents
+                .map(::toIssueVersionPair)
 
-            val addVersions = versions.flatMap(::applyParents.partially2(parents)).filterNotNull()
-            assertNotEmpty(addVersions).bind()
+            parentEithers.toFailedModuleEither().bind()
+            val parents = parentEithers
+                .map { (it as Either.Right).b }
 
-            tryRunAll(addVersions).bind()
+            val versionAdders = parents
+                .flatMap(::toVersionAdders.partially2(versions))
+
+            assertNotEmpty(versionAdders).bind()
+            tryRunAll(versionAdders).bind()
         }
     }
+
+    private fun toIssueVersionPair(issue: LinkedIssue): Either<Throwable, Pair<LinkedIssue, List<String>>> {
+        val details = issue.getAffectedVersions()
+        return details.fold(
+            { it.left() },
+            { (issue to it).right() }
+        )
+    }
+
+    private fun toVersionAdders(parent: Pair<LinkedIssue, List<String>>, versions: List<String>) =
+        versions
+            .filter { it !in parent.second }
+            .map{ parent.first.addVersion.partially1(it) }
 
     private fun isDuplicatesLink(link: Link) =
         link.type.toLowerCase() == "duplicate" && link.outwards
 
-    private fun isSameProject(link: Link, key: String) =
-        link.issueKey.getProject() == key.getProject()
+    private fun isSameProject(issue:  LinkedIssue, key: String) =
+        issue.key.getProject() == key.getProject()
+
+    private fun isUnresolved(issue: LinkedIssue) =
+        issue.status in listOf("Open", "Reopened")
 
     private fun String.getProject() =
         substring(0, indexOf('-'))
 
-    private fun applyParents(version: String, parents: List<Either<Throwable, LinkedIssue>>) =
-        parents.map { parentEither ->
-            parentEither.fold({ throwable ->
-                { throwable.left() }
-            }, { parent ->
-                if (version !in parent.versions)
-                    parent.addVersion.partially1(version)
-                else
-                    null
-            })
-        }
 }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/TransferVersionsModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/TransferVersionsModule.kt
@@ -62,12 +62,12 @@ class TransferVersionsModule : Module<TransferVersionsModule.Request> {
     private fun toVersionAdders(parent: Pair<LinkedIssue, List<String>>, versions: List<String>) =
         versions
             .filter { it !in parent.second }
-            .map{ parent.first.addVersion.partially1(it) }
+            .map { parent.first.addVersion.partially1(it) }
 
     private fun isDuplicatesLink(link: Link) =
         link.type.toLowerCase() == "duplicate" && link.outwards
 
-    private fun isSameProject(issue:  LinkedIssue, key: String) =
+    private fun isSameProject(issue: LinkedIssue, key: String) =
         issue.key.getProject() == key.getProject()
 
     private fun isUnresolved(issue: LinkedIssue) =
@@ -75,5 +75,4 @@ class TransferVersionsModule : Module<TransferVersionsModule.Request> {
 
     private fun String.getProject() =
         substring(0, indexOf('-'))
-
 }


### PR DESCRIPTION
## Purpose
Fixes #166

## Approach
This slightly refactors the LinkedIssue of TransferVersions. Instead of a function that returns a linked issue, the linked issue is now directly available with all fields that are present in the issue link.
LinkedIssue now includes a function that returns a list of versions, as versions are not available in the issue object that is present in the link.

## Future work
TransferVersions is pretty messy in the ModuleRegistry, we should look into moving mapping functions into a separate file, as was already suggested by urielsalis in #125

#### Checklist
- [x] Included tests
- [ ] Tested in MCTEST-xxx
