### PR TITLE
Revert "Disable RemoveTriagedMeqs module"

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -92,7 +92,6 @@
         ]
       },
       "removeTriagedMeqs": {
-        "whitelist": [],
         "meqsTags": [
           "MEQS_WAI",
           "MEQS_WONTFIX"


### PR DESCRIPTION
Reverts mojira/arisa-kt#196
An old screen was running which was likely causing issues (see #197).

Should be good now, as this is literally the version now that was running fine for weeks.