### PR TITLE
Double lengthThreshold of Language

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -265,7 +265,7 @@
           "it": "I have detected that this ticket is in *Italian*."
         },
         "defaultMessage": "I would have closed this ticket as Invalid. This module is currently in the testing phase. If you find any issues, please [report them on GitHub|https://github.com/mojira/arisa-kt/issues].\nARISA_LANGUAGE_MODULE_TEST\n\n~{color:#888}-- I am a bot. This action was performed automagically!{color}~",
-        "lengthThreshold": 80
+        "lengthThreshold": 160
       },
       "hideImpostors": {},
       "resolveTrash": {


### PR DESCRIPTION
## Purpose
Try fixing #142... again...
## Approach
Statistics of known false positives on tickets that only has English texts (different from #122).
| Ticket     | Summary                                                 | Description                                                                                                                                     | Summary Length | Description Length | Total Length | Note                                                                     |
| ---------- | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | ------------------ | ------------ | ------------------------------------------------------------------------ |
| MC-180009  | Raining underground                                     | !image-2020-04-23-01-34-33-236.png \| thumbnail!                                                                                                | 19             | 47                 | 67           |                                                                          |
| MC-182790  | chickens despawn when their rider zombie dies           | chickens despawn when their rider zombie dies                                                                                                   | 45             | 45                 | 91           |                                                                          |
| MC-182947  | Ancient Debris does not generate in Basalt Deltas biome | Ancient Debris does not generate inside of basalt delta biomes                                                                                  | 55             | 62                 | 118          |                                                                          |
| MCPE-71549 | ?                                                       | Villagers can open iron doors                                                                                                                   | 1              | 29                 | 31           |                                                                          |
| MCPE-72386 | Baby Zombie Riding Adult Zombies                        | Baby Zombie Riding Adult Zombies\n\nZombie Jockey                                                                                               | 32             | 47                 | 80           |                                                                          |
| MCPE-73476 | Pillager doesn’t aim child villager                     | pillager doesn’t aim child villager.\n\n Reproduce:\n\n1.Summon pillager\n\n2.Summon child villager                                             | 35             | 93                 | 129          |                                                                          |
| MCPE-74498 | Zombie Villages generate about 25%-30%                  | Zombie Villages should spawn about 2%-5%.                                                                                                       | 38             | 41                 | 80           |                                                                          |
| MCPE-75920 | Armor Doesn't Render on Zombie Villager                 | Armor on Zombie Villager doesn't render but however the helmet renders on zombie zillager and also boots render but Not Chestplate or Leggings. | 39             | 143                | 183          | Broken English (no offense, still better than Bedrock's translations /s) |

I suppose doubling the threshold from `80` to `160` should be enough. Note this may create some false negatives (e.g. MCPE-79043 with length `115`, MCPE-79030 with length `155`), which is still better than false positives imo.

Do you have any ideas on how large the threshold shold be?

#### Checklist
- [ ] Included tests
- [ ] Tested in MCTEST-xxx
