### PR TITLE
Feature/duplicate message

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -63,6 +63,7 @@
         "resolutions": [
           "Duplicate"
         ],
+        "commentDelay": 5,
         "message": "duplicate",
         "ticketMessages": {
           "MC-297": "duplicate-of-mc-297",

--- a/arisa.json
+++ b/arisa.json
@@ -59,6 +59,17 @@
           "url"
         ]
       },
+      "duplicateMessage": {
+        "resolutions": [
+          "Duplicate"
+        ],
+        "message": "duplicate",
+        "privateMessage": "duplicate-private",
+        "resolutionMessages": {
+          "Fixed": "duplicate-fixed",
+          "Works As Intended": "duplicate-wai"
+        }
+      },
       "piracy": {
         "excludedStatuses": ["Postponed"],
         "message": "pirated-minecraft",

--- a/arisa.json
+++ b/arisa.json
@@ -64,6 +64,11 @@
           "Duplicate"
         ],
         "message": "duplicate",
+        "ticketMessages": {
+          "MC-297": "duplicate-of-mc-297",
+          "MC-128302": "duplicate-of-mc-128302",
+          "MCL-5638": "duplicate-of-mcl-5638"
+        },
         "privateMessage": "duplicate-private",
         "resolutionMessages": {
           "Fixed": "duplicate-fixed",

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -105,23 +105,14 @@ class ModuleRegistry(private val config: Config) {
         register(Modules.Empty, EmptyModule(config[Modules.Empty.message]))
 
         register(
-            Modules.DuplicateMessage, DuplicateMessageModule(
+            Modules.DuplicateMessage,
+            DuplicateMessageModule(
                 config[Modules.DuplicateMessage.message],
+                config[Modules.DuplicateMessage.ticketMessages],
                 config[Modules.DuplicateMessage.privateMessage],
                 config[Modules.DuplicateMessage.resolutionMessages]
             )
-        ) { issue ->
-            DuplicateMessageModule.Request(
-                issue.getLinks<String?, Nothing>(jiraClient, ::updateSecurity, ::getSecurityGetField),
-                issue.getComments(jiraClient)
-            ) { messageKey, filledText ->
-                addComment(
-                    issue, messages.getMessageWithBotSignature(
-                        issue.project.key, messageKey, filledText
-                    )
-                )
-            }
-        }
+        )
 
         register(Modules.FutureVersion, FutureVersionModule(config[Modules.FutureVersion.message]))
 

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -112,7 +112,11 @@ class ModuleRegistry(private val config: Config) {
                 config[Modules.DuplicateMessage.privateMessage],
                 config[Modules.DuplicateMessage.resolutionMessages]
             )
-        )
+        ) { lastRun ->
+            val checkStart = lastRun.minus(config[Modules.DuplicateMessage.commentDelay], ChronoUnit.MINUTES)
+            val checkEnd = Instant.now().minus(config[Modules.DuplicateMessage.commentDelay], ChronoUnit.MINUTES)
+            return@register "updated > ${checkStart.toEpochMilli()} AND updated < ${checkEnd.toEpochMilli()}"
+        }
 
         register(Modules.FutureVersion, FutureVersionModule(config[Modules.FutureVersion.message]))
 

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
@@ -76,8 +76,12 @@ object Arisa : ConfigSpec() {
                 "",
                 description = "The key of the message that is posted under duplicate tickets."
             )
