### PR TITLE
Fix RemoveNonStaffMeqs not restricting comments

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/RemoveNonStaffMeqsModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RemoveNonStaffMeqsModule.kt
@@ -14,7 +14,7 @@ class RemoveNonStaffMeqsModule(private val removalReason: String) : Module<Remov
         val updateMeqsComments = request.comments
             .filter(::hasMeqsTag)
             .filter(::isNotStaffRestricted)
-            .map { it.update.partially1(removeMeqsTags(it.body)) }
+            .map { it.restrict.partially1(removeMeqsTags(it.body)) }
         assertNotEmpty(updateMeqsComments).bind()
 
         tryRunAll(updateMeqsComments).bind()

--- a/src/test/kotlin/io/github/mojira/arisa/modules/RemoveNonStaffMeqsModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/RemoveNonStaffMeqsModuleTest.kt
@@ -195,8 +195,8 @@ class RemoveNonStaffMeqsModuleTest : StringSpec({
             Instant.now(),
             null,
             null,
-            { Unit.right() },
-            { it.shouldBe("MEQS_ARISA_REMOVED_WAI Removal Reason: Test.\nI like QC.").right() }
+            { it.shouldBe("MEQS_ARISA_REMOVED_WAI Removal Reason: Test.\nI like QC."); Unit.right() },
+            { Unit.right() }
         )
         val request = Request(listOf(comment))
 
@@ -204,5 +204,4 @@ class RemoveNonStaffMeqsModuleTest : StringSpec({
 
         result.shouldBeRight(ModuleResponse)
     }
-}
-        )
+})


### PR DESCRIPTION
## Purpose
Fix RemoveNonStaffMeqs not restricting comments.
## Approach
Change `update` to `restrict`.
## Checklist
- [x] Included tests
- [ ] Tested in MCTEST-xxx
