### PR TITLE
Resolve as awaiting response when removing future version

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -102,7 +102,7 @@
         "removalReason": "Ticket has been triaged."
       },
       "futureVersion": {
-        "message": "panel-future-version"
+        "message": "provide-affected-versions"
       },
       "chk": {
         "excludedStatuses": ["Postponed"],

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -212,7 +212,7 @@ class ModuleRegistry(jiraClient: JiraClient, private val config: Config, private
                         issue.project.key, config[Modules.FutureVersion.message]
                     )
                 ),
-                ::resolveAs.partially1(issue).partially1("Invalid")
+                ::resolveAs.partially1(issue).partially1("Awaiting Response")
             )
         }
 

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -211,7 +211,8 @@ class ModuleRegistry(jiraClient: JiraClient, private val config: Config, private
                     messages.getMessageWithBotSignature(
                         issue.project.key, config[Modules.FutureVersion.message]
                     )
-                )
+                ),
+                ::resolveAs.partially1(issue).partially1("Invalid")
             )
         }
 

--- a/src/main/kotlin/io/github/mojira/arisa/modules/FutureVersionModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/FutureVersionModule.kt
@@ -9,7 +9,8 @@ class FutureVersionModule : Module<FutureVersionModule.Request> {
     data class Request(
         val affectedVersions: List<Version>,
         val versions: List<Version>?,
-        val addFutureVersionComment: () -> Either<Throwable, Unit>
+        val addFutureVersionComment: () -> Either<Throwable, Unit>,
+        val resolveAsAwaitingResponse: () -> Either<Throwable, Unit>
     )
 
     override fun invoke(request: Request): Either<ModuleError, ModuleResponse> = with(request) {
@@ -25,6 +26,7 @@ class FutureVersionModule : Module<FutureVersionModule.Request> {
             latestVersion!!.execute().toFailedModuleEither().bind()
             tryRunAll(removeFutureVersions).bind()
             addFutureVersionComment().toFailedModuleEither().bind()
+            resolveAsAwaitingResponse().toFailedModuleEither().bind()
         }
     }
 

--- a/src/test/kotlin/io/github/mojira/arisa/modules/FutureVersionModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/FutureVersionModuleTest.kt
@@ -18,7 +18,7 @@ class FutureVersionModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse when affected versions are empty" {
         val module = FutureVersionModule()
         val releasedVersion = getVersion(true, false) { Unit.right() }
-        val request = Request(emptyList(), listOf(releasedVersion)) { Unit.right() }
+        val request = Request(emptyList(), listOf(releasedVersion), { Unit.right() }) { Unit.right() }
 
         val result = module(request)
 
@@ -28,7 +28,7 @@ class FutureVersionModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse when project versions are empty" {
         val module = FutureVersionModule()
         val futureVersion = getVersion(false, false) { Unit.right() }
-        val request = Request(listOf(futureVersion), emptyList()) { Unit.right() }
+        val request = Request(listOf(futureVersion), emptyList(), { Unit.right() }) { Unit.right() }
 
         val result = module(request)
 
@@ -38,7 +38,7 @@ class FutureVersionModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse when project versions are null" {
         val module = FutureVersionModule()
         val futureVersion = getVersion(false, false) { Unit.right() }
-        val request = Request(listOf(futureVersion), null) { Unit.right() }
+        val request = Request(listOf(futureVersion), null, { Unit.right() }) { Unit.right() }
 
         val result = module(request)
 
@@ -48,7 +48,7 @@ class FutureVersionModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse when project versions do not contain released versions" {
         val module = FutureVersionModule()
         val futureVersion = getVersion(false, false) { Unit.right() }
-        val request = Request(listOf(futureVersion), listOf(futureVersion)) { Unit.right() }
+        val request = Request(listOf(futureVersion), listOf(futureVersion), { Unit.right() }) { Unit.right() }
 
         val result = module(request)
 
@@ -58,7 +58,7 @@ class FutureVersionModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse if no future version is marked affected" {
         val module = FutureVersionModule()
         val releasedVersion = getVersion(true, false) { Unit.right() }
-        val request = Request(listOf(releasedVersion), listOf(releasedVersion)) { Unit.right() }
+        val request = Request(listOf(releasedVersion), listOf(releasedVersion), { Unit.right() }) { Unit.right() }
 
         val result = module(request)
 
@@ -69,7 +69,7 @@ class FutureVersionModuleTest : StringSpec({
         val module = FutureVersionModule()
         val archivedVersion = getVersion(false, true) { Unit.right() }
         val releasedVersion = getVersion(true, false) { Unit.right() }
-        val request = Request(listOf(archivedVersion), listOf(releasedVersion)) { Unit.right() }
+        val request = Request(listOf(archivedVersion), listOf(releasedVersion), { Unit.right() }) { Unit.right() }
 
         val result = module(request)
 
@@ -80,7 +80,7 @@ class FutureVersionModuleTest : StringSpec({
         val module = FutureVersionModule()
         val futureVersion = getVersion(false, false) { Unit.right() }
         val releasedVersion = getVersion(true, false) { Unit.right() }
-        val request = Request(listOf(futureVersion), listOf(releasedVersion)) { Unit.right() }
+        val request = Request(listOf(futureVersion), listOf(releasedVersion), { Unit.right() }) { Unit.right() }
 
         val result = module(request)
 
@@ -91,7 +91,7 @@ class FutureVersionModuleTest : StringSpec({
         val module = FutureVersionModule()
         val futureVersion = getVersion(false, false) { RuntimeException().left() }
         val releasedVersion = getVersion(true, false) { Unit.right() }
-        val request = Request(listOf(futureVersion), listOf(releasedVersion)) { Unit.right() }
+        val request = Request(listOf(futureVersion), listOf(releasedVersion), { Unit.right() }) { Unit.right() }
 
         val result = module(request)
 
@@ -104,7 +104,7 @@ class FutureVersionModuleTest : StringSpec({
         val module = FutureVersionModule()
         val futureVersion = getVersion(false, false) { RuntimeException().left() }
         val releasedVersion = getVersion(true, false) { Unit.right() }
-        val request = Request(listOf(futureVersion, futureVersion), listOf(releasedVersion)) { Unit.right() }
+        val request = Request(listOf(futureVersion, futureVersion), listOf(releasedVersion), { Unit.right() }) { Unit.right() }
 
         val result = module(request)
 
@@ -117,7 +117,7 @@ class FutureVersionModuleTest : StringSpec({
         val module = FutureVersionModule()
         val futureVersion = getVersion(false, false) { Unit.right() }
         val releasedVersion = getVersion(true, false) { RuntimeException().left() }
-        val request = Request(listOf(futureVersion), listOf(releasedVersion)) { Unit.right() }
+        val request = Request(listOf(futureVersion), listOf(releasedVersion), { Unit.right() }) { Unit.right() }
 
         val result = module(request)
 
@@ -130,7 +130,7 @@ class FutureVersionModuleTest : StringSpec({
         val module = FutureVersionModule()
         val futureVersion = getVersion(false, false) { Unit.right() }
         val releasedVersion = getVersion(true, false) { Unit.right() }
-        val request = Request(listOf(futureVersion), listOf(releasedVersion)) { RuntimeException().left() }
+        val request = Request(listOf(futureVersion), listOf(releasedVersion), { Unit.right() }) { RuntimeException().left() }
 
         val result = module(request)
 


### PR DESCRIPTION
## Purpose
Fixes #228 

## Approach
Resolve issues as awaiting response after removing the future version. Includes a message telling the user why

For some reason this module doesn't work in MCTEST, probably on the versions check. We might want to ask them to mark one of the versions as released

#### Checklist
- [x] Included tests
- [x] Tested in https://bugs.mojang.com/browse/TRASH-25372