### PR TITLE
Add global-moderators to staff groups in RemoveNonStaffMeqsModule

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/RemoveNonStaffMeqsModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RemoveNonStaffMeqsModule.kt
@@ -24,7 +24,7 @@ class RemoveNonStaffMeqsModule(private val removalReason: String) : Module {
         comment.body?.contains("""MEQS_[A-Z_]+""".toRegex()) ?: false
 
     private fun isNotStaffRestricted(comment: Comment) =
-        comment.visibilityType != "group" || comment.visibilityValue != "staff"
+        comment.visibilityType != "group" || !listOf("staff", "global-moderators").contains(comment.visibilityValue)
 
     private fun removeMeqsTags(comment: String): String {
         val regex = """MEQS(_[A-Z_]+)""".toRegex()

--- a/src/test/kotlin/io/github/mojira/arisa/modules/RemoveNonStaffMeqsModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/RemoveNonStaffMeqsModuleTest.kt
@@ -51,6 +51,22 @@ class RemoveNonStaffMeqsModuleTest : StringSpec({
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
+    "should return OperationNotNeededModuleResponse for a global-moderators restricted comment" {
+        val module = RemoveNonStaffMeqsModule("")
+        val comment = mockComment(
+            body = "MEQS_WAI I like QC.",
+            visibilityType = "group",
+            visibilityValue = "global-moderators"
+        )
+        val issue = mockIssue(
+            comments = listOf(comment)
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
     "should return OperationNotNeededModuleResponse if MEQS is not part of a tag" {
         val module = RemoveNonStaffMeqsModule("")
         val comment = mockComment(


### PR DESCRIPTION
## Purpose
Fix #283.

## Approach
Simply added `global-moderators` to the list of allowed groups.

## Future work
Make groups configurable. Not really necessary though since these groups shouldn't really change.

#### Checklist
- [X] Included tests
- [ ] Tested in MCTEST-xxx
