### PR TITLE
get all fields in getFullIssue

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
@@ -20,7 +20,7 @@ import java.time.temporal.ChronoField
 
 fun getIssue(jiraClient: JiraClient, key: String) = runBlocking {
     Either.catch {
-        jiraClient.getIssue(key)
+        jiraClient.getIssue(key, "*all", "changelog")
     }
 }
 const val MILLI_FOR_FORMAT = 123L


### PR DESCRIPTION
## Purpose
Fixes TransferFields throwing errors, caused by getFullIssue not containing all fields

## Approach
get all fields in getIssue

#### Checklist
- [ ] Included tests
- [ ] Tested in MCTEST-xxx
