### PR TITLE
Fix arisa trying to add versions in transfer versions that are already added

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -300,7 +300,7 @@ class ModuleRegistry(jiraClient: JiraClient, private val config: Config) {
                                                 { it.left() },
                                                 { issue ->
                                                     issue.versions
-                                                        .map { it.name }
+                                                        .map { it.id }
                                                         .right()
                                                 }
                                             )


### PR DESCRIPTION
## Purpose
Currently, Arisa is trying to transfer versions, even if the parent already has the version added

## Approach
This was caused by the module registry mapping to the version id in one instance and the version name in another instance.
Both instances now correctly map to the version id.

#### Checklist
- [ ] Included tests
- [ ] Tested in MCTEST-xxx
