### PR TITLE
Make KeepPrivate only comment when necessary

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -134,6 +134,18 @@
         ]
       },
       "removeNonStaffMeqs": {
+        "resolutions": [
+          "Awaiting Response",
+          "Cannot Reproduce",
+          "Done",
+          "Duplicate",
+          "Fixed",
+          "Incomplete",
+          "Invalid",
+          "Unresolved",
+          "Won't Fix",
+          "Works As Intended"
+        ],
         "removalReason": "Comment was not properly staff-restricted."
       },
       "empty": {

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -196,7 +196,8 @@ class ModuleRegistry(jiraClient: JiraClient, private val config: Config) {
             KeepPrivateModule.Request(
                 issue.security?.id,
                 issue.getSecurityLevelId(config),
-                issue.comments.map { c -> c.body },
+                issue.getComments(jiraClient),
+                issue.getChangeLogEntries(jiraClient),
                 ::updateSecurity.partially1(issue).partially1(issue.getSecurityLevelId(config)),
                 ::addComment.partially1(issue).partially1(config[Modules.KeepPrivate.message])
             )

--- a/src/main/kotlin/io/github/mojira/arisa/modules/KeepPrivateModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/KeepPrivateModule.kt
@@ -23,9 +23,9 @@ class KeepPrivateModule(private val keepPrivateTag: String?) : Module<KeepPrivat
             assertContainsKeepPrivateTag(comments).bind()
             assertIsPublic(securityLevel, privateLevel).bind()
 
-            val markedTime = comments.last(::isKeepPrivateTag).created.toEpochMilli()
-            val changedTime = changeLog.lastOrNull(::isSecurityChange)?.created?.toEpochMilli()
-            if (changedTime != null && changedTime > markedTime) {
+            val markedTime = comments.last(::isKeepPrivateTag).created
+            val changedTime = changeLog.lastOrNull(::isSecurityChange)?.created
+            if (changedTime != null && changedTime.isAfter(markedTime)) {
                 addSecurityComment().toFailedModuleEither().bind()
             }
             setPrivate().toFailedModuleEither().bind()

--- a/src/main/kotlin/io/github/mojira/arisa/modules/KeepPrivateModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/KeepPrivateModule.kt
@@ -39,7 +39,7 @@ class KeepPrivateModule(private val keepPrivateTag: String?) : Module<KeepPrivat
     private fun isSecurityChange(item: ChangeLogItem) = item.field == "security"
 
     private fun assertContainsKeepPrivateTag(comments: List<Comment>) = when {
-        comments.any { isKeepPrivateTag(it) } -> Unit.right()
+        comments.any(::isKeepPrivateTag) -> Unit.right()
         else -> OperationNotNeededModuleResponse.left()
     }
 

--- a/src/main/kotlin/io/github/mojira/arisa/modules/KeepPrivateModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/KeepPrivateModule.kt
@@ -23,7 +23,7 @@ class KeepPrivateModule(private val keepPrivateTag: String?) : Module<KeepPrivat
             assertContainsKeepPrivateTag(comments).bind()
             assertIsPublic(securityLevel, privateLevel).bind()
 
-            val markedTime = comments.last(::isKeepPrivateTag).created
+            val markedTime = comments.first(::isKeepPrivateTag).created
             val changedTime = changeLog.lastOrNull(::isSecurityChange)?.created
             if (changedTime != null && changedTime.isAfter(markedTime)) {
                 addSecurityComment().toFailedModuleEither().bind()

--- a/src/test/kotlin/io/github/mojira/arisa/modules/KeepPrivateModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/KeepPrivateModuleTest.kt
@@ -65,14 +65,23 @@ class KeepPrivateModuleTest : StringSpec({
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
-    "should set to private when security level is null" {
+    "should both set to private and comment when security level is null" {
+        var didSetToPrivate = false
+        var didComment = false
+
         val module = KeepPrivateModule("MEQS_KEEP_PRIVATE")
         val comment = getComment("MEQS_KEEP_PRIVATE", visibilityType = "group", visibilityValue = "staff")
-        val request = KeepPrivateModule.Request(null, "private", listOf(comment), listOf(REMOVE_SECURITY), { Unit.right() }, { Unit.right() })
+        val request = KeepPrivateModule.Request(
+            null, "private", listOf(comment), listOf(REMOVE_SECURITY),
+            { didSetToPrivate = true; Unit.right() },
+            { didComment = true; Unit.right() }
+        )
 
         val result = module(request)
 
         result.shouldBeRight(ModuleResponse)
+        didSetToPrivate shouldBe true
+        didComment shouldBe true
     }
 
     "should both set to private and comment when security level is not private" {
@@ -94,14 +103,14 @@ class KeepPrivateModuleTest : StringSpec({
         didComment shouldBe true
     }
 
-    "should set to private but not comment when security level has neven been changed" {
+    "should set to private but not comment when security level has never been changed" {
         var didSetToPrivate = false
         var didComment = false
 
         val module = KeepPrivateModule("MEQS_KEEP_PRIVATE")
-        val comment = getComment("MEQS_KEEP_PRIVATE", NOW.minusSeconds(2), "group", "staff")
+        val comment = getComment("MEQS_KEEP_PRIVATE", visibilityType = "group", visibilityValue = "staff")
         val request = KeepPrivateModule.Request(
-            null, "private", listOf(comment), listOf(REMOVE_SECURITY),
+            null, "private", listOf(comment), emptyList(),
             { didSetToPrivate = true; Unit.right() },
             { didComment = true; Unit.right() }
         )
@@ -113,12 +122,12 @@ class KeepPrivateModuleTest : StringSpec({
         didComment shouldBe false
     }
 
-    "should set to private but not comment when security level has neven been changed since the ticket was marked" {
+    "should set to private but not comment when security level hasn't been changed since the ticket was marked" {
         var didSetToPrivate = false
         var didComment = false
 
         val module = KeepPrivateModule("MEQS_KEEP_PRIVATE")
-        val comment = getComment("MEQS_KEEP_PRIVATE", visibilityType = "group", visibilityValue = "staff")
+        val comment = getComment("MEQS_KEEP_PRIVATE", NOW.minusSeconds(2), "group", "staff")
         val request = KeepPrivateModule.Request(
             null, "private", listOf(comment), emptyList(),
             { didSetToPrivate = true; Unit.right() },

--- a/src/test/kotlin/io/github/mojira/arisa/modules/KeepPrivateModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/KeepPrivateModuleTest.kt
@@ -75,14 +75,61 @@ class KeepPrivateModuleTest : StringSpec({
         result.shouldBeRight(ModuleResponse)
     }
 
-    "should set to private when security level is not private" {
+    "should both set to private and comment when security level is not private" {
+        var didSetToPrivate = false
+        var didComment = false
+
         val module = KeepPrivateModule("MEQS_KEEP_PRIVATE")
         val comment = getComment("MEQS_KEEP_PRIVATE", visibilityType = "group", visibilityValue = "staff")
-        val request = KeepPrivateModule.Request("not private", "private", listOf(comment), listOf(REMOVE_SECURITY), { Unit.right() }, { Unit.right() })
+        val request = KeepPrivateModule.Request(
+            "not private", "private", listOf(comment), listOf(REMOVE_SECURITY),
+            { didSetToPrivate = true; Unit.right() },
+            { didComment = true; Unit.right() }
+        )
 
         val result = module(request)
 
         result.shouldBeRight(ModuleResponse)
+        didSetToPrivate shouldBe true
+        didComment shouldBe true
+    }
+
+    "should set to private but not comment when security level has neven been changed" {
+        var didSetToPrivate = false
+        var didComment = false
+
+        val module = KeepPrivateModule("MEQS_KEEP_PRIVATE")
+        val comment = getComment("MEQS_KEEP_PRIVATE", NOW.minusSeconds(2), "group", "staff")
+        val request = KeepPrivateModule.Request(
+            null, "private", listOf(comment), listOf(REMOVE_SECURITY),
+            { didSetToPrivate = true; Unit.right() },
+            { didComment = true; Unit.right() }
+        )
+
+        val result = module(request)
+
+        result.shouldBeRight(ModuleResponse)
+        didSetToPrivate shouldBe true
+        didComment shouldBe false
+    }
+
+    "should set to private but not comment when security level has neven been changed since the ticket was marked" {
+        var didSetToPrivate = false
+        var didComment = false
+
+        val module = KeepPrivateModule("MEQS_KEEP_PRIVATE")
+        val comment = getComment("MEQS_KEEP_PRIVATE", visibilityType = "group", visibilityValue = "staff")
+        val request = KeepPrivateModule.Request(
+            null, "private", listOf(comment), emptyList(),
+            { didSetToPrivate = true; Unit.right() },
+            { didComment = true; Unit.right() }
+        )
+
+        val result = module(request)
+
+        result.shouldBeRight(ModuleResponse)
+        didSetToPrivate shouldBe true
+        didComment shouldBe false
     }
 
     "should return FailedModuleResponse when setting security level fails" {


### PR DESCRIPTION
# Purpose
Fix #226 
## Approach
KeepPrivate module will no longer comment if the security level hasn't been
changed since the ticket was marked by the private tag.
#### Checklist
- [x] Included tests
- [ ] Tested in MCTEST-xxx
