### PR TITLE
Fix issue changes aren't applied

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/ArisaMain.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ArisaMain.kt
@@ -52,7 +52,7 @@ fun main() {
     val failedTickets = mutableSetOf<String>()
 
     val queryCache = Cache<List<Issue>>()
-    val issueUpdateContextCache = Cache<Lazy<IssueUpdateContext>>()
+    val issueUpdateContextCache = Cache<IssueUpdateContext>()
 
     val helperMessagesFile = File("helper-messages.json")
     val helperMessagesInterval = config[Arisa.HelperMessages.updateIntervalSeconds]

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/Cache.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/Cache.kt
@@ -15,4 +15,4 @@ open class Cache<V> {
     }
 }
 
-typealias IssueUpdateContextCache = Cache<Lazy<IssueUpdateContext>>
+typealias IssueUpdateContextCache = Cache<IssueUpdateContext>

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
@@ -53,22 +53,16 @@ fun JiraVersion.toDomain(jiraClient: JiraClient, issue: JiraIssue, cache: IssueU
     ::removeAffectedVersion.partially1(issue.getUpdateContext(jiraClient, cache)).partially1(this)
 )
 
-fun JiraIssue.getUpdateContext(jiraClient: JiraClient, cache: IssueUpdateContextCache): Lazy<IssueUpdateContext> {
-    var context = cache.get(key)
-    if (context == null) {
-        context = lazy {
-            IssueUpdateContext(
-                jiraClient,
-                this,
-                update(),
-                transition(),
-                transition()
-            )
-        }
-        cache.add(key, context)
+fun JiraIssue.getUpdateContext(jiraClient: JiraClient, cache: IssueUpdateContextCache): Lazy<IssueUpdateContext> =
+    lazy {
+        cache.get(key) ?: IssueUpdateContext(
+            jiraClient,
+            this,
+            update(),
+            transition(),
+            transition()
+        ).also { cache.add(key, it) }
     }
-    return context
-}
 
 @Suppress("LongMethod")
 fun JiraIssue.toDomain(


### PR DESCRIPTION
## Purpose
Fix issue changes made by modules other than the first one aren't applied.
## Approach
Changes made by modules other than the first one are ignored because the `IssueUpdateContextCache` is cleared in `executeModule`.

This PR moves the process of adding new context to the cache to the returned `Lazy`, so that even if the cache is cleared the context will always be added back to the cache, therefore changes made by other modules won't be ignored
## Future work
Merge #299 after this PR is merged.
#### Checklist
- [ ] Included tests
- [ ] Tested in MCTEST-xxx