-            val privateMessage by optional(
-                "",
+            val ticketMessages by optional(
+                emptyMap<String, String>(),
+                description = "A map from ticket keys to keys of messages that are posted for specific parents"
+            )
+            val privateMessage by optional<String?>(
+                null,
                 description = "The key of the message that is posted under duplicate tickets when the parent is private."
             )
             val resolutionMessages by optional(

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
@@ -89,6 +89,10 @@ object Arisa : ConfigSpec() {
                 description = "A map from resolution names to keys of messages that are posted when the parents were" +
                         " resolved as specific resolutions"
             )
+            val commentDelay by UpdateLinked.optional(
+                0L,
+                description = "Delay in which the module should add the comment in minutes"
+            )
         }
 
         object Piracy : ModuleConfigSpec() {

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
@@ -82,7 +82,7 @@ object Arisa : ConfigSpec() {
             )
             val privateMessage by optional<String?>(
                 null,
-                description = "The key of the message that is posted under duplicate tickets when the parent is private."
+                description = "The key of the message that is posted when the parent is private."
             )
             val resolutionMessages by optional(
                 emptyMap<String, String>(),

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
@@ -34,7 +34,7 @@ object Arisa : ConfigSpec() {
         val special by optional<Map<String, String>>(
             emptyMap(),
             description = "Some projects define their own security level. These projects need to be defined here with" +
-                " their own ID.. Default is all projects use the default ID"
+                    " their own ID.. Default is all projects use the default ID"
         )
     }
 
@@ -55,12 +55,12 @@ object Arisa : ConfigSpec() {
             val resolutions by optional(
                 listOf("unresolved"),
                 description = "Optional. The resolutions that should be considered for this module." +
-                    " Default is unresolved."
+                        " Default is unresolved."
             )
             val excludedStatuses by optional(
                 emptyList<String>(),
                 description = "A list of statuses that are not considered for this module. Important for modules" +
-                    " that resolve or update, as those transitions do not exist for Postponed."
+                        " that resolve or update, as those transitions do not exist for Postponed."
             )
         }
 
@@ -68,6 +68,22 @@ object Arisa : ConfigSpec() {
             val extensionBlacklist by optional(
                 emptyList<String>(),
                 description = "The extensions that should be removed on issues. Default is no extensions."
+            )
+        }
+
+        object DuplicateMessage : ModuleConfigSpec() {
+            val message by optional(
+                "",
+                description = "The key of the message that is posted under duplicate tickets."
+            )
+            val privateMessage by optional(
+                "",
+                description = "The key of the message that is posted under duplicate tickets when the parent is private."
+            )
+            val resolutionMessages by optional(
+                emptyMap<String, String>(),
+                description = "A map from resolution names to keys of messages that are posted when the parents were" +
+                        " resolved as specific resolutions"
             )
         }
 
@@ -90,7 +106,7 @@ object Arisa : ConfigSpec() {
             val messages by optional(
                 emptyMap<String, String>(),
                 description = "Translated messages for various languages. Use lowercase ISO 639-1 as keys." +
-                    " Default is no translated messages."
+                        " Default is no translated messages."
             )
             val defaultMessage by optional(
                 "", description = "The message that is posted when this module succeeds."
@@ -98,12 +114,12 @@ object Arisa : ConfigSpec() {
             val messageFormat by optional(
                 "%s\n----\n%s",
                 description = "The message format to be used if the translated message is present." +
-                    " First argument is translated message, second is default message."
+                        " First argument is translated message, second is default message."
             )
             val lengthThreshold by optional(
                 0,
                 description = "The minimum string length that the combined summary and description text must exceed" +
-                    " before they can be detected by this module (inclusive)."
+                        " before they can be detected by this module (inclusive)."
             )
         }
 
@@ -130,12 +146,12 @@ object Arisa : ConfigSpec() {
             val confirmationStatusWhitelist by optional(
                 emptyList<String>(),
                 description = "List of confirmation status that can be replaced by the target status if Linked is" +
-                    " greater than or equal to the threshold."
+                        " greater than or equal to the threshold."
             )
             val targetConfirmationStatus by optional(
                 "",
                 description = "The target confirmation status for tickets whose Linked is greater than or equal" +
-                    " to the threshold."
+                        " to the threshold."
             )
             val linkedThreshold by optional(
                 0.0,
@@ -161,7 +177,7 @@ object Arisa : ConfigSpec() {
         object RemoveNonStaffMeqs : ModuleConfigSpec() {
             val removalReason by required<String>(
                 description = "Reason Arisa should add to the edited comment for" +
-                    " removing the tag. Default is no reason."
+                        " removing the tag. Default is no reason."
             )
         }
 

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
@@ -162,39 +162,11 @@ fun JiraIssue.toLinkedIssue(
 ) = LinkedIssue(
     key,
     status.name,
-<<<<<<< Updated upstream
     ::getFullIssue.partially1(jiraClient).partially1(messages).partially1(config),
     ::createLink.partially1(this)
 )
 
 fun JiraIssueLink.toDomain(
-=======
-    setField.partially1(this),
-    {
-        toCompleteIssue(
-            jiraClient
-        ) pipe { issueEither ->
-            issueEither.fold(
-                { it.left() },
-                { getField(it) }
-            )
-        }
-    }
-)
-
-fun JiraIssue.toCompleteIssue(
-    jiraClient: JiraClient
-) = getIssue(
-    jiraClient,
-    key
-)
-
-fun getVersionsGetField(issue: JiraIssue) = issue.versions.map { it.id }.right()
-
-fun getSecurityGetField(issue: JiraIssue) = issue.security?.id.right()
-
-fun <FIELD, FUNPARAM> JiraIssueLink.toDomain(
->>>>>>> Stashed changes
     jiraClient: JiraClient,
     messages: HelperMessages,
     config: Config

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
@@ -162,11 +162,39 @@ fun JiraIssue.toLinkedIssue(
 ) = LinkedIssue(
     key,
     status.name,
+<<<<<<< Updated upstream
     ::getFullIssue.partially1(jiraClient).partially1(messages).partially1(config),
     ::createLink.partially1(this)
 )
 
 fun JiraIssueLink.toDomain(
+=======
+    setField.partially1(this),
+    {
+        toCompleteIssue(
+            jiraClient
+        ) pipe { issueEither ->
+            issueEither.fold(
+                { it.left() },
+                { getField(it) }
+            )
+        }
+    }
+)
+
+fun JiraIssue.toCompleteIssue(
+    jiraClient: JiraClient
+) = getIssue(
+    jiraClient,
+    key
+)
+
+fun getVersionsGetField(issue: JiraIssue) = issue.versions.map { it.id }.right()
+
+fun getSecurityGetField(issue: JiraIssue) = issue.security?.id.right()
+
+fun <FIELD, FUNPARAM> JiraIssueLink.toDomain(
+>>>>>>> Stashed changes
     jiraClient: JiraClient,
     messages: HelperMessages,
     config: Config

--- a/src/main/kotlin/io/github/mojira/arisa/modules/DuplicateMessageModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/DuplicateMessageModule.kt
@@ -2,77 +2,86 @@ package io.github.mojira.arisa.modules
 
 import arrow.core.Either
 import arrow.core.extensions.fx
-import arrow.core.left
-import arrow.core.right
+import arrow.syntax.function.partially1
 import io.github.mojira.arisa.domain.Comment
+import io.github.mojira.arisa.domain.CommentOptions
+import io.github.mojira.arisa.domain.Issue
 import io.github.mojira.arisa.domain.Link
 import io.github.mojira.arisa.domain.LinkedIssue
+import java.time.Instant
 
 class DuplicateMessageModule(
     private val message: String,
+    private val ticketMessages: Map<String, String>,
     private val privateMessage: String?,
-    private val resolutionMessages: Map<String, String?>?
-) : Module<DuplicateMessageModule.Request> {
-    data class Request(
-        val links: List<Link<String?, *>>,
-        val comments: List<Comment>,
-        val addComment: (key: String, filledText: String) -> Either<Throwable, Unit>
-    )
-
-    data class LinkedIssue(
-        val key: String,
-        val security: String?,
-        val resolution: String?
-    )
-
-    override fun invoke(request: Request): Either<ModuleError, ModuleResponse> = with(request) {
+    private val resolutionMessages: Map<String, String>
+) : Module {
+    override fun invoke(issue: Issue, lastRun: Instant): Either<ModuleError, ModuleResponse> = with(issue) {
         Either.fx {
             val parents = links
                 .filter(::isDuplicatesLink)
+                .map { it.issue }
+                .sortedBy { it.key }
             assertNotEmpty(parents).bind()
 
             val visibleComments = comments
-                .filter(::isVisibleComment)
+                .filter(::isPublicComment)
             assertNotAllMentionedBefore(visibleComments, parents).bind()
 
-            val parentSecurity = parents
-                .fold(parents[0].security) { parentSecurity, (_, security) ->
-                    if (parentSecurity == security) {
-                        parentSecurity
-                    } else {
-                        null
-                    }
-                }
+            val parentKey = parents.getCommonFieldOrNull { it.key }
+            var messageKey = ticketMessages[parentKey]
+            if (messageKey == null) {
+                val fullParentEitherList = parents
+                    .map { it.getFullIssue() }
+                fullParentEitherList.toFailedModuleEither().bind()
+                val fullParents = fullParentEitherList
+                    .map { (it as Either.Right).b }
 
-            val messageKey = if (parentSecurity != null) {
-                privateMessage
-            } else {
-                val parentResolution = parentPairs
-                    .fold(parentPairs[0].security) { parentSecurity, (ticket, security) ->
-                        ticket.
-                        if (parentSecurity == security) {
-                            parentSecurity
-                        } else {
-                            null
-                        }
-                    }
+                messageKey = getPrivateMessageOrNull(fullParents) ?: getResolutionMessageOrNull(fullParents) ?: message
             }
+
             val filledText = parents.getFilledText()
-            addComment(messageKey, filledText).toFailedModuleEither().bind()
+
+            addComment(CommentOptions(messageKey, filledText)).toFailedModuleEither().bind()
         }
     }
 
-    private fun List<String>.getFilledText() = when (size) {
-        1 -> get(0)
-        2 -> "${get(0)}* and *${get(1)}"
-        else -> "${subList(0, lastIndex).joinToString("*, *")}*, and *${last()}"
+    private fun List<LinkedIssue>.getFilledText() = this
+        .map { it.key }
+        .run {
+            when (size) {
+                1 -> get(0)
+                2 -> "${get(0)}* and *${get(1)}"
+                else -> "${subList(0, lastIndex).joinToString("*, *")}*, and *${last()}"
+            }
+        }
+
+    private fun <V, F> List<V>.getCommonFieldOrNull(getField: (V) -> F?) =
+        if (this.any { getField(it) != getField(this[0]) }) {
+            null
+        } else {
+            getField(this[0])
+        }
+
+    private fun getPrivateMessageOrNull(issues: List<Issue>): String? {
+        val parentSecurity = issues.getCommonFieldOrNull { it.securityLevel }
+        return privateMessage.takeIf { parentSecurity != null }
     }
 
-    private fun assertNotAllMentionedBefore(comments: List<Comment>, parents: List<Link<*, *>>) =
-        assertNotEmpty(parents.filter { link -> comments.none { it.body.contains(link.issue.key) } })
+    private fun getResolutionMessageOrNull(issues: List<Issue>): String? {
+        val parentResolution = issues.getCommonFieldOrNull { it.resolution }
+        return resolutionMessages[parentResolution]
+    }
 
-    private fun isVisibleComment(comment: Comment) = comment.visibilityType == null
+    private fun assertNotAllMentionedBefore(comments: List<Comment>, parents: List<LinkedIssue>) =
+        assertNotEmpty(parents.filter(::hasNotBeenMentioned.partially1(comments)))
 
-    private fun isDuplicatesLink(link: Link<*, *>) =
+    private fun hasNotBeenMentioned(comments: List<Comment>, issue: LinkedIssue) =
+        comments.none { it.body.contains(issue.key) }
+
+    private fun isPublicComment(comment: Comment) =
+        comment.visibilityType == null
+
+    private fun isDuplicatesLink(link: Link) =
         link.type.toLowerCase() == "duplicate" && link.outwards
 }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/DuplicateMessageModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/DuplicateMessageModule.kt
@@ -1,0 +1,78 @@
+package io.github.mojira.arisa.modules
+
+import arrow.core.Either
+import arrow.core.extensions.fx
+import arrow.core.left
+import arrow.core.right
+import io.github.mojira.arisa.domain.Comment
+import io.github.mojira.arisa.domain.Link
+import io.github.mojira.arisa.domain.LinkedIssue
+
+class DuplicateMessageModule(
+    private val message: String,
+    private val privateMessage: String?,
+    private val resolutionMessages: Map<String, String?>?
+) : Module<DuplicateMessageModule.Request> {
+    data class Request(
+        val links: List<Link<String?, *>>,
+        val comments: List<Comment>,
+        val addComment: (key: String, filledText: String) -> Either<Throwable, Unit>
+    )
+
+    data class LinkedIssue(
+        val key: String,
+        val security: String?,
+        val resolution: String?
+    )
+
+    override fun invoke(request: Request): Either<ModuleError, ModuleResponse> = with(request) {
+        Either.fx {
+            val parents = links
+                .filter(::isDuplicatesLink)
+            assertNotEmpty(parents).bind()
+
+            val visibleComments = comments
+                .filter(::isVisibleComment)
+            assertNotAllMentionedBefore(visibleComments, parents).bind()
+
+            val parentSecurity = parents
+                .fold(parents[0].security) { parentSecurity, (_, security) ->
+                    if (parentSecurity == security) {
+                        parentSecurity
+                    } else {
+                        null
+                    }
+                }
+
+            val messageKey = if (parentSecurity != null) {
+                privateMessage
+            } else {
+                val parentResolution = parentPairs
+                    .fold(parentPairs[0].security) { parentSecurity, (ticket, security) ->
+                        ticket.
+                        if (parentSecurity == security) {
+                            parentSecurity
+                        } else {
+                            null
+                        }
+                    }
+            }
+            val filledText = parents.getFilledText()
+            addComment(messageKey, filledText).toFailedModuleEither().bind()
+        }
+    }
+
+    private fun List<String>.getFilledText() = when (size) {
+        1 -> get(0)
+        2 -> "${get(0)}* and *${get(1)}"
+        else -> "${subList(0, lastIndex).joinToString("*, *")}*, and *${last()}"
+    }
+
+    private fun assertNotAllMentionedBefore(comments: List<Comment>, parents: List<Link<*, *>>) =
+        assertNotEmpty(parents.filter { link -> comments.none { it.body.contains(link.issue.key) } })
+
+    private fun isVisibleComment(comment: Comment) = comment.visibilityType == null
+
+    private fun isDuplicatesLink(link: Link<*, *>) =
+        link.type.toLowerCase() == "duplicate" && link.outwards
+}

--- a/src/main/kotlin/io/github/mojira/arisa/modules/Module.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/Module.kt
@@ -36,8 +36,8 @@ fun Collection<Either<Throwable, Any>>.toFailedModuleEither(): Either<ModuleErro
     }
 }
 
-fun Either<OperationNotNeededModuleResponse, ModuleResponse>.invert(e: Either<OperationNotNeededModuleResponse, Unit>) =
-    if (e.isLeft()) {
+fun Either<OperationNotNeededModuleResponse, ModuleResponse>.invert() =
+    if (isLeft()) {
         Unit.right()
     } else {
         OperationNotNeededModuleResponse.left()

--- a/src/test/kotlin/io/github/mojira/arisa/infrastructure/IntegrationTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/infrastructure/IntegrationTest.kt
@@ -29,6 +29,13 @@ class IntegrationTest : StringSpec({
         val helperMessages = helperMessagesFile.getHelperMessages()
 
         with(helperMessages.messages) {
+            this shouldContainKey "duplicate"
+            this shouldContainKey "duplicate-fixed"
+            this shouldContainKey "duplicate-of-mc-297"
+            this shouldContainKey "duplicate-of-mc-128302"
+            this shouldContainKey "duplicate-of-mcl-5638"
+            this shouldContainKey "duplicate-private"
+            this shouldContainKey "duplicate-wai"
             this shouldContainKey "pirated-minecraft"
             this shouldContainKey "provide-affected-versions"
             this shouldContainKey "incomplete"

--- a/src/test/kotlin/io/github/mojira/arisa/modules/DuplicateMessageModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/DuplicateMessageModuleTest.kt
@@ -1,0 +1,578 @@
+package io.github.mojira.arisa.modules
+
+import arrow.core.left
+import arrow.core.right
+import io.github.mojira.arisa.domain.CommentOptions
+import io.github.mojira.arisa.utils.RIGHT_NOW
+import io.github.mojira.arisa.utils.mockComment
+import io.github.mojira.arisa.utils.mockIssue
+import io.github.mojira.arisa.utils.mockLink
+import io.github.mojira.arisa.utils.mockLinkedIssue
+import io.kotest.assertions.arrow.either.shouldBeLeft
+import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+class DuplicateMessageModuleTest : StringSpec({
+    val module = DuplicateMessageModule(
+        "duplicate",
+        mapOf("MC-297" to "duplicate-of-mc-297"),
+        "duplicate-private",
+        mapOf("Fixed" to "duplicate-fixed")
+    )
+
+    "should return OperationNotNeededModuleResponse when the issue has no links" {
+        val issue = mockIssue()
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when the issue has no duplicate links" {
+        val issue = mockIssue(
+            links = listOf(
+                mockLink(
+                    type = "Relates"
+                )
+            )
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when the issue has no outward duplicate links" {
+        val issue = mockIssue(
+            links = listOf(
+                mockLink(
+                    outwards = false
+                )
+            )
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when the parent has been mentioned in a public comment" {
+        val issue = mockIssue(
+            links = listOf(
+                mockLink()
+            ),
+            comments = listOf(
+                mockComment(
+                    body = "This duplicates MC-1."
+                )
+            )
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when all the parents have been mentioned in a public comment" {
+        val issue = mockIssue(
+            links = listOf(
+                mockLink(),
+                mockLink(
+                    issue = mockLinkedIssue(
+                        key = "MC-2"
+                    )
+                )
+            ),
+            comments = listOf(
+                mockComment(
+                    body = "This duplicates MC-1 and MC-2."
+                )
+            )
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when all the parents have been mentioned in different public comments" {
+        val issue = mockIssue(
+            links = listOf(
+                mockLink(),
+                mockLink(
+                    issue = mockLinkedIssue(
+                        key = "MC-2"
+                    )
+                )
+            ),
+            comments = listOf(
+                mockComment(
+                    body = "This duplicates MC-1."
+                ),
+                mockComment(
+                    body = "This duplicates MC-2."
+                )
+            )
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should add comment when the parent hasn't been mentioned anywhere" {
+        var commentOptions: CommentOptions? = null
+        val issue = mockIssue(
+            links = listOf(
+                mockLink()
+            ),
+            addComment = { commentOptions = it; Unit.right() }
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight(ModuleResponse)
+        commentOptions shouldBe CommentOptions("duplicate", "MC-1")
+    }
+
+    "should add comment when the parent has only been mentioned in an restricted comment" {
+        var commentOptions: CommentOptions? = null
+        val issue = mockIssue(
+            links = listOf(
+                mockLink()
+            ),
+            comments = listOf(
+                mockComment(
+                    body = "MC-1",
+                    visibilityType = "group",
+                    visibilityValue = "helper"
+                )
+            ),
+            addComment = { commentOptions = it; Unit.right() }
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight(ModuleResponse)
+        commentOptions shouldBe CommentOptions("duplicate", "MC-1")
+    }
+
+    "should add comment when only a portion of parents have been mentioned in public comments" {
+        var commentOptions: CommentOptions? = null
+        val issue = mockIssue(
+            links = listOf(
+                mockLink(),
+                mockLink(
+                    issue = mockLinkedIssue(
+                        key = "MC-2"
+                    )
+                )
+            ),
+            comments = listOf(
+                mockComment(
+                    body = "This duplicates MC-1."
+                )
+            ),
+            addComment = { commentOptions = it; Unit.right() }
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight(ModuleResponse)
+        commentOptions shouldBe CommentOptions("duplicate", "MC-1* and *MC-2")
+    }
+
+    "should add comment with all three parents' keys in ascending order" {
+        var commentOptions: CommentOptions? = null
+        val issue = mockIssue(
+            links = listOf(
+                mockLink(),
+                mockLink(
+                    issue = mockLinkedIssue(
+                        key = "MC-3"
+                    )
+                ),
+                mockLink(
+                    issue = mockLinkedIssue(
+                        key = "MC-2"
+                    )
+                )
+            ),
+            addComment = { commentOptions = it; Unit.right() }
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight(ModuleResponse)
+        commentOptions shouldBe CommentOptions("duplicate", "MC-1*, *MC-2*, and *MC-3")
+    }
+
+    "should add the comment for specific ticket when there's only one parent" {
+        var commentOptions: CommentOptions? = null
+        val issue = mockIssue(
+            links = listOf(
+                mockLink(
+                    issue = mockLinkedIssue(
+                        key = "MC-297"
+                    )
+                )
+            ),
+            addComment = { commentOptions = it; Unit.right() }
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight(ModuleResponse)
+        commentOptions shouldBe CommentOptions("duplicate-of-mc-297", "MC-297")
+    }
+
+    "should add the normal comment even if one of the parents is a special ticket" {
+        var commentOptions: CommentOptions? = null
+        val issue = mockIssue(
+            links = listOf(
+                mockLink(),
+                mockLink(
+                    issue = mockLinkedIssue(
+                        key = "MC-297"
+                    )
+                )
+            ),
+            addComment = { commentOptions = it; Unit.right() }
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight(ModuleResponse)
+        commentOptions shouldBe CommentOptions("duplicate", "MC-1* and *MC-297")
+    }
+
+    "should add the comment for private parent when the only parent is private" {
+        var commentOptions: CommentOptions? = null
+        val issue = mockIssue(
+            links = listOf(
+                mockLink(
+                    issue = mockLinkedIssue(
+                        key = "MC-1",
+                        getFullIssue = {
+                            mockIssue(
+                                securityLevel = "private"
+                            ).right()
+                        }
+                    )
+                )
+            ),
+            addComment = { commentOptions = it; Unit.right() }
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight(ModuleResponse)
+        commentOptions shouldBe CommentOptions("duplicate-private", "MC-1")
+    }
+
+    "should add the comment for private parents when all parents are private" {
+        var commentOptions: CommentOptions? = null
+        val issue = mockIssue(
+            links = listOf(
+                mockLink(
+                    issue = mockLinkedIssue(
+                        key = "MC-1",
+                        getFullIssue = {
+                            mockIssue(
+                                securityLevel = "private"
+                            ).right()
+                        }
+                    )
+                ),
+                mockLink(
+                    issue = mockLinkedIssue(
+                        key = "MC-2",
+                        getFullIssue = {
+                            mockIssue(
+                                securityLevel = "private"
+                            ).right()
+                        }
+                    )
+                )
+            ),
+            addComment = { commentOptions = it; Unit.right() }
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight(ModuleResponse)
+        commentOptions shouldBe CommentOptions("duplicate-private", "MC-1* and *MC-2")
+    }
+
+    "should add the normal comment even if portion of the parents are private" {
+        var commentOptions: CommentOptions? = null
+        val issue = mockIssue(
+            links = listOf(
+                mockLink(),
+                mockLink(
+                    issue = mockLinkedIssue(
+                        key = "MC-2",
+                        getFullIssue = {
+                            mockIssue(
+                                securityLevel = "private"
+                            ).right()
+                        }
+                    )
+                )
+            ),
+            addComment = { commentOptions = it; Unit.right() }
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight(ModuleResponse)
+        commentOptions shouldBe CommentOptions("duplicate", "MC-1* and *MC-2")
+    }
+
+    "should add the normal comment if there's no special message for private parents" {
+        val module = DuplicateMessageModule(
+            "duplicate",
+            mapOf("MC-297" to "duplicate-of-mc-297"),
+            null,
+            mapOf("Fixed" to "duplicate-fixed")
+
+        )
+        var commentOptions: CommentOptions? = null
+        val issue = mockIssue(
+            links = listOf(
+                mockLink(
+                    issue = mockLinkedIssue(
+                        key = "MC-1",
+                        getFullIssue = {
+                            mockIssue(
+                                securityLevel = "private"
+                            ).right()
+                        }
+                    )
+                )
+            ),
+            addComment = { commentOptions = it; Unit.right() }
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight(ModuleResponse)
+        commentOptions shouldBe CommentOptions("duplicate", "MC-1")
+    }
+
+    "should add the comment for specific resolution when the only parent has that resolution" {
+        var commentOptions: CommentOptions? = null
+        val issue = mockIssue(
+            links = listOf(
+                mockLink(
+                    issue = mockLinkedIssue(
+                        key = "MC-1",
+                        getFullIssue = {
+                            mockIssue(
+                                resolution = "Fixed"
+                            ).right()
+                        }
+                    )
+                )
+            ),
+            addComment = { commentOptions = it; Unit.right() }
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight(ModuleResponse)
+        commentOptions shouldBe CommentOptions("duplicate-fixed", "MC-1")
+    }
+
+    "should add the comment for specific resolution when all parents have the same resolution" {
+        var commentOptions: CommentOptions? = null
+        val issue = mockIssue(
+            links = listOf(
+                mockLink(
+                    issue = mockLinkedIssue(
+                        key = "MC-1",
+                        getFullIssue = {
+                            mockIssue(
+                                resolution = "Fixed"
+                            ).right()
+                        }
+                    )
+                ),
+                mockLink(
+                    issue = mockLinkedIssue(
+                        key = "MC-2",
+                        getFullIssue = {
+                            mockIssue(
+                                resolution = "Fixed"
+                            ).right()
+                        }
+                    )
+                )
+            ),
+            addComment = { commentOptions = it; Unit.right() }
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight(ModuleResponse)
+        commentOptions shouldBe CommentOptions("duplicate-fixed", "MC-1* and *MC-2")
+    }
+
+    "should add the normal comment even if portion of the parents have the special resolution" {
+        var commentOptions: CommentOptions? = null
+        val issue = mockIssue(
+            links = listOf(
+                mockLink(),
+                mockLink(
+                    issue = mockLinkedIssue(
+                        key = "MC-2",
+                        getFullIssue = {
+                            mockIssue(
+                                resolution = "Fixed"
+                            ).right()
+                        }
+                    )
+                )
+            ),
+            addComment = { commentOptions = it; Unit.right() }
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight(ModuleResponse)
+        commentOptions shouldBe CommentOptions("duplicate", "MC-1* and *MC-2")
+    }
+
+    "should add the normal comment if there's no special message for the resolution" {
+        var commentOptions: CommentOptions? = null
+        val issue = mockIssue(
+            links = listOf(
+                mockLink(
+                    issue = mockLinkedIssue(
+                        key = "MC-1",
+                        getFullIssue = {
+                            mockIssue(
+                                resolution = "Invalid"
+                            ).right()
+                        }
+                    )
+                )
+            ),
+            addComment = { commentOptions = it; Unit.right() }
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight(ModuleResponse)
+        commentOptions shouldBe CommentOptions("duplicate", "MC-1")
+    }
+
+    "should add the comment for specific parent instead of the comment for private parents" {
+        var commentOptions: CommentOptions? = null
+        val issue = mockIssue(
+            links = listOf(
+                mockLink(
+                    issue = mockLinkedIssue(
+                        key = "MC-297",
+                        getFullIssue = {
+                            mockIssue(
+                                securityLevel = "private"
+                            ).right()
+                        }
+                    )
+                )
+            ),
+            addComment = { commentOptions = it; Unit.right() }
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight(ModuleResponse)
+        commentOptions shouldBe CommentOptions("duplicate-of-mc-297", "MC-297")
+    }
+
+    "should add the comment for private instead of the comment for specific resolution" {
+        var commentOptions: CommentOptions? = null
+        val issue = mockIssue(
+            links = listOf(
+                mockLink(
+                    issue = mockLinkedIssue(
+                        key = "MC-1",
+                        getFullIssue = {
+                            mockIssue(
+                                securityLevel = "private",
+                                resolution = "Fixed"
+                            ).right()
+                        }
+                    )
+                )
+            ),
+            addComment = { commentOptions = it; Unit.right() }
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight(ModuleResponse)
+        commentOptions shouldBe CommentOptions("duplicate-private", "MC-1")
+    }
+
+    "should return FailedModuleResponse when adding comments fails" {
+        val issue = mockIssue(
+            links = listOf(
+                mockLink()
+            ),
+            addComment = { RuntimeException().left() }
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft()
+        result.a should { it is FailedModuleResponse }
+        (result.a as FailedModuleResponse).exceptions.size shouldBe 1
+    }
+
+    "should return FailedModuleResponse when getting an issue fails" {
+        val issue = mockIssue(
+            links = listOf(
+                mockLink(
+                    issue = mockLinkedIssue(
+                        getFullIssue = { RuntimeException().left() }
+                    )
+                )
+            )
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft()
+        result.a should { it is FailedModuleResponse }
+        (result.a as FailedModuleResponse).exceptions.size shouldBe 1
+    }
+
+    "should return FailedModuleResponse with all errors when getting an issue fails" {
+        val issue = mockIssue(
+            links = listOf(
+                mockLink(
+                    issue = mockLinkedIssue(
+                        key = "MC-1",
+                        getFullIssue = { RuntimeException().left() }
+                    )
+                ),
+                mockLink(
+                    issue = mockLinkedIssue(
+                        key = "MC-2",
+                        getFullIssue = { RuntimeException().left() }
+                    )
+                )
+            )
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft()
+        result.a should { it is FailedModuleResponse }
+        (result.a as FailedModuleResponse).exceptions.size shouldBe 2
+    }
+})

--- a/src/test/kotlin/io/github/mojira/arisa/modules/DuplicateMessageModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/DuplicateMessageModuleTest.kt
@@ -337,7 +337,6 @@ class DuplicateMessageModuleTest : StringSpec({
             mapOf("MC-297" to "duplicate-of-mc-297"),
             null,
             mapOf("Fixed" to "duplicate-fixed")
-
         )
         var commentOptions: CommentOptions? = null
         val issue = mockIssue(


### PR DESCRIPTION
## Purpose
Resolve #116.
## Approach
After merging this PR, we will be able to make Arisa send different duplicate messages for tickets with normal parents, private parents, parents with specific resolutions, and specific parents. Arisa will not send the message only if all of the parent keys have been mentioned publicly in former comments.
## Future work

#### Checklist
- [x] Included tests
- [ ] Tested in MCTEST-xxx
