### PR TITLE
Disable piracy module

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -83,6 +83,7 @@
         }
       },
       "piracy": {
+        "whitelist": [],
         "excludedStatuses": ["Postponed", "Resolved"],
         "message": "pirated-minecraft",
         "piracySignatures": [


### PR DESCRIPTION
The piracy module still spams tickets, let's disable it completely

https://bugs.mojang.com/browse/MC-190760