### PR TITLE
Add test for Module Registry

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
     testImplementation("io.kotest", "kotest-runner-junit5", kotestVersion)
     testImplementation("io.kotest", "kotest-assertions-arrow", kotestVersion)
     testImplementation("io.mockk", "mockk", "1.9.3")
+    testImplementation("org.reflections", "reflections", "0.9.12")
 }
 
 tasks {
@@ -69,7 +70,8 @@ tasks {
 
     test {
         useJUnitPlatform()
-        maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).takeIf { it > 0 } ?: 1 // Run with same number of cores
+        maxParallelForks =
+            (Runtime.getRuntime().availableProcessors() / 2).takeIf { it > 0 } ?: 1 // Run with same number of cores
         reports.html.isEnabled = false
         reports.junitXml.isEnabled = false
     }

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
@@ -42,7 +42,7 @@ class ModuleExecutor(
             do {
                 missingResultsPage = false
 
-                registry.getModules(config).forEach { (config, getJql, exec) ->
+                registry.getModules().forEach { (_, config, getJql, exec) ->
                     executeModule(
                         config,
                         queryCache,

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -72,7 +72,7 @@ class ModuleRegistry(private val config: Config) {
     ) = { issue: Issue, lastRun: Instant ->
         config::class.simpleName!! to
                 ({ lastRun pipe (issue pipe2 module::invoke) } pipe ::tryExecuteModule)
-    } pipe (getJql pipe2 (config pipe3 (config::class.java.simpleName pipe4 ModuleRegistry::Entry))) pipe modules::add
+    } pipe (getJql pipe2 (config pipe3 (config::class.simpleName!! pipe4 ModuleRegistry::Entry))) pipe modules::add
 
     @Suppress("TooGenericExceptionCaught")
     private fun tryExecuteModule(executeModule: () -> Either<ModuleError, ModuleResponse>) = try {

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -6,6 +6,7 @@ import arrow.syntax.function.partially1
 import arrow.syntax.function.pipe
 import arrow.syntax.function.pipe2
 import arrow.syntax.function.pipe3
+import arrow.syntax.function.pipe4
 import com.uchuhimo.konf.Config
 import io.github.mojira.arisa.domain.Issue
 import io.github.mojira.arisa.infrastructure.config.Arisa.Credentials
@@ -46,6 +47,7 @@ val DEFAULT_JQL = { lastRun: Instant -> "updated > ${lastRun.toEpochMilli()}" }
 
 class ModuleRegistry(private val config: Config) {
     data class Entry(
+        val name: String,
         val config: ModuleConfigSpec,
         val getJql: (lastRun: Instant) -> String,
         val execute: (issue: Issue, lastRun: Instant) -> Pair<String, Either<ModuleError, ModuleResponse>>
@@ -53,7 +55,7 @@ class ModuleRegistry(private val config: Config) {
 
     private val modules = mutableListOf<Entry>()
 
-    fun getModules(config: Config): List<Entry> {
+    fun getModules(): List<Entry> {
         val onlyModules = modules
             .filter { config[it.config.only] }
         return if (onlyModules.isEmpty()) {
@@ -70,7 +72,7 @@ class ModuleRegistry(private val config: Config) {
     ) = { issue: Issue, lastRun: Instant ->
         config::class.simpleName!! to
                 ({ lastRun pipe (issue pipe2 module::invoke) } pipe ::tryExecuteModule)
-    } pipe (getJql pipe2 (config pipe3 ModuleRegistry::Entry)) pipe modules::add
+    } pipe (getJql pipe2 (config pipe3 (config::class.java.simpleName pipe4 ModuleRegistry::Entry))) pipe modules::add
 
     @Suppress("TooGenericExceptionCaught")
     private fun tryExecuteModule(executeModule: () -> Either<ModuleError, ModuleResponse>) = try {

--- a/src/test/kotlin/io/github/mojira/arisa/ModuleRegistryTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/ModuleRegistryTest.kt
@@ -29,7 +29,7 @@ class ModuleRegistryTest : StringSpec({
         modules.size shouldBe 1
     }
 
-    "should register a module for each file ending in Module" {
+    "should register a module for each non-abstract module" {
         val classes = Reflections("io.github.mojira.arisa.modules")
             .getSubTypesOf(Module::class.java)
             .map { it.simpleName }

--- a/src/test/kotlin/io/github/mojira/arisa/ModuleRegistryTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/ModuleRegistryTest.kt
@@ -1,0 +1,49 @@
+package io.github.mojira.arisa
+
+import com.uchuhimo.konf.Config
+import io.github.mojira.arisa.infrastructure.config.Arisa
+import io.github.mojira.arisa.modules.Module
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import org.reflections.Reflections
+
+class ModuleRegistryTest : StringSpec({
+    "should register a module for each config class" {
+        val modules = ModuleRegistry(getConfig()).getModules().map { it.name }
+        val configs = Arisa.Modules::class.java.classes.map { it.simpleName }.filter { !it.endsWith("Spec") }
+        println("Configs not mapped to a registered module " + configs.filter { !modules.contains(it) })
+        println("Registered modules not mapped to a config " + modules.filter { !configs.contains(it) })
+        configs shouldContainExactlyInAnyOrder modules
+    }
+
+    "should get only get a module with only" {
+        val modules = ModuleRegistry(getConfig(true)).getModules()
+        modules.size shouldBe 1
+    }
+
+    "should register a module for each file ending in Module" {
+        val classes = Reflections("io.github.mojira.arisa.modules")
+            .getSubTypesOf(Module::class.java)
+            .map { it.simpleName }
+            .filter { !it.startsWith("Abstract") }
+            .map { it.replace("Module", "") }
+        val modules = ModuleRegistry(getConfig()).getModules()
+            .map { it.name }
+
+        println("Classes not mapped to a registered module " + classes.filter { !modules.contains(it) })
+        println("Registered modules not mapped to a class " + modules.filter { !classes.contains(it) })
+        classes shouldContainExactlyInAnyOrder modules
+    }
+})
+
+private fun getConfig(only: Boolean = false) = Config { addSpec(Arisa) }
+    .from.json.watchFile("arisa.json")
+    .from.map.flat(
+        mapOf(
+            "arisa.modules.attachment.only" to only.toString(),
+            "arisa.credentials.username" to "test",
+            "arisa.credentials.password" to "test",
+            "arisa.credentials.dandelionToken" to "test"
+        )
+    )

--- a/src/test/kotlin/io/github/mojira/arisa/ModuleRegistryTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/ModuleRegistryTest.kt
@@ -17,6 +17,13 @@ class ModuleRegistryTest : StringSpec({
         configs shouldContainExactlyInAnyOrder modules
     }
 
+    "should register max 1 time each config" {
+        val modules = ModuleRegistry(getConfig()).getModules().map { it.config.prefix }
+        val uniqueModules = modules.distinct()
+        println("Not unique modules " + modules.filter { !uniqueModules.contains(it) })
+        uniqueModules shouldContainExactlyInAnyOrder modules
+    }
+
     "should get only get a module with only" {
         val modules = ModuleRegistry(getConfig(true)).getModules()
         modules.size shouldBe 1


### PR DESCRIPTION
## Purpose
Tests the module registry to make sure we dont forget a module
## Approach
Check that we have a registered module per config
Check that we have a registered module per module class
Check that the configs are used by only 1 module to prevent us forgetting from using the correct config