### PR TITLE
Enable linked module for more projects

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -305,9 +305,14 @@
         "excludedStatuses": ["Postponed"],
         "updateIntervalHours": 24,
         "whitelist": [
-          "MC",
-          "MCL",
-          "MCPE"
+        "MC",
+        "MCPE",
+        "MCL",
+        "MCD",
+        "MCE",
+        "BDS",
+        "REALMS",
+        "WEB"
         ]
       },
       "transferVersions": {

--- a/arisa.json
+++ b/arisa.json
@@ -305,14 +305,14 @@
         "excludedStatuses": ["Postponed"],
         "updateIntervalHours": 24,
         "whitelist": [
-        "MC",
-        "MCPE",
-        "MCL",
-        "MCD",
-        "MCE",
-        "BDS",
-        "REALMS",
-        "WEB"
+          "MC",
+          "MCPE",
+          "MCL",
+          "MCD",
+          "MCE",
+          "BDS",
+          "REALMS",
+          "WEB"
         ]
       },
       "transferVersions": {


### PR DESCRIPTION
## Purpose
The Linked field has been added to more projects (see [STAFF-389](https://bugs.mojang.com/browse/STAFF-389)), thus the module should be enabled for more projects

## Approach
Change json config
