### PR TITLE
Disable MissingCrashModule

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -259,9 +259,6 @@
           "log"
         ],
         "whitelist": [
-          "MC",
-          "MCL",
-          "MCTEST"
         ],
         "message": "attach-crash-report"
       },


### PR DESCRIPTION
## Purpose
See #376 and https://discordapp.com/channels/647810384031645728/663488001346764805/734097599556091945.
I am disabling that module for now, until this has been discussed with more people from the team.

## Approach
Disable the module

## Future work

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
