### PR TITLE
Feature/131

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -236,7 +236,6 @@
       },
       "language": {
         "excludedStatuses": ["Postponed"],
-        "jql": "created > %s AND filter != 24600",
         "messages": {
           "zh": "I have detected that this ticket is in *Chinese*.",
           "fr": "I have detected that this ticket is in *French*.",

--- a/arisa.json
+++ b/arisa.json
@@ -264,6 +264,7 @@
       },
       "updateLinked": {
         "excludedStatuses": ["Postponed"],
+        "updateInterval": 24,
         "whitelist": [
           "MC",
           "MCL",

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
@@ -36,12 +36,12 @@ class ModuleExecutor(
             do {
                 missingResultsPage = false
 
-                registry.getModules().forEach { (config, exec) ->
+                registry.getModules().forEach { (config, getJql, exec) ->
                     executeModule(
                         config,
                         queryCache,
                         rerunTickets,
-                        lastRun,
+                        getJql(lastRun),
                         startAt,
                         failedTickets::add,
                         { missingResultsPage = true },
@@ -63,7 +63,7 @@ class ModuleExecutor(
         moduleConfig: Arisa.Modules.ModuleConfigSpec,
         queryCache: QueryCache,
         rerunTickets: Collection<String>,
-        lastRun: Long,
+        moduleJql: String,
         startAt: Int,
         addFailedTicket: (String) -> Any,
         onQueryNotAtResultEnd: () -> Unit,
@@ -78,7 +78,7 @@ class ModuleExecutor(
             else ""
         }
 
-        val jql = "$failedTicketsJQL(${config[moduleConfig.jql].format(lastRun)})"
+        val jql = "$failedTicketsJQL($moduleJql})"
         val issues = queryCache.get(jql) ?: searchIssues(jql, startAt, onQueryNotAtResultEnd)
 
         queryCache.add(jql, issues)

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -499,7 +499,7 @@ class ModuleRegistry(jiraClient: JiraClient, private val config: Config) {
                     issue.changeLog.entries
                         .flatMap { e ->
                             e.items
-                                .map {  i ->
+                                .map { i ->
                                     UpdateLinkedModule.ChangeLogItem(
                                         i.field,
                                         e.created.toInstant(),

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -6,6 +6,7 @@ import arrow.core.right
 import arrow.syntax.function.partially1
 import arrow.syntax.function.pipe
 import arrow.syntax.function.pipe2
+import arrow.syntax.function.pipe3
 import com.uchuhimo.konf.Config
 import io.github.mojira.arisa.infrastructure.addAffectedVersion
 import io.github.mojira.arisa.infrastructure.addAffectedVersionById
@@ -58,10 +59,13 @@ import net.rcarz.jiraclient.Issue
 import net.rcarz.jiraclient.JiraClient
 import net.sf.json.JSONObject
 import java.text.SimpleDateFormat
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 class ModuleRegistry(jiraClient: JiraClient, private val config: Config) {
     data class Entry(
         val config: ModuleConfigSpec,
+        val getJql: (lastRun: Long) -> String,
         val execute: (Issue, Long) -> Pair<String, Either<ModuleError, ModuleResponse>>
     )
 
@@ -74,17 +78,19 @@ class ModuleRegistry(jiraClient: JiraClient, private val config: Config) {
         name: String,
         config: ModuleConfigSpec,
         module: Module<T>,
+        getJql: (lastRun: Long) -> String = { "updated > $it" },
         requestCreator: (Issue) -> T
-    ) = register(name, config, module) { issue, _ -> requestCreator(issue) }
+    ) = register(name, config, module, getJql) { issue, _ -> requestCreator(issue) }
 
     private fun <T> register(
         name: String,
         config: ModuleConfigSpec,
         module: Module<T>,
+        getJql: (lastRun: Long) -> String = { "updated > $it" },
         requestCreator: (Issue, Long) -> T
     ) = { issue: Issue, lastRun: Long ->
         name to ({ lastRun pipe (issue pipe2 requestCreator) pipe module::invoke } pipe ::tryExecuteModule)
-    } pipe (config pipe2 ModuleRegistry::Entry) pipe modules::add
+    } pipe (getJql pipe2 (config pipe3 ModuleRegistry::Entry)) pipe modules::add
 
     private fun tryExecuteModule(executeModule: () -> Either<ModuleError, ModuleResponse>) = try {
         executeModule()
@@ -480,14 +486,31 @@ class ModuleRegistry(jiraClient: JiraClient, private val config: Config) {
         register(
             "UpdateLinked",
             Modules.UpdateLinked,
-            UpdateLinkedModule()
-        ) { issue ->
-            UpdateLinkedModule.Request(
-                issue.issueLinks
-                    .map { it.type.name },
-                issue.getField(config[CustomFields.linked]) as? Double?,
-                ::updateLinked.partially1(issue).partially1(config[CustomFields.linked])
-            )
-        }
+            UpdateLinkedModule(config[Modules.UpdateLinked.updateInterval]),
+            { lastRun ->
+                val now = Instant.now()
+                val intervalStart = now.minus(config[Modules.UpdateLinked.updateInterval], ChronoUnit.HOURS)
+                val intervalEnd = intervalStart.minusMillis(now.minusMillis(lastRun).toEpochMilli())
+                return@register "updated > $lastRun OR (updated < ${intervalStart.toEpochMilli()} AND updated > ${intervalEnd.toEpochMilli()})"
+            },
+            { issue ->
+                UpdateLinkedModule.Request(
+                    issue.createdDate.toInstant(),
+                    issue.changeLog.entries
+                        .flatMap { e ->
+                            e.items
+                                .map {  i ->
+                                    UpdateLinkedModule.ChangeLogItem(
+                                        i.field,
+                                        e.created.toInstant(),
+                                        i.toString
+                                    )
+                                }
+                        },
+                    issue.getField(config[CustomFields.linked]) as? Double?,
+                    ::updateLinked.partially1(issue).partially1(config[CustomFields.linked])
+                )
+            }
+        )
     }
 }

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
@@ -103,7 +103,7 @@ object Arisa : ConfigSpec() {
         object ResolveTrash : ModuleConfigSpec()
 
         object UpdateLinked : ModuleConfigSpec() {
-            val updateInterval by optional(24L, description = "Interval in which the module should update the Linked field in hours")
+            val updateInterval by optional(0L, description = "Interval in which the module should update the Linked field in hours")
         }
 
         object TransferVersions : ModuleConfigSpec()

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
@@ -35,7 +35,6 @@ object Arisa : ConfigSpec() {
             val whitelist by optional<List<String>?>(null, description = "Optional. The projects this module should operate on. Default is arisa.issues.projects")
             val resolutions by optional(listOf("unresolved"), description = "Optional. The resolutions that should be considered for this module. Default is unresolved.")
             val excludedStatuses by optional(emptyList<String>(), description = "A list of statuses that are not considered for this module. Important for modules that resolve or update, as those transitions do not exist for Postponed.")
-            val jql by optional("updated > %s", description = "Optional. Jql query that should be used to fetch issues from this module %s will be replaced by the last time all queries successfully ran. Default is updated since last run.")
         }
 
         object Attachment : ModuleConfigSpec() {
@@ -103,7 +102,9 @@ object Arisa : ConfigSpec() {
 
         object ResolveTrash : ModuleConfigSpec()
 
-        object UpdateLinked : ModuleConfigSpec()
+        object UpdateLinked : ModuleConfigSpec() {
+            val updateInterval by optional(24L, description = "Interval in which the module should update the Linked field in hours")
+        }
 
         object TransferVersions : ModuleConfigSpec()
 

--- a/src/main/kotlin/io/github/mojira/arisa/modules/UpdateLinkedModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/UpdateLinkedModule.kt
@@ -2,23 +2,66 @@ package io.github.mojira.arisa.modules
 
 import arrow.core.Either
 import arrow.core.extensions.fx
+import arrow.core.left
+import arrow.core.right
+import arrow.syntax.function.partially2
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 
-class UpdateLinkedModule : Module<UpdateLinkedModule.Request> {
+class UpdateLinkedModule(
+    private val updateInterval: Long
+) : Module<UpdateLinkedModule.Request> {
+    data class ChangeLogItem(
+        val field: String,
+        val created: Instant,
+        val value: String?
+    )
+
     data class Request(
-        val links: List<String>,
+        val created: Instant,
+        val changeLogItems: List<ChangeLogItem>,
         val linkedField: Double?,
-        val setLinks: (Double) -> Either<Throwable, Unit>
+        val setLinked: (Double) -> Either<Throwable, Unit>
     )
 
     override fun invoke(request: Request): Either<ModuleError, ModuleResponse> = with(request) {
         Either.fx {
-            val duplicates = links.filter(::isDuplicate).size.toDouble()
-            assertNotEquals(duplicates, linkedField ?: 0.0).bind()
+            val lastLinkedChange = changeLogItems
+                .lastOrNull(::isLinkedChange)
+                ?.created
+                ?: created
 
-            setLinks(duplicates).toFailedModuleEither().bind()
+            val duplicates = changeLogItems.filter(::isDuplicateAddedChange)
+            val duplicateAmount = duplicates.size.toDouble()
+            assertNotEquals(duplicateAmount, linkedField ?: 0.0).bind()
+
+            val firstAddedLinkSinceLastUpdate = changeLogItems
+                .firstOrNull(::createdAfter.partially2(lastLinkedChange))
+                ?.created
+
+            assertNotNull(firstAddedLinkSinceLastUpdate).bind()
+            assertLinkNotAddedRecently(firstAddedLinkSinceLastUpdate!!).bind()
+
+            setLinked(duplicateAmount).toFailedModuleEither().bind()
         }
     }
 
-    private fun isDuplicate(link: String) =
-        link == "Duplicate"
+    private fun isLinkedChange(change: ChangeLogItem) =
+        change.field == "Linked"
+
+    private fun isDuplicateAddedChange(change: ChangeLogItem) =
+        change.field == "Link" &&
+            change.value?.matches("""This issue is duplicated by [A-Z]+-[0-9]+""".toRegex()) ?: false
+
+    private fun createdAfter(change: ChangeLogItem, lastUpdate: Instant) =
+        change.created.isAfter(lastUpdate)
+
+    private fun assertLinkNotAddedRecently(lastUpdate: Instant) =
+        when {
+            lastUpdate
+                .isBefore(
+                    Instant.now().minus(updateInterval, ChronoUnit.HOURS)
+                ) -> Unit.right()
+            else -> OperationNotNeededModuleResponse.left()
+        }
 }

--- a/src/test/kotlin/io/github/mojira/arisa/modules/UpdateLinkedModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/UpdateLinkedModuleTest.kt
@@ -16,7 +16,7 @@ class UpdateLinkedModuleTest : StringSpec({
     val NOW = Instant.now()
     val A_SECOND_AGO = NOW.minusSeconds(1)
     val DUPLICATE_LINK = ChangeLogItem("Link", NOW, "This issue is duplicated by MC-4")
-    
+
     "should return OperationNotNeededModuleResponse when linked is empty and there are no duplicates" {
         val module = UpdateLinkedModule(0)
         val request = Request(A_SECOND_AGO, emptyList(), null) { Unit.right() }

--- a/src/test/kotlin/io/github/mojira/arisa/modules/UpdateLinkedModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/UpdateLinkedModuleTest.kt
@@ -2,16 +2,24 @@ package io.github.mojira.arisa.modules
 
 import arrow.core.left
 import arrow.core.right
+import io.github.mojira.arisa.modules.UpdateLinkedModule.ChangeLogItem
+import io.github.mojira.arisa.modules.UpdateLinkedModule.Request
 import io.kotest.assertions.arrow.either.shouldBeLeft
 import io.kotest.assertions.arrow.either.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 class UpdateLinkedModuleTest : StringSpec({
+    val NOW = Instant.now()
+    val A_SECOND_AGO = NOW.minusSeconds(1)
+    val DUPLICATE_LINK = ChangeLogItem("Link", NOW, "This issue is duplicated by MC-4")
+    
     "should return OperationNotNeededModuleResponse when linked is empty and there are no duplicates" {
-        val module = UpdateLinkedModule()
-        val request = UpdateLinkedModule.Request(emptyList(), null) { Unit.right() }
+        val module = UpdateLinkedModule(0)
+        val request = Request(A_SECOND_AGO, emptyList(), null) { Unit.right() }
 
         val result = module(request)
 
@@ -19,8 +27,8 @@ class UpdateLinkedModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse when linked is 0 and there are no duplicates" {
-        val module = UpdateLinkedModule()
-        val request = UpdateLinkedModule.Request(emptyList(), 0.0) { Unit.right() }
+        val module = UpdateLinkedModule(0)
+        val request = Request(A_SECOND_AGO, emptyList(), 0.0) { Unit.right() }
 
         val result = module(request)
 
@@ -28,8 +36,28 @@ class UpdateLinkedModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse when linked and number of duplicates is equal" {
-        val module = UpdateLinkedModule()
-        val request = UpdateLinkedModule.Request(listOf("Duplicate"), 1.0) { Unit.right() }
+        val module = UpdateLinkedModule(0)
+        val request = Request(A_SECOND_AGO, listOf(DUPLICATE_LINK), 1.0) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when there is only a recently added link" {
+        val module = UpdateLinkedModule(1)
+        val request = Request(A_SECOND_AGO, listOf(DUPLICATE_LINK), 0.0) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when there is only a recently added link after the last Linked change" {
+        val module = UpdateLinkedModule(1)
+        val linkedChange = ChangeLogItem("Linked", NOW.minusSeconds(2), "1.0")
+        val oldAddedLink = ChangeLogItem("Link", NOW.minus(2, ChronoUnit.HOURS), "This issue is duplicated by MC-4")
+        val request = Request(NOW.minus(3, ChronoUnit.HOURS), listOf(oldAddedLink, linkedChange, DUPLICATE_LINK), 0.0) { Unit.right() }
 
         val result = module(request)
 
@@ -37,8 +65,8 @@ class UpdateLinkedModuleTest : StringSpec({
     }
 
     "should set linked when there are duplicates and linked is empty" {
-        val module = UpdateLinkedModule()
-        val request = UpdateLinkedModule.Request(listOf("Duplicate"), null) { Unit.right() }
+        val module = UpdateLinkedModule(0)
+        val request = Request(A_SECOND_AGO, listOf(DUPLICATE_LINK), null) { Unit.right() }
 
         val result = module(request)
 
@@ -46,8 +74,8 @@ class UpdateLinkedModuleTest : StringSpec({
     }
 
     "should set linked when there are duplicates and linked is too low" {
-        val module = UpdateLinkedModule()
-        val request = UpdateLinkedModule.Request(listOf("Duplicate"), 0.0) { Unit.right() }
+        val module = UpdateLinkedModule(0)
+        val request = Request(A_SECOND_AGO, listOf(DUPLICATE_LINK), 0.0) { Unit.right() }
 
         val result = module(request)
 
@@ -55,8 +83,8 @@ class UpdateLinkedModuleTest : StringSpec({
     }
 
     "should set linked when there are duplicates and linked is too high" {
-        val module = UpdateLinkedModule()
-        val request = UpdateLinkedModule.Request(listOf("Duplicate"), 2.0) { Unit.right() }
+        val module = UpdateLinkedModule(0)
+        val request = Request(A_SECOND_AGO, listOf(DUPLICATE_LINK), 2.0) { Unit.right() }
 
         val result = module(request)
 
@@ -65,8 +93,9 @@ class UpdateLinkedModuleTest : StringSpec({
 
     "should only count duplicates" {
         var linked = 0.0
-        val module = UpdateLinkedModule()
-        val request = UpdateLinkedModule.Request(listOf("Duplicate", "Relates", "Duplicate"), null) { linked = it; Unit.right() }
+        val module = UpdateLinkedModule(0)
+        val relatesLink = ChangeLogItem("Link", NOW.minusSeconds(1), "This issue relates to MC-4")
+        val request = Request(A_SECOND_AGO, listOf(DUPLICATE_LINK, relatesLink, DUPLICATE_LINK), null) { linked = it; Unit.right() }
 
         val result = module(request)
 
@@ -74,9 +103,19 @@ class UpdateLinkedModuleTest : StringSpec({
         linked shouldBe 2.0
     }
 
+    "should update if there is an old and a recent link" {
+        val module = UpdateLinkedModule(1)
+        val oldAddedLink = ChangeLogItem("Link", NOW.minus(2, ChronoUnit.HOURS), "This issue is duplicated by MC-4")
+        val request = Request(A_SECOND_AGO.minus(2, ChronoUnit.HOURS), listOf(oldAddedLink, DUPLICATE_LINK), null) { Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeRight(ModuleResponse)
+    }
+
     "should return FailedModuleResponse when setting linked fails" {
-        val module = UpdateLinkedModule()
-        val request = UpdateLinkedModule.Request(listOf("Duplicate"), null) { RuntimeException().left() }
+        val module = UpdateLinkedModule(0)
+        val request = Request(A_SECOND_AGO, listOf(DUPLICATE_LINK), null) { RuntimeException().left() }
 
         val result = module(request)
 


### PR DESCRIPTION
## Purpose
Resolves #131

## Approach
This removes the jql config entry again and instead allows to register modules in the ModuleRegistry with a custom jql.
In the module registry, it is now possible to register a function that receives the lastRun timestamp and returns a jql string.

This makes it possible to look for issues that were exactly a day ago, since it is possible to run additional code when evaluating the jql query.

The UpdateLinkedModule now sees all recently updated issues (like before), and additionally, all issues that were updated in an interval from currentTime - 24h to lastRun -24h.
The module now requires that there was first link that was added after the last change of `Linked` is at least 24h ago.

The update interval (currently set to 24h) is also configurable. This both changes which issues the module sees and the required time elapsed since the last change.

TL;DR With this change, the UpdateLinkedModule will only update the Linked field on issues where the Linked field has not been updated for at least 24h (and at most 47h59m59s999ms, though that is pretty unlikely)

#### Checklist
- [x] Included tests
- [ ] Tested in MCTEST-xxx
