### PR TITLE
Fix not removing identical relates links

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/RemoveIdenticalLinkModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RemoveIdenticalLinkModule.kt
@@ -17,7 +17,17 @@ class RemoveIdenticalLinkModule : Module {
             assertNotEmpty(links).bind()
 
             val removeLinkFunctions = links
-                .groupBy { GroupingLink(it.type, it.outwards, it.issue.key) }
+                .groupBy {
+                    GroupingLink(
+                        it.type,
+                        if (it.type.toLowerCase() == "relates") {
+                            true
+                        } else {
+                            it.outwards
+                        },
+                        it.issue.key
+                    )
+                }
                 .filterValues { it.size > 1 }
                 .values
                 .flatMap { list ->

--- a/src/main/kotlin/io/github/mojira/arisa/modules/TransferLinksModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/TransferLinksModule.kt
@@ -28,7 +28,7 @@ class TransferLinksModule : AbstractTransferFieldModule() {
     private fun parentDoesNotHaveLink(parentLinks: List<Link>, other: Link) =
         parentLinks.none {
             it.type == other.type &&
-                it.outwards == other.outwards &&
+                (it.type.toLowerCase() == "relates" || it.outwards == other.outwards) &&
                 it.issue.key == other.issue.key
         }
 

--- a/src/test/kotlin/io/github/mojira/arisa/modules/RemoveIdenticalLinkModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/RemoveIdenticalLinkModuleTest.kt
@@ -34,7 +34,7 @@ class RemoveIdenticalLinkModuleTest : StringSpec({
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
-    "should return OperationNotNeededModuleResponse when the links have directions" {
+    "should return OperationNotNeededModuleResponse when the links have different directions" {
         val link1 = mockLink(
             outwards = true
         )
@@ -96,6 +96,32 @@ class RemoveIdenticalLinkModuleTest : StringSpec({
         val link2 = mockLink(
             remove = { hasRemovedLink2 = true; Unit.right() }
         )
+        val issue = mockIssue(
+            links = listOf(link1, link2)
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight(ModuleResponse)
+        hasRemovedLink1 shouldBe false
+        hasRemovedLink2 shouldBe true
+    }
+
+    "should remove extra relates link that is identical to the former one regardless of directions" {
+        var hasRemovedLink1 = false
+        var hasRemovedLink2 = false
+
+        val link1 = mockLink(
+            type = "Relates",
+            outwards = true,
+            remove = { hasRemovedLink1 = true; Unit.right() }
+        )
+        val link2 = mockLink(
+            type = "Relates",
+            outwards = false,
+            remove = { hasRemovedLink2 = true; Unit.right() }
+        )
+
         val issue = mockIssue(
             links = listOf(link1, link2)
         )

--- a/src/test/kotlin/io/github/mojira/arisa/modules/TransferLinksModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/TransferLinksModuleTest.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
 import io.github.mojira.arisa.domain.Issue
+import io.github.mojira.arisa.domain.Link
 import io.github.mojira.arisa.utils.RIGHT_NOW
 import io.github.mojira.arisa.utils.mockIssue
 import io.github.mojira.arisa.utils.mockLink
@@ -74,6 +75,7 @@ class TransferLinksModuleTest : StringSpec({
 
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
+
     "should return OperationNotNeededModuleResponse when the issue has no additional links" {
         val module = TransferLinksModule()
         val issue = mockIssue(
@@ -96,6 +98,44 @@ class TransferLinksModuleTest : StringSpec({
         val result = module(issue, RIGHT_NOW)
 
         result.shouldBeRight(ModuleResponse)
+    }
+
+    "should not transfer relates link that exists in parent regardless of direction" {
+        var hasTransferred = false
+        val module = TransferLinksModule()
+
+        val createLink = { _: String, _: String, _: String -> hasTransferred = true; Unit.right() }
+
+        /**
+         * MC-42 duplicates MC-1
+         */
+        val link = linkIssues(
+            key1 = "MC-42",
+            key2 = "MC-1",
+            createLink = createLink,
+            additionalLinksOnParent = listOf(
+                /**
+                 * MC-10 relates to MC-1
+                 */
+                linkIssues(
+                    key1 = "MC-1",
+                    key2 = "MC-10",
+                    type = "Relates",
+                    outwards = false,
+                    createLink = createLink
+                )
+            )
+        )
+
+        val issue = mockIssue(
+            key = "MC-42",
+            links = listOf(link, RELATES_LINK)
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight(ModuleResponse)
+        hasTransferred.shouldBeFalse()
     }
 
     "should remove links" {
@@ -568,10 +608,11 @@ private fun linkIssues(
     outwards: Boolean = true,
     createLink: (key1: String, type: String, key2: String) -> Either<Throwable, Unit> = { _, _, _ -> Unit.right() },
     removeLink: (key1: String, key2: String, type: String) -> Either<Throwable, Unit> = { _, _, _ -> Unit.right() },
+    additionalLinksOnParent: List<Link> = emptyList(),
     getFullIssue: () -> Either<Throwable, Issue> = {
         mockIssue(
             key = key2,
-            links = listOf(
+            links = mutableListOf(
                 mockLink(
                     type = type,
                     outwards = !outwards,
@@ -581,7 +622,7 @@ private fun linkIssues(
                     ),
                     remove = { removeLink(key2, type, key1) }
                 )
-            ),
+            ).also { it.addAll(additionalLinksOnParent) },
             createLink = { linkType, key -> createLink(key2, linkType, key) }
         ).right()
     }


### PR DESCRIPTION
## Purpose
Fix #302
## Approach
By ignoring the direction (`outwards`) of `Relates` links.
## Future work

#### Checklist
- [x] Included tests
- [ ] Tested in MCTEST-xxx
