### PR TITLE
Disable RemoveTriagedMeqs module

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -92,6 +92,7 @@
         ]
       },
       "removeTriagedMeqs": {
+        "whitelist": [],
         "meqsTags": [
           "MEQS_WAI",
           "MEQS_WONTFIX"


### PR DESCRIPTION
The module was activated again in #194, but #184 still happens.