### PR TITLE
Also consider changes caused by removed links in UpdateLinkedModule

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -571,6 +571,7 @@ class ModuleRegistry(jiraClient: JiraClient, private val config: Config) {
                                     UpdateLinkedModule.ChangeLogItem(
                                         i.field,
                                         e.created.toInstant(),
+                                        i.fromString,
                                         i.toString
                                     )
                                 }

--- a/src/test/kotlin/io/github/mojira/arisa/modules/UpdateLinkedModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/UpdateLinkedModuleTest.kt
@@ -15,7 +15,7 @@ import java.time.temporal.ChronoUnit
 class UpdateLinkedModuleTest : StringSpec({
     val NOW = Instant.now()
     val A_SECOND_AGO = NOW.minusSeconds(1)
-    val DUPLICATE_LINK = ChangeLogItem("Link", NOW, "This issue is duplicated by MC-4")
+    val DUPLICATE_LINK = ChangeLogItem("Link", NOW, null, "This issue is duplicated by MC-4")
 
     "should return OperationNotNeededModuleResponse when linked is empty and there are no duplicates" {
         val module = UpdateLinkedModule(0)
@@ -55,8 +55,8 @@ class UpdateLinkedModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when there is only a recently added link after the last Linked change" {
         val module = UpdateLinkedModule(1)
-        val linkedChange = ChangeLogItem("Linked", NOW.minusSeconds(2), "1.0")
-        val oldAddedLink = ChangeLogItem("Link", NOW.minus(2, ChronoUnit.HOURS), "This issue is duplicated by MC-4")
+        val linkedChange = ChangeLogItem("Linked", NOW.minusSeconds(2), null, "1.0")
+        val oldAddedLink = ChangeLogItem("Link", NOW.minus(2, ChronoUnit.HOURS), null, "This issue is duplicated by MC-4")
         val request = Request(NOW.minus(3, ChronoUnit.HOURS), listOf(oldAddedLink, linkedChange, DUPLICATE_LINK), 0.0) { Unit.right() }
 
         val result = module(request)
@@ -74,27 +74,32 @@ class UpdateLinkedModuleTest : StringSpec({
     }
 
     "should set linked when there are duplicates and linked is too low" {
+        var linked = 0.0
         val module = UpdateLinkedModule(0)
-        val request = Request(A_SECOND_AGO, listOf(DUPLICATE_LINK), 0.0) { Unit.right() }
+        val request = Request(A_SECOND_AGO, listOf(DUPLICATE_LINK), 0.0) { linked = it; Unit.right() }
 
         val result = module(request)
 
         result.shouldBeRight(ModuleResponse)
+        linked shouldBe 1.0
     }
 
     "should set linked when there are duplicates and linked is too high" {
+        var linked = 1.0
         val module = UpdateLinkedModule(0)
-        val request = Request(A_SECOND_AGO, listOf(DUPLICATE_LINK), 2.0) { Unit.right() }
+        val removedLink = ChangeLogItem("Link", NOW.plusSeconds(1), "This issue is duplicated by MC-4", null)
+        val request = Request(A_SECOND_AGO, listOf(DUPLICATE_LINK, removedLink), 1.0) { linked = it; Unit.right() }
 
         val result = module(request)
 
         result.shouldBeRight(ModuleResponse)
+        linked shouldBe 0.0
     }
 
     "should only count duplicates" {
         var linked = 0.0
         val module = UpdateLinkedModule(0)
-        val relatesLink = ChangeLogItem("Link", NOW.minusSeconds(1), "This issue relates to MC-4")
+        val relatesLink = ChangeLogItem("Link", NOW, null, "This issue relates to MC-4")
         val request = Request(A_SECOND_AGO, listOf(DUPLICATE_LINK, relatesLink, DUPLICATE_LINK), null) { linked = it; Unit.right() }
 
         val result = module(request)
@@ -105,12 +110,26 @@ class UpdateLinkedModuleTest : StringSpec({
 
     "should update if there is an old and a recent link" {
         val module = UpdateLinkedModule(1)
-        val oldAddedLink = ChangeLogItem("Link", NOW.minus(2, ChronoUnit.HOURS), "This issue is duplicated by MC-4")
+        val oldAddedLink = ChangeLogItem("Link", NOW.minus(2, ChronoUnit.HOURS), null, "This issue is duplicated by MC-4")
         val request = Request(A_SECOND_AGO.minus(2, ChronoUnit.HOURS), listOf(oldAddedLink, DUPLICATE_LINK), null) { Unit.right() }
 
         val result = module(request)
 
         result.shouldBeRight(ModuleResponse)
+    }
+
+    "should update if a link was removed" {
+        var linked = 1.0
+        val module = UpdateLinkedModule(1)
+        val addedLink = ChangeLogItem("Link", NOW.minus(4, ChronoUnit.HOURS), null, "This issue is duplicated by MC-4")
+        val linkedChange = ChangeLogItem("Linked", A_SECOND_AGO.minus(3, ChronoUnit.HOURS), null, "1.0")
+        val removedLink = ChangeLogItem("Link", NOW.minus(2, ChronoUnit.HOURS), "This issue is duplicated by MC-4", null)
+        val request = Request(A_SECOND_AGO.minus(4, ChronoUnit.HOURS), listOf(addedLink, linkedChange, removedLink), 1.0) { linked = it; Unit.right() }
+
+        val result = module(request)
+
+        result.shouldBeRight(ModuleResponse)
+        linked shouldBe 0.0
     }
 
     "should return FailedModuleResponse when setting linked fails" {


### PR DESCRIPTION
## Purpose
This fixes UpdateLinkedModule only updating when a link was added, and not when one was removed.
Additionally, the module would count all links that were ever added, even if they were removed again.

## Approach
The module now also receives the old value for all changes, so that it can also know when a link was removed.

#### Checklist
- [x] Included tests
- [ ] Tested in MCTEST-xxx
