### PR TITLE
Fix Arisa searching issues caused by extra '}' in jql string

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
@@ -78,7 +78,7 @@ class ModuleExecutor(
             else ""
         }
 
-        val jql = "$failedTicketsJQL($moduleJql})"
+        val jql = "$failedTicketsJQL($moduleJql)"
         val issues = queryCache.get(jql) ?: searchIssues(jql, startAt, onQueryNotAtResultEnd)
 
         queryCache.add(jql, issues)


### PR DESCRIPTION
## Purpose

## Approach

## Future work

#### Checklist
- [ ] Included tests
- [ ] Tested in MCTEST-xxx
