### PR TITLE
No longer remove future versions added by staff

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/domain/ChangeLogItem.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/domain/ChangeLogItem.kt
@@ -6,7 +6,9 @@ data class ChangeLogItem(
     val created: Instant,
     val field: String,
     val changedFrom: String?,
+    val changedFromString: String?,
     val changedTo: String?,
+    val changedToString: String?,
     val author: User,
     val getAuthorGroups: () -> List<String>?
 )

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
@@ -186,7 +186,9 @@ fun JiraIssueLink.toDomain(
 fun JiraChangeLogItem.toDomain(jiraClient: JiraClient, entry: JiraChangeLogEntry) = ChangeLogItem(
     entry.created.toInstant(),
     field,
+    from,
     fromString,
+    to,
     toString,
     entry.author.toDomain(),
     ::getUserGroups.partially1(jiraClient).partially1(entry.author.name)

--- a/src/main/kotlin/io/github/mojira/arisa/modules/DuplicateMessageModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/DuplicateMessageModule.kt
@@ -63,7 +63,7 @@ class DuplicateMessageModule(
     }
 
     private fun isAddingDuplicateLink(item: ChangeLogItem) = item.field == "Link" &&
-            item.changedTo != null && item.changedTo.startsWith("This issue duplicates ")
+            item.changedToString != null && item.changedToString.startsWith("This issue duplicates ")
 
     private fun List<LinkedIssue>.getFilledText() = this
         .map { it.key }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/FutureVersionModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/FutureVersionModule.kt
@@ -3,6 +3,7 @@ package io.github.mojira.arisa.modules
 import arrow.core.Either
 import arrow.core.extensions.fx
 import arrow.syntax.function.complement
+import io.github.mojira.arisa.domain.ChangeLogItem
 import io.github.mojira.arisa.domain.Issue
 import io.github.mojira.arisa.domain.Version
 import io.github.mojira.arisa.domain.CommentOptions
@@ -13,8 +14,10 @@ class FutureVersionModule(
 ) : Module {
     override fun invoke(issue: Issue, lastRun: Instant): Either<ModuleError, ModuleResponse> = with(issue) {
         Either.fx {
+            val addedVersions = getLatelyAddedVersions(lastRun)
             val removeFutureVersions = affectedVersions
                 .filter(::isFutureVersion)
+                .filter { it.id in addedVersions }
                 .map { it.remove }
             assertNotEmpty(removeFutureVersions).bind()
 
@@ -26,6 +29,16 @@ class FutureVersionModule(
             addComment(CommentOptions(message)).toFailedModuleEither().bind()
             resolveAsAwaitingResponse().toFailedModuleEither().bind()
         }
+    }
+
+    private fun Issue.getLatelyAddedVersions(lastRun: Instant): List<String> {
+        return changeLog
+            .asSequence()
+            .filter { it.created.isAfter(lastRun) }
+            .filter { it.field.toLowerCase() == "version" }
+            .filterNot { "staff" in (it.getAuthorGroups() ?: emptyList()) }
+            .mapNotNull { it.changedTo }
+            .toList()
     }
 
     private fun isFutureVersion(version: Version) =

--- a/src/main/kotlin/io/github/mojira/arisa/modules/FutureVersionModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/FutureVersionModule.kt
@@ -3,7 +3,6 @@ package io.github.mojira.arisa.modules
 import arrow.core.Either
 import arrow.core.extensions.fx
 import arrow.syntax.function.complement
-import io.github.mojira.arisa.domain.ChangeLogItem
 import io.github.mojira.arisa.domain.Issue
 import io.github.mojira.arisa.domain.Version
 import io.github.mojira.arisa.domain.CommentOptions

--- a/src/main/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModule.kt
@@ -81,7 +81,7 @@ class ReopenAwaitingModule(
         .filter { it.field != "Comment" }
 
     private fun isAwaitingResolve(change: ChangeLogItem) =
-        change.changedTo == "Awaiting Response"
+        change.changedToString == "Awaiting Response"
 
     private fun assertCreationIsNotRecent(updated: Long, created: Long) = when {
         (updated - created) < TWO_SECONDS_IN_MILLIS -> OperationNotNeededModuleResponse.left()

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModule.kt
@@ -14,7 +14,7 @@ class RevokeConfirmationModule : Module {
                 .filter(::isConfirmationChange)
                 .filter(::changedByVolunteer)
                 .lastOrNull()
-                ?.changedTo.getOrDefault("Unconfirmed")
+                ?.changedToString.getOrDefault("Unconfirmed")
 
             assertNotEquals(confirmationStatus.getOrDefault("Unconfirmed"), volunteerConfirmation).bind()
             updateConfirmationStatus(volunteerConfirmation).toFailedModuleEither().bind()

--- a/src/main/kotlin/io/github/mojira/arisa/modules/UpdateLinkedModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/UpdateLinkedModule.kt
@@ -49,11 +49,11 @@ class UpdateLinkedModule(
 
     private fun isDuplicateLinkAddedChange(change: ChangeLogItem) =
         change.field == "Link" &&
-                change.changedTo?.matches(DUPLICATE_REGEX) ?: false
+                change.changedToString?.matches(DUPLICATE_REGEX) ?: false
 
     private fun isDuplicateLinkRemovedChange(change: ChangeLogItem) =
         change.field == "Link" &&
-                change.changedFrom?.matches(DUPLICATE_REGEX) ?: false
+                change.changedFromString?.matches(DUPLICATE_REGEX) ?: false
 
     private fun isDuplicateLinkChange(change: ChangeLogItem) =
         change.field == "Link" && (

--- a/src/test/kotlin/io/github/mojira/arisa/modules/DuplicateMessageModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/DuplicateMessageModuleTest.kt
@@ -46,7 +46,7 @@ class DuplicateMessageModuleTest : StringSpec({
             changeLog = listOf(
                 mockChangeLogItem(
                     field = "Confirmation Status",
-                    changedTo = "Confirmed"
+                    changedToString = "Confirmed"
                 )
             )
         )
@@ -61,7 +61,7 @@ class DuplicateMessageModuleTest : StringSpec({
             changeLog = listOf(
                 mockChangeLogItem(
                     field = "Link",
-                    changedTo = "This issue relates to MC-42"
+                    changedToString = "This issue relates to MC-42"
                 )
             )
         )
@@ -75,9 +75,9 @@ class DuplicateMessageModuleTest : StringSpec({
         val issue = getIssue(
             changeLog = listOf(
                 mockChangeLogItem(
+                    created = TWO_SECONDS_AGO,
                     field = "Link",
-                    changedTo = "This issue duplicates MC-42",
-                    created = TWO_SECONDS_AGO
+                    changedToString = "This issue duplicates MC-42"
                 )
             )
         )
@@ -612,9 +612,9 @@ private fun getIssue(
     links: List<Link> = emptyList(),
     changeLog: List<ChangeLogItem> = listOf(
         mockChangeLogItem(
+            created = TEN_THOUSAND_YEARS_LATER,
             field = "Link",
-            changedTo = "This issue duplicates MC-42",
-            created = TEN_THOUSAND_YEARS_LATER
+            changedToString = "This issue duplicates MC-42"
         )
     ),
     comments: List<Comment> = emptyList(),

--- a/src/test/kotlin/io/github/mojira/arisa/modules/FutureVersionModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/FutureVersionModuleTest.kt
@@ -32,7 +32,7 @@ private val ADD_ARCHIVED_VERSION = mockChangeLogItem(field = "Version", changedT
 private val ADD_FUTURE_VERSION = mockChangeLogItem(field = "Version", changedTo = "3")
 
 class FutureVersionModuleTest : StringSpec({
-    "should return OperationNotNeededModuleResponse when there was no change log" {
+    "should return OperationNotNeededModuleResponse when there is no change log" {
         val module = FutureVersionModule("message")
         val issue = mockIssue(
             affectedVersions = listOf(FUTURE_VERSION),
@@ -46,7 +46,7 @@ class FutureVersionModuleTest : StringSpec({
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
-    "should return OperationNotNeededModuleResponse when there was no version changes" {
+    "should return OperationNotNeededModuleResponse when there are no version changes" {
         val module = FutureVersionModule("message")
         val issue = mockIssue(
             affectedVersions = listOf(FUTURE_VERSION),
@@ -86,7 +86,7 @@ class FutureVersionModuleTest : StringSpec({
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
-    "should return OperationNotNeededModuleResponse when the version change is removing" {
+    "should return OperationNotNeededModuleResponse when the version change is an removal" {
         val module = FutureVersionModule("message")
         val issue = mockIssue(
             affectedVersions = listOf(FUTURE_VERSION),

--- a/src/test/kotlin/io/github/mojira/arisa/modules/FutureVersionModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/FutureVersionModuleTest.kt
@@ -3,6 +3,8 @@ package io.github.mojira.arisa.modules
 import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
+import io.github.mojira.arisa.utils.RIGHT_NOW
+import io.github.mojira.arisa.utils.mockChangeLogItem
 import io.github.mojira.arisa.utils.mockIssue
 import io.github.mojira.arisa.utils.mockProject
 import io.github.mojira.arisa.utils.mockVersion
@@ -11,123 +13,270 @@ import io.kotest.assertions.arrow.either.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
-import java.time.Instant
 
-private val NOW = Instant.now()
+private val TWO_SECONDS_BEFORE = RIGHT_NOW.minusSeconds(2)
+
+private val ARCHIVED_VERSION = mockVersion(id = "1", released = false, archived = true)
+private val RELEASED_VERSION = mockVersion(id = "2", released = true, archived = false)
+private val FUTURE_VERSION = mockVersion(id = "3", released = false, archived = false)
+private val RELEASED_VERSION_WITH_ADD_ERROR = mockVersion(
+    id = "2", released = true, archived = false,
+    add = { RuntimeException().left() }
+)
+private val FUTURE_VERSION_WITH_REMOVE_ERROR = mockVersion(
+    id = "3", released = false, archived = false,
+    remove = { RuntimeException().left() }
+)
+
+private val ADD_ARCHIVED_VERSION = mockChangeLogItem(field = "Version", changedTo = "1")
+private val ADD_FUTURE_VERSION = mockChangeLogItem(field = "Version", changedTo = "3")
 
 class FutureVersionModuleTest : StringSpec({
-    "should return OperationNotNeededModuleResponse when affected versions are empty" {
+    "should return OperationNotNeededModuleResponse when there was no change log" {
         val module = FutureVersionModule("message")
-        val releasedVersion = getVersion(true, false)
         val issue = mockIssue(
+            affectedVersions = listOf(FUTURE_VERSION),
             project = mockProject(
-                versions = listOf(releasedVersion)
+                versions = listOf(RELEASED_VERSION)
             )
         )
 
-        val result = module(issue, NOW)
+        val result = module(issue, TWO_SECONDS_BEFORE)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when there was no version changes" {
+        val module = FutureVersionModule("message")
+        val issue = mockIssue(
+            affectedVersions = listOf(FUTURE_VERSION),
+            changeLog = listOf(
+                mockChangeLogItem(
+                    field = "description"
+                )
+            ),
+            project = mockProject(
+                versions = listOf(RELEASED_VERSION)
+            )
+        )
+
+        val result = module(issue, TWO_SECONDS_BEFORE)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when the version change is before last run" {
+        val module = FutureVersionModule("message")
+        val issue = mockIssue(
+            affectedVersions = listOf(FUTURE_VERSION),
+            changeLog = listOf(
+                mockChangeLogItem(
+                    field = "Version",
+                    created = RIGHT_NOW.minusSeconds(10),
+                    changedTo = "3"
+                )
+            ),
+            project = mockProject(
+                versions = listOf(RELEASED_VERSION)
+            )
+        )
+
+        val result = module(issue, TWO_SECONDS_BEFORE)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when the version change is removing" {
+        val module = FutureVersionModule("message")
+        val issue = mockIssue(
+            affectedVersions = listOf(FUTURE_VERSION),
+            changeLog = listOf(
+                mockChangeLogItem(
+                    field = "Version",
+                    changedTo = null
+                )
+            ),
+            project = mockProject(
+                versions = listOf(RELEASED_VERSION)
+            )
+        )
+
+        val result = module(issue, TWO_SECONDS_BEFORE)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when the future version is added by a staff" {
+        val module = FutureVersionModule("message")
+        val issue = mockIssue(
+            affectedVersions = listOf(FUTURE_VERSION),
+            changeLog = listOf(
+                mockChangeLogItem(
+                    field = "Version",
+                    changedTo = "3",
+                    getAuthorGroups = { listOf("staff") }
+                )
+            ),
+            project = mockProject(
+                versions = listOf(RELEASED_VERSION)
+            )
+        )
+
+        val result = module(issue, TWO_SECONDS_BEFORE)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when affected versions are empty" {
+        val module = FutureVersionModule("message")
+        val issue = mockIssue(
+            project = mockProject(
+                versions = listOf(RELEASED_VERSION)
+            )
+        )
+
+        val result = module(issue, TWO_SECONDS_BEFORE)
 
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
     "should return OperationNotNeededModuleResponse when project versions are empty" {
         val module = FutureVersionModule("message")
-        val futureVersion = getVersion(false, false)
         val issue = mockIssue(
-            affectedVersions = listOf(futureVersion)
+            affectedVersions = listOf(FUTURE_VERSION),
+            changeLog = listOf(ADD_FUTURE_VERSION)
         )
 
-        val result = module(issue, NOW)
+        val result = module(issue, TWO_SECONDS_BEFORE)
 
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
     "should return OperationNotNeededModuleResponse when project versions are null" {
         val module = FutureVersionModule("message")
-        val futureVersion = getVersion(false, false)
         val issue = mockIssue(
-            affectedVersions = listOf(futureVersion)
+            affectedVersions = listOf(FUTURE_VERSION),
+            changeLog = listOf(ADD_FUTURE_VERSION)
         )
 
-        val result = module(issue, NOW)
+        val result = module(issue, TWO_SECONDS_BEFORE)
 
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
     "should return OperationNotNeededModuleResponse when project versions do not contain released versions" {
         val module = FutureVersionModule("message")
-        val futureVersion = getVersion(false, false)
         val issue = mockIssue(
-            affectedVersions = listOf(futureVersion),
+            affectedVersions = listOf(FUTURE_VERSION),
+            changeLog = listOf(ADD_FUTURE_VERSION),
             project = mockProject(
-                versions = listOf(futureVersion)
+                versions = listOf(FUTURE_VERSION)
             )
         )
 
-        val result = module(issue, NOW)
+        val result = module(issue, TWO_SECONDS_BEFORE)
 
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
     "should return OperationNotNeededModuleResponse if no future version is marked affected" {
         val module = FutureVersionModule("message")
-        val releasedVersion = getVersion(true, false)
         val issue = mockIssue(
-            affectedVersions = listOf(releasedVersion),
+            affectedVersions = listOf(RELEASED_VERSION),
+            changeLog = listOf(ADD_FUTURE_VERSION),
             project = mockProject(
-                versions = listOf(releasedVersion)
+                versions = listOf(RELEASED_VERSION)
             )
         )
 
-        val result = module(issue, NOW)
+        val result = module(issue, TWO_SECONDS_BEFORE)
 
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
     "should return OperationNotNeededModuleResponse if only an archived version is marked affected" {
         val module = FutureVersionModule("message")
-        val archivedVersion = getVersion(false, true)
-        val releasedVersion = getVersion(true, false)
         val issue = mockIssue(
-            affectedVersions = listOf(archivedVersion),
+            affectedVersions = listOf(ARCHIVED_VERSION),
+            changeLog = listOf(ADD_ARCHIVED_VERSION),
             project = mockProject(
-                versions = listOf(releasedVersion)
+                versions = listOf(RELEASED_VERSION)
             )
         )
 
-        val result = module(issue, NOW)
+        val result = module(issue, TWO_SECONDS_BEFORE)
 
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
     "should remove future versions" {
         val module = FutureVersionModule("message")
-        val futureVersion = getVersion(false, false)
-        val releasedVersion = getVersion(true, false)
         val issue = mockIssue(
-            affectedVersions = listOf(futureVersion),
+            affectedVersions = listOf(FUTURE_VERSION),
+            changeLog = listOf(ADD_FUTURE_VERSION),
             project = mockProject(
-                versions = listOf(releasedVersion)
+                versions = listOf(RELEASED_VERSION)
             )
         )
 
-        val result = module(issue, NOW)
+        val result = module(issue, TWO_SECONDS_BEFORE)
+
+        result.shouldBeRight(ModuleResponse)
+    }
+
+    "should remove future versions added by users" {
+        val module = FutureVersionModule("message")
+        val issue = mockIssue(
+            affectedVersions = listOf(FUTURE_VERSION),
+            changeLog = listOf(
+                mockChangeLogItem(
+                    field = "Version",
+                    changedTo = "3",
+                    getAuthorGroups = { listOf("user") }
+                )
+            ),
+            project = mockProject(
+                versions = listOf(RELEASED_VERSION)
+            )
+        )
+
+        val result = module(issue, TWO_SECONDS_BEFORE)
+
+        result.shouldBeRight(ModuleResponse)
+    }
+
+    "should remove future versions added by users without a group" {
+        val module = FutureVersionModule("message")
+        val issue = mockIssue(
+            affectedVersions = listOf(FUTURE_VERSION),
+            changeLog = listOf(
+                mockChangeLogItem(
+                    field = "Version",
+                    changedTo = "3",
+                    getAuthorGroups = { null }
+                )
+            ),
+            project = mockProject(
+                versions = listOf(RELEASED_VERSION)
+            )
+        )
+
+        val result = module(issue, TWO_SECONDS_BEFORE)
 
         result.shouldBeRight(ModuleResponse)
     }
 
     "should return FailedModuleResponse when removing a version fails" {
         val module = FutureVersionModule("message")
-        val futureVersion = getVersion(false, false, remove = { RuntimeException().left() })
-        val releasedVersion = getVersion(true, false, add = { Unit.right() })
         val issue = mockIssue(
-            affectedVersions = listOf(futureVersion),
+            affectedVersions = listOf(FUTURE_VERSION_WITH_REMOVE_ERROR),
+            changeLog = listOf(ADD_FUTURE_VERSION),
             project = mockProject(
-                versions = listOf(releasedVersion)
+                versions = listOf(RELEASED_VERSION)
             )
         )
 
-        val result = module(issue, NOW)
+        val result = module(issue, TWO_SECONDS_BEFORE)
 
         result.shouldBeLeft()
         result.a should { it is FailedModuleResponse }
@@ -136,16 +285,15 @@ class FutureVersionModuleTest : StringSpec({
 
     "should return FailedModuleResponse with all exceptions when removing versions fails" {
         val module = FutureVersionModule("message")
-        val futureVersion = getVersion(false, false, remove = { RuntimeException().left() })
-        val releasedVersion = getVersion(true, false, add = { Unit.right() })
         val issue = mockIssue(
-            affectedVersions = listOf(futureVersion, futureVersion),
+            affectedVersions = listOf(FUTURE_VERSION_WITH_REMOVE_ERROR, FUTURE_VERSION_WITH_REMOVE_ERROR),
+            changeLog = listOf(ADD_FUTURE_VERSION, ADD_FUTURE_VERSION),
             project = mockProject(
-                versions = listOf(releasedVersion)
+                versions = listOf(RELEASED_VERSION)
             )
         )
 
-        val result = module(issue, NOW)
+        val result = module(issue, TWO_SECONDS_BEFORE)
 
         result.shouldBeLeft()
         result.a should { it is FailedModuleResponse }
@@ -154,16 +302,15 @@ class FutureVersionModuleTest : StringSpec({
 
     "should return FailedModuleResponse when adding the latest version fails" {
         val module = FutureVersionModule("message")
-        val futureVersion = getVersion(false, false, remove = { Unit.right() })
-        val releasedVersion = getVersion(true, false, add = { RuntimeException().left() })
         val issue = mockIssue(
-            affectedVersions = listOf(futureVersion),
+            affectedVersions = listOf(FUTURE_VERSION),
+            changeLog = listOf(ADD_FUTURE_VERSION),
             project = mockProject(
-                versions = listOf(releasedVersion)
+                versions = listOf(RELEASED_VERSION_WITH_ADD_ERROR)
             )
         )
 
-        val result = module(issue, NOW)
+        val result = module(issue, TWO_SECONDS_BEFORE)
 
         result.shouldBeLeft()
         result.a should { it is FailedModuleResponse }
@@ -172,17 +319,16 @@ class FutureVersionModuleTest : StringSpec({
 
     "should return FailedModuleResponse when adding the comment fails" {
         val module = FutureVersionModule("message")
-        val futureVersion = getVersion(false, false, remove = { Unit.right() })
-        val releasedVersion = getVersion(true, false, add = { Unit.right() })
         val issue = mockIssue(
-            affectedVersions = listOf(futureVersion),
+            affectedVersions = listOf(FUTURE_VERSION),
+            changeLog = listOf(ADD_FUTURE_VERSION),
             project = mockProject(
-                versions = listOf(releasedVersion)
+                versions = listOf(RELEASED_VERSION)
             ),
             addComment = { RuntimeException().left() }
         )
 
-        val result = module(issue, NOW)
+        val result = module(issue, TWO_SECONDS_BEFORE)
 
         result.shouldBeLeft()
         result.a should { it is FailedModuleResponse }

--- a/src/test/kotlin/io/github/mojira/arisa/modules/KeepPrivateModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/KeepPrivateModuleTest.kt
@@ -15,7 +15,7 @@ import io.kotest.matchers.shouldBe
 private val REMOVE_SECURITY = mockChangeLogItem(
     created = RIGHT_NOW.minusSeconds(10),
     field = "security",
-    changedFrom = "10318"
+    changedFromString = "10318"
 )
 
 class KeepPrivateModuleTest : StringSpec({

--- a/src/test/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModuleTest.kt
@@ -32,12 +32,12 @@ private val MODULE = ReopenAwaitingModule(
 private val AWAITING_RESOLVE = mockChangeLogItem(
     created = TEN_SECONDS_AGO,
     field = "resolution",
-    changedTo = "Awaiting Response"
+    changedToString = "Awaiting Response"
 )
 private val OLD_AWAITING_RESOLVE = mockChangeLogItem(
     created = TWO_YEARS_AGO,
     field = "resolution",
-    changedTo = "Awaiting Response"
+    changedToString = "Awaiting Response"
 )
 
 class ReopenAwaitingModuleTest : StringSpec({
@@ -123,7 +123,7 @@ class ReopenAwaitingModuleTest : StringSpec({
         val oldResolve = mockChangeLogItem(
             created = RIGHT_NOW.minusSeconds(30),
             field = "resolution",
-            changedTo = "Awaiting Response"
+            changedToString = "Awaiting Response"
         )
         val comment = getComment(
             RIGHT_NOW.minusSeconds(20),
@@ -147,12 +147,12 @@ class ReopenAwaitingModuleTest : StringSpec({
         val oldResolve = mockChangeLogItem(
             created = RIGHT_NOW.minusSeconds(30),
             field = "resolution",
-            changedTo = "Awaiting Response"
+            changedToString = "Awaiting Response"
         )
         val changeLog = mockChangeLogItem(
             created = RIGHT_NOW.minusSeconds(15),
             field = "customfield_00042",
-            changedTo = "Confirmed"
+            changedToString = "Confirmed"
         )
         val issue = mockIssue(
             resolution = "Awaiting Response",
@@ -216,10 +216,10 @@ class ReopenAwaitingModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when there's no change after resolved" {
         val changeLog = mockChangeLogItem(
-            author = REPORTER,
             created = RIGHT_NOW.minusSeconds(20),
             field = "Versions",
-            changedTo = "1.15.2"
+            changedToString = "1.15.2",
+            author = REPORTER
         )
         val updated = RIGHT_NOW.plusSeconds(3)
         val issue = mockIssue(
@@ -238,7 +238,7 @@ class ReopenAwaitingModuleTest : StringSpec({
         val changeLog = mockChangeLogItem(
             created = RIGHT_NOW.plusSeconds(3),
             field = "Versions",
-            changedTo = "1.15.2"
+            changedToString = "1.15.2"
         )
         val updated = RIGHT_NOW.plusSeconds(3)
         val issue = mockIssue(
@@ -257,7 +257,7 @@ class ReopenAwaitingModuleTest : StringSpec({
         val changeLog = mockChangeLogItem(
             created = RIGHT_NOW.plusSeconds(3),
             field = "Versions",
-            changedTo = "1.15.2"
+            changedToString = "1.15.2"
         )
         val updated = RIGHT_NOW.plusSeconds(3)
         val issue = mockIssue(
@@ -276,8 +276,8 @@ class ReopenAwaitingModuleTest : StringSpec({
         val changeLog = mockChangeLogItem(
             created = RIGHT_NOW.plusSeconds(3),
             field = "Comment",
-            changedFrom = "aaa",
-            changedTo = "AAA",
+            changedFromString = "aaa",
+            changedToString = "AAA",
             author = REPORTER
         ) { emptyList() }
         val updated = RIGHT_NOW.plusSeconds(3)
@@ -371,8 +371,8 @@ class ReopenAwaitingModuleTest : StringSpec({
         val change = mockChangeLogItem(
             created = RIGHT_NOW.plusSeconds(3),
             field = "",
-            changedFrom = "",
-            changedTo = "Confirmed"
+            changedFromString = "",
+            changedToString = "Confirmed"
         ) { emptyList() }
         val issue = mockIssue(
             resolution = "Awaiting Response",
@@ -605,10 +605,10 @@ class ReopenAwaitingModuleTest : StringSpec({
         var hasCommented = false
 
         val changeLog = mockChangeLogItem(
-            author = REPORTER,
             created = RIGHT_NOW.plusSeconds(3),
             field = "Versions",
-            changedTo = "1.15.2"
+            changedToString = "1.15.2",
+            author = REPORTER
         )
         val updated = RIGHT_NOW.plusSeconds(3)
         val issue = mockIssue(
@@ -632,10 +632,10 @@ class ReopenAwaitingModuleTest : StringSpec({
         var hasCommented = false
 
         val changeLog = mockChangeLogItem(
-            author = REPORTER,
             created = RIGHT_NOW.plusSeconds(3),
             field = "Versions",
-            changedTo = "1.15.2"
+            changedToString = "1.15.2",
+            author = REPORTER
         )
         val comment = getComment()
         val updated = RIGHT_NOW.plusSeconds(3)

--- a/src/test/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModuleTest.kt
@@ -254,6 +254,6 @@ private fun mockChangeLogItem(
 ) = mockChangeLogItem(
     created = created,
     field = field,
-    changedTo = value,
+    changedToString = value,
     getAuthorGroups = getAuthorGroups
 )

--- a/src/test/kotlin/io/github/mojira/arisa/modules/UpdateLinkedModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/UpdateLinkedModuleTest.kt
@@ -15,7 +15,7 @@ import java.time.temporal.ChronoUnit
 private val A_SECOND_AGO = RIGHT_NOW.minusSeconds(1)
 private val DUPLICATE_LINK = mockChangeLogItem(
     field = "Link",
-    changedTo = "This issue is duplicated by MC-4"
+    changedToString = "This issue is duplicated by MC-4"
 )
 
 class UpdateLinkedModuleTest : StringSpec({
@@ -73,12 +73,12 @@ class UpdateLinkedModuleTest : StringSpec({
         val linkedChange = mockChangeLogItem(
             created = RIGHT_NOW.minusSeconds(2),
             field = "Linked",
-            changedFrom = "1.0"
+            changedFromString = "1.0"
         )
         val oldAddedLink = mockChangeLogItem(
             created = RIGHT_NOW.minus(2, ChronoUnit.HOURS),
             field = "Link",
-            changedTo = "This issue is duplicated by MC-4"
+            changedToString = "This issue is duplicated by MC-4"
         )
         val issue = mockIssue(
             created = RIGHT_NOW.minus(3, ChronoUnit.HOURS),
@@ -125,7 +125,7 @@ class UpdateLinkedModuleTest : StringSpec({
         val removedLink = mockChangeLogItem(
             created = RIGHT_NOW.plusSeconds(1),
             field = "Link",
-            changedFrom = "This issue is duplicated by MC-4"
+            changedFromString = "This issue is duplicated by MC-4"
         )
         val issue = mockIssue(
             created = A_SECOND_AGO,
@@ -145,7 +145,7 @@ class UpdateLinkedModuleTest : StringSpec({
         val module = UpdateLinkedModule(0)
         val relatesLink = mockChangeLogItem(
             field = "Link",
-            changedTo = "This issue relates to MC-4"
+            changedToString = "This issue relates to MC-4"
         )
         val issue = mockIssue(
             created = A_SECOND_AGO,
@@ -166,7 +166,7 @@ class UpdateLinkedModuleTest : StringSpec({
         val oldAddedLink = mockChangeLogItem(
             created = RIGHT_NOW.minus(2, ChronoUnit.HOURS),
             field = "Link",
-            changedTo = "This issue is duplicated by MC-4"
+            changedToString = "This issue is duplicated by MC-4"
         )
         val issue = mockIssue(
             created = A_SECOND_AGO.minus(2, ChronoUnit.HOURS),
@@ -184,17 +184,17 @@ class UpdateLinkedModuleTest : StringSpec({
         val addedLink = mockChangeLogItem(
             created = RIGHT_NOW.minus(4, ChronoUnit.HOURS),
             field = "Link",
-            changedTo = "This issue is duplicated by MC-4"
+            changedToString = "This issue is duplicated by MC-4"
         )
         val linkedChange = mockChangeLogItem(
             created = A_SECOND_AGO.minus(3, ChronoUnit.HOURS),
             field = "Linked",
-            changedFrom = "1.0"
+            changedFromString = "1.0"
         )
         val removedLink = mockChangeLogItem(
             created = RIGHT_NOW.minus(2, ChronoUnit.HOURS),
             field = "Link",
-            changedFrom = "This issue is duplicated by MC-4"
+            changedFromString = "This issue is duplicated by MC-4"
         )
         val issue = mockIssue(
             created = A_SECOND_AGO.minus(4, ChronoUnit.HOURS),

--- a/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
@@ -32,14 +32,18 @@ fun mockChangeLogItem(
     created: Instant = RIGHT_NOW,
     field: String = "",
     changedFrom: String? = null,
+    changedFromString: String? = null,
     changedTo: String? = null,
+    changedToString: String? = null,
     author: User = mockUser(),
     getAuthorGroups: () -> List<String>? = { emptyList() }
 ) = ChangeLogItem(
     created,
     field,
     changedFrom,
+    changedFromString,
     changedTo,
+    changedToString,
     author,
     getAuthorGroups
 )


### PR DESCRIPTION
## Purpose
Resolve #307.
## Approach
By checking the change log to see if the change is made by an user with the `staff` group.
## Future work

#### Checklist
- [x] Included tests
- [ ] Tested in MCTEST-xxx
