### PR TITLE
Handle variables containing other variables

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/HelperMessages.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/HelperMessages.kt
@@ -104,10 +104,19 @@ data class HelperMessages(
             value
         }
 
-    private fun resolveVariables(message: String, project: String, lang: String): String {
-        return variables.entries.fold(message) { msg, (key, list) ->
-            val variable = list.find { isProjectMatch(project, it.project) }
-            msg.replace("%$key%", localizeValue(variable?.value ?: "", variable?.localizedValues, lang))
+    private fun resolveVariables(message: String, project: String, lang: String, limit: Int = 10): String {
+        return if (limit == 0) {
+            message
+        } else {
+            variables.entries.fold(message) { msg, (key, list) ->
+                val variable = list.find { isProjectMatch(project, it.project) }
+                val variableValue = localizeValue(variable?.value ?: "", variable?.localizedValues, lang)
+                if (msg.contains("%$key%")) {
+                    msg.replace("%$key%", resolveVariables(variableValue, project, lang, limit - 1))
+                } else {
+                    msg
+                }
+            }
         }
     }
 

--- a/src/test/kotlin/io/github/mojira/arisa/infrastructure/HelperMessagesTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/infrastructure/HelperMessagesTest.kt
@@ -23,6 +23,36 @@ class HelperMessagesTest : StringSpec({
                         "project": "mcd",
                         "value": "variable for MCD"
                     }
+                ],
+                "varception0": [
+                    {
+                        "project": "mctest",
+                        "value": "0"
+                    }
+                ],
+                "varception1": [
+                    {
+                        "project": "mctest",
+                        "value": "1 %varception0%"
+                    }
+                ],
+                "varception2": [
+                    {
+                        "project": "mctest",
+                        "value": "2 %varception1%"
+                    }
+                ],
+                "varception3": [
+                    {
+                        "project": "mctest",
+                        "value": "3 %varception2%"
+                    }
+                ],
+                "infinite_loop": [
+                    {
+                        "project": "mctest",
+                        "value": ".%infinite_loop%"
+                    }
                 ]
             },
             "messages": {
@@ -72,6 +102,22 @@ class HelperMessagesTest : StringSpec({
                         "localizedMessages": {
                             "ab": "~{color:#888}-- A ba b aba.{color}~"
                         },
+                        "fillname": []
+                    }
+                ],
+                "infinite-loop": [
+                    {
+                        "project": ["mctest"],
+                        "name": "Infinite Loop",
+                        "message": "%infinite_loop%",
+                        "fillname": []
+                    }
+                ],
+                "varception": [
+                    {
+                        "project": ["mctest"],
+                        "name": "Varception",
+                        "message": "%varception3%",
                         "fillname": []
                     }
                 ]
@@ -129,6 +175,20 @@ class HelperMessagesTest : StringSpec({
 
         result.shouldBeRight()
         result.b shouldBe "With "
+    }
+
+    "should be able to handle variables containing other variables" {
+        val result = messages.getSingleMessage("MCTEST", "varception")
+
+        result.shouldBeRight()
+        result.b shouldBe "3 2 1 0"
+    }
+
+    "should not get caught in an infinite loop when a variable contains itself" {
+        val result = messages.getSingleMessage("MCTEST", "infinite-loop")
+
+        result.shouldBeRight()
+        result.b shouldBe "..........%infinite_loop%"
     }
 
     "should replace the placeholder with filled text" {


### PR DESCRIPTION
## Purpose
Fix #282 by expecting variables to contain other variables.

## Approach
When resolving a variable, the replacement text is thrown again into the `resolveVariables` function in order to find and replace other variables. This happens up to 10 times. Depending on how complicated the variables are, this might lead to a significant speed decrease, but I expect the helper message variables to be rather sane.

## Future work
I don't think variables should become even more complicated lol

#### Checklist
- [X] Included tests
- [ ] Tested in MCTEST-xxx
