### PR TITLE
Support null releaseDate of versions

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/domain/Version.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/domain/Version.kt
@@ -8,6 +8,6 @@ data class Version(
     val name: String,
     val released: Boolean,
     val archived: Boolean,
-    val releaseDate: Instant,
+    val releaseDate: Instant?,
     val execute: () -> Either<Throwable, Unit>
 )

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
@@ -67,7 +67,7 @@ fun JiraVersion.toDomain(execute: (JiraVersion) -> Either<Throwable, Unit>) = Ve
     name,
     isReleased,
     isArchived,
-    releaseDate.toVersionReleaseInstant(),
+    releaseDate?.toVersionReleaseInstant(),
     execute.partially1(this)
 )
 

--- a/src/main/kotlin/io/github/mojira/arisa/modules/TransferVersionsModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/TransferVersionsModule.kt
@@ -14,20 +14,28 @@ class TransferVersionsModule : AbstractTransferFieldModule<List<Version>, String
         field: List<Version>
     ) =
         parents.flatMap { (parentIssue, parentField) ->
-            val oldestVersionOnParent = getOldestVersion(parentField)
+            val oldestVersionWithKnownReleaseDateOnParent = getOldestVersionWithKnownReleaseDate(parentField)
             field
                 .filter { it !in parentField }
-                .filter { it isReleasedAfter oldestVersionOnParent }
+                .filter { it isReleasedAfter oldestVersionWithKnownReleaseDateOnParent }
                 .map { it.id }
                 .map(parentIssue.setField::partially1)
         }
 
-    private fun getOldestVersion(field: List<Version>) = field
+    private fun getOldestVersionWithKnownReleaseDate(field: List<Version>) = field
+        .filter { it.releaseDate != null }
         .sortedBy { it.releaseDate }
         .getOrNull(0)
 
+    /**
+     * Returns true only if:
+     * - The other version is `null`;
+     * - The other version has a `null` release date; OR
+     * - The current version has a non-`null` release date which is after the other version's release date.
+     */
     private infix fun Version.isReleasedAfter(other: Version?) =
-        other == null || this.releaseDate.isAfter(other.releaseDate)
+        other?.releaseDate == null ||
+                this.releaseDate?.isAfter(other.releaseDate) == true
 
     private fun LinkedIssue<*, *>.isSameProject(otherKey: String) =
         key.getProject() == otherKey.getProject()

--- a/src/main/kotlin/io/github/mojira/arisa/modules/TransferVersionsModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/TransferVersionsModule.kt
@@ -35,7 +35,7 @@ class TransferVersionsModule : AbstractTransferFieldModule<List<Version>, String
      */
     private infix fun Version.isReleasedAfter(other: Version?) =
         other?.releaseDate == null ||
-                this.releaseDate?.isAfter(other.releaseDate)
+            (releaseDate != null && releaseDate.isAfter(other.releaseDate))
 
     private fun LinkedIssue<*, *>.isSameProject(otherKey: String) =
         key.getProject() == otherKey.getProject()

--- a/src/main/kotlin/io/github/mojira/arisa/modules/TransferVersionsModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/TransferVersionsModule.kt
@@ -35,7 +35,7 @@ class TransferVersionsModule : AbstractTransferFieldModule<List<Version>, String
      */
     private infix fun Version.isReleasedAfter(other: Version?) =
         other?.releaseDate == null ||
-                this.releaseDate?.isAfter(other.releaseDate) == true
+                this.releaseDate?.isAfter(other.releaseDate)
 
     private fun LinkedIssue<*, *>.isSameProject(otherKey: String) =
         key.getProject() == otherKey.getProject()


### PR DESCRIPTION
## Purpose
Fix #250.
## Approach
Only transfer versions that has a non-`null` `releaseDate`.

#### Checklist
- [x] Included tests
- [ ] Tested in MCTEST-xxx
