### PR TITLE
Disable module for date fields, fix for double

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -209,7 +209,14 @@
       },
       "revokeFieldChanges": {
         "excludedStatuses": ["Postponed"],
-        "whitelist": [],
+        "whitelist": [
+          "MC",
+          "MCL",
+          "MCPE",
+          "BDS",
+          "MCD",
+          "MCE"
+        ],
         "fields": [
           {
             "fieldId": "customfield_10500",

--- a/arisa.json
+++ b/arisa.json
@@ -224,18 +224,6 @@
             "message": "{panel:borderColor=orange}(!) Don't try to change \"Confirmation Status\". It may only be changed by moderators and helpers. Consider this a warning.{panel}\n~{color:#888}-- I am a bot. This action was performed automagically! Please report any issues in [Discord|https://discordapp.com/invite/rpCyfKV] or [Reddit|https://www.reddit.com/r/Mojira/]{color}~"
           },
           {
-            "fieldId": "customfield_10701",
-            "fieldName": "CHK",
-            "fieldType": "STRING",
-            "defaultValue": null,
-            "permissionGroups": [
-              "staff",
-              "global-moderators",
-              "helper"
-            ],
-            "message": "{panel:borderColor=orange}(!) Don't try to change \"CHK\". It may only be changed by moderators and helpers. Consider this a warning.{panel}\n~{color:#888}-- I am a bot. This action was performed automagically! Please report any issues in [Discord|https://discordapp.com/invite/rpCyfKV] or [Reddit|https://www.reddit.com/r/Mojira/]{color}~"
-          },
-          {
             "fieldId": "customfield_11100",
             "fieldName": "Linked",
             "fieldType": "DOUBLE",
@@ -268,16 +256,6 @@
               "staff"
             ],
             "message": "{panel:borderColor=orange}(!) Don't try to change \"Mojang Priority\". It may only be changed by the developers of the game. Consider this a warning.{panel}\n~{color:#888}-- I am a bot. This action was performed automagically! Please report any issues in [Discord|https://discordapp.com/invite/rpCyfKV] or [Reddit|https://www.reddit.com/r/Mojira/]{color}~"
-          },
-          {
-            "fieldId": "customfield_12201",
-            "fieldName": "Triaged Time",
-            "fieldType": "STRING",
-            "defaultValue": null,
-            "permissionGroups": [
-              "staff"
-            ],
-            "message": "{panel:borderColor=orange}(!) Don't try to change \"Triaged Time\". It may only be changed by the developers of the game. Consider this a warning.{panel}\n~{color:#888}-- I am a bot. This action was performed automagically! Please report any issues in [Discord|https://discordapp.com/invite/rpCyfKV] or [Reddit|https://www.reddit.com/r/Mojira/]{color}~"
           },
           {
             "fieldId": "customfield_11500",

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
@@ -36,8 +36,6 @@ class ModuleExecutor(
             do {
                 missingResultsPage = false
 
-                registry.getModules()[16].execute(jiraClient.getIssue("MC-178663", "*all", "changelog"), 0)
-
                 registry.getModules().forEach { (config, getJql, exec) ->
                     executeModule(
                         config,

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -530,7 +530,8 @@ class ModuleRegistry(jiraClient: JiraClient, private val config: Config) {
                         config.fieldName,
                         when (config.fieldType) {
                             FieldType.VALUE -> issue.getCustomField(config.fieldId)
-                            FieldType.DOUBLE, FieldType.STRING -> issue.getFieldAsString(config.fieldId)
+                            FieldType.DOUBLE -> (issue.getField(config.fieldId) as? Double?)?.toInt()?.toString()
+                            FieldType.STRING -> issue.getFieldAsString(config.fieldId)
                         },
                         config.defaultValue,
                         config.permissionGroups,


### PR DESCRIPTION
## Purpose
Fix #180 

## Approach
This removes date fields such as CHK and Triaged Time from the config.
They are not that important anyways and a bit harder to parse, which would probably need some specific code just for date fields inside of the module.

Double fields are now first cast to int, so that the field matches the entry from the changelog.

#### Checklist
- [x] Tested in shadow mode for half an hour
