### PR TITLE
Fix #118

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -56,8 +56,14 @@
           "run",
           "lnk",
           "dmg",
-          "url"
-        ]
+          "url",
+          "pdf",
+          "doc",
+          "docx",
+          "odt",
+          "rtf"
+        ],
+        "message": "attach-new-attachment"
       },
       "duplicateMessage": {
         "resolutions": [

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -81,7 +81,8 @@ class ModuleRegistry(private val config: Config) {
 
     init {
         register(
-            Modules.Attachment, AttachmentModule(config[Modules.Attachment.extensionBlacklist])
+            Modules.Attachment,
+            AttachmentModule(config[Modules.Attachment.extensionBlacklist], config[Modules.Attachment.comment])
         )
 
         register(Modules.CHK, CHKModule())

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
@@ -71,6 +71,10 @@ object Arisa : ConfigSpec() {
                 emptyList<String>(),
                 description = "The extensions that should be removed on issues. Default is no extensions."
             )
+            val comment by optional(
+                "",
+                description = "The key of the message that is posted when this module succeeds."
+            )
         }
 
         object DuplicateMessage : ModuleConfigSpec() {

--- a/src/main/kotlin/io/github/mojira/arisa/modules/AttachmentModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/AttachmentModule.kt
@@ -3,11 +3,13 @@ package io.github.mojira.arisa.modules
 import arrow.core.Either
 import arrow.core.extensions.fx
 import arrow.syntax.function.partially1
+import io.github.mojira.arisa.domain.CommentOptions
 import io.github.mojira.arisa.domain.Issue
 import java.time.Instant
 
 class AttachmentModule(
-    private val extensionBlackList: List<String>
+    private val extensionBlackList: List<String>,
+    private val attachmentRemovedMessage: String
 ) : Module {
 
     override fun invoke(issue: Issue, lastRun: Instant): Either<ModuleError, ModuleResponse> = with(issue) {
@@ -18,6 +20,7 @@ class AttachmentModule(
                 .map { it.remove }
             assertNotEmpty(functions).bind()
             tryRunAll(functions).bind()
+            addComment(CommentOptions(attachmentRemovedMessage)).toFailedModuleEither().bind()
         }
     }
 

--- a/src/test/kotlin/io/github/mojira/arisa/infrastructure/IntegrationTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/infrastructure/IntegrationTest.kt
@@ -29,6 +29,7 @@ class IntegrationTest : StringSpec({
         val helperMessages = helperMessagesFile.getHelperMessages()
 
         with(helperMessages.messages) {
+            this shouldContainKey "attach-new-attachment"
             this shouldContainKey "duplicate"
             this shouldContainKey "duplicate-fixed"
             this shouldContainKey "duplicate-of-mc-297"

--- a/src/test/kotlin/io/github/mojira/arisa/modules/AttachmentModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/AttachmentModuleTest.kt
@@ -17,7 +17,7 @@ private val NOW = Instant.now()
 class AttachmentModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when there is no attachments" {
-        val module = AttachmentModule(emptyList())
+        val module = AttachmentModule(emptyList(), "attach-new-attachment")
         val issue = mockIssue()
 
         val result = module(issue, NOW)
@@ -26,7 +26,7 @@ class AttachmentModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse when there is no blacklisted attachments" {
-        val module = AttachmentModule(listOf(".test"))
+        val module = AttachmentModule(listOf(".test"), "attach-new-attachment")
         val attachment = getAttachment(
             name = "testfile"
         )
@@ -40,7 +40,7 @@ class AttachmentModuleTest : StringSpec({
     }
 
     "should return FailedModuleResponse when deleting fails" {
-        val module = AttachmentModule(listOf(".test"))
+        val module = AttachmentModule(listOf(".test"), "attach-new-attachment")
         val attachment = getAttachment(
             remove = { RuntimeException().left() }
         )
@@ -56,7 +56,7 @@ class AttachmentModuleTest : StringSpec({
     }
 
     "should return FailedModuleResponse with all exceptions when deleting fails" {
-        val module = AttachmentModule(listOf(".test"))
+        val module = AttachmentModule(listOf(".test"), "attach-new-attachment")
         val attachment = getAttachment(
             remove = { RuntimeException().left() }
         )
@@ -72,7 +72,7 @@ class AttachmentModuleTest : StringSpec({
     }
 
     "should return ModuleResponse when something is deleted successfully" {
-        val module = AttachmentModule(listOf(".test"))
+        val module = AttachmentModule(listOf(".test"), "attach-new-attachment")
         val attachment = getAttachment()
         val issue = mockIssue(
             attachments = listOf(attachment)


### PR DESCRIPTION
## Purpose
Fix #118
## Approach
Adds a comment when the user attaches a file with an invalid extension, adds common doc formats to the blacklist
Requires https://github.com/mojira/helper-messages/pull/70 to be merged
## Future work

#### Checklist
- [ ] Included tests
- [ ] Tested in MCTEST-xxx
