### PR TITLE
Fix being able to confirm user's own tickets

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/ConfirmParentModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ConfirmParentModule.kt
@@ -40,12 +40,6 @@ class ConfirmParentModule(
 
     private fun isDuplicatedLink(link: Link): Boolean = link.type == "Duplicate" && !link.outwards
 
-    private fun assertLinkedMoreThanThreshold(linked: Double) = if (linked >= linkedThreshold) {
-        Unit.right()
-    } else {
-        OperationNotNeededModuleResponse.left()
-    }
-
     private fun assertConfirmationStatusWhitelisted(status: String?, whitelist: List<String>) =
         if ((status.getOrDefault("Unconfirmed")) in whitelist) {
             Unit.right()

--- a/src/main/kotlin/io/github/mojira/arisa/modules/Helpers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/Helpers.kt
@@ -7,9 +7,9 @@ import arrow.core.left
 import arrow.core.right
 import java.time.Instant
 
-fun Either<Throwable, Unit>.toFailedModuleEither() = this.bimap(
+fun <T> Either<Throwable, T>.toFailedModuleEither() = this.bimap(
     { FailedModuleResponse(listOf(it)) },
-    { ModuleResponse }
+    { it }
 )
 
 fun Collection<Either<Throwable, Any>>.toFailedModuleEither(): Either<ModuleError, ModuleResponse> {

--- a/src/test/kotlin/io/github/mojira/arisa/modules/ConfirmParentModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/ConfirmParentModuleTest.kt
@@ -1,136 +1,214 @@
 package io.github.mojira.arisa.modules
 
+import arrow.core.left
 import arrow.core.right
+import io.github.mojira.arisa.utils.RIGHT_NOW
 import io.github.mojira.arisa.utils.mockIssue
+import io.github.mojira.arisa.utils.mockLink
+import io.github.mojira.arisa.utils.mockLinkedIssue
+import io.github.mojira.arisa.utils.mockUser
 import io.kotest.assertions.arrow.either.shouldBeLeft
 import io.kotest.assertions.arrow.either.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
-import java.time.Instant
 
-private val NOW = Instant.now()
+private val duplicatedLink1 = mockLink(
+    outwards = false,
+    issue = mockLinkedIssue(
+        getFullIssue = { mockIssue(reporter = mockUser(name = "user1")).right() }
+    )
+)
+private val duplicatedLink2 = mockLink(
+    outwards = false,
+    issue = mockLinkedIssue(
+        getFullIssue = { mockIssue(reporter = mockUser(name = "user2")).right() }
+    )
+)
+private val duplicatedLinkError = mockLink(
+    outwards = false,
+    issue = mockLinkedIssue(
+        getFullIssue = { RuntimeException().left() }
+    )
+)
+private val relatesLink = mockLink(
+    type = "Relates"
+)
+private val duplicatesLink = mockLink()
 
 class ConfirmParentModuleTest : StringSpec({
-    "should return OperationNotNeededModuleResponse when Linked is null" {
-        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 1.0)
-        val issue = mockIssue(
-            confirmationStatus = "Unconfirmed"
-        )
-
-        val result = module(issue, NOW)
-
-        result.shouldBeLeft(OperationNotNeededModuleResponse)
-    }
-
-    "should return OperationNotNeededModuleResponse when Linked is 0" {
-        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 1.0)
+    "should return OperationNotNeededModuleResponse when there are no links" {
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 2.0)
         val issue = mockIssue(
             confirmationStatus = "Unconfirmed",
-            linked = 0.0
+            links = emptyList()
         )
 
-        val result = module(issue, NOW)
+        val result = module(issue, RIGHT_NOW)
 
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
-    "should return OperationNotNeededModuleResponse when Confirmation Status is Community Consensus and Linked is 1" {
-        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 1.0)
+    "should return OperationNotNeededModuleResponse when there are only Relates links" {
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 2.0)
+        val issue = mockIssue(
+            confirmationStatus = "Unconfirmed",
+            links = listOf(relatesLink)
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when there are only outwards Duplicate links" {
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 2.0)
+        val issue = mockIssue(
+            confirmationStatus = "Unconfirmed",
+            links = listOf(duplicatesLink)
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when Confirmation Status is already Community Consensus" {
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 2.0)
         val issue = mockIssue(
             confirmationStatus = "Community Consensus",
-            linked = 1.0
+            links = listOf(duplicatedLink1, duplicatedLink2)
         )
 
-        val result = module(issue, NOW)
+        val result = module(issue, RIGHT_NOW)
 
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
-    "should return OperationNotNeededModuleResponse when Confirmation Status is Confirmed and Linked is 1" {
-        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 1.0)
+    "should return OperationNotNeededModuleResponse when Confirmation Status is already Confirmed" {
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 2.0)
         val issue = mockIssue(
-            confirmationStatus = "Community Consensus",
-            linked = 1.0
+            confirmationStatus = "Confirmed",
+            links = listOf(duplicatedLink1, duplicatedLink2)
         )
 
-        val result = module(issue, NOW)
+        val result = module(issue, RIGHT_NOW)
 
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
-    "should set to Community Consensus when Confirmation Status is null and Linked is 1" {
+    "should return OperationNotNeededModuleResponse when the duplicated issues are all of the same reporter" {
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 2.0)
+        val issue = mockIssue(
+            confirmationStatus = "Unconfirmed",
+            links = listOf(duplicatedLink1, duplicatedLink1)
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when one of the duplicated issue has the same reporter as parent" {
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 2.0)
+        val issue = mockIssue(
+            reporter = mockUser(name = "user1"),
+            confirmationStatus = "Unconfirmed",
+            links = listOf(duplicatedLink1, duplicatedLink2)
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should set to Community Consensus when Confirmation Status is null and there are enough duplicates" {
         var changedConfirmation = ""
 
-        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 1.0)
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 2.0)
         val issue = mockIssue(
             confirmationStatus = null,
-            linked = 1.0,
+            links = listOf(duplicatedLink1, duplicatedLink2, duplicatedLinkError),
             updateConfirmationStatus = {
                 changedConfirmation = it
                 Unit.right()
             }
         )
 
-        val result = module(issue, NOW)
+        val result = module(issue, RIGHT_NOW)
 
         result.shouldBeRight(ModuleResponse)
         changedConfirmation.shouldBe("Community Consensus")
     }
 
-    "should set to Community Consensus when Confirmation Status is empty and Linked is 1" {
+    "should set to Community Consensus when Confirmation Status is empty and there are enough duplicates" {
         var changedConfirmation = ""
 
-        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 1.0)
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 2.0)
         val issue = mockIssue(
             confirmationStatus = "",
-            linked = 1.0,
+            links = listOf(duplicatedLink1, duplicatedLink2, duplicatedLinkError),
             updateConfirmationStatus = {
                 changedConfirmation = it
                 Unit.right()
             }
         )
 
-        val result = module(issue, NOW)
+        val result = module(issue, RIGHT_NOW)
 
         result.shouldBeRight(ModuleResponse)
         changedConfirmation.shouldBe("Community Consensus")
     }
 
-    "should set to Community Consensus when Confirmation Status is Unconfirmed and Linked is 1" {
+    "should set to Community Consensus when Confirmation Status is Unconfirmed and there are enough duplicates" {
         var changedConfirmation = ""
 
-        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 1.0)
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 2.0)
         val issue = mockIssue(
             confirmationStatus = "Unconfirmed",
-            linked = 1.0,
+            links = listOf(duplicatedLink1, duplicatedLink2, duplicatedLinkError),
             updateConfirmationStatus = {
                 changedConfirmation = it
                 Unit.right()
             }
         )
 
-        val result = module(issue, NOW)
+        val result = module(issue, RIGHT_NOW)
 
         result.shouldBeRight(ModuleResponse)
         changedConfirmation.shouldBe("Community Consensus")
     }
 
-    "should set to Community Consensus when Confirmation Status is Plausible and Linked is 1" {
+    "should set to Community Consensus when Confirmation Status is Plausible and there are enough duplicates" {
         var changedConfirmation = ""
 
-        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 1.0)
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 2.0)
         val issue = mockIssue(
             confirmationStatus = "Plausible",
-            linked = 1.0,
+            links = listOf(duplicatedLink1, duplicatedLink2, duplicatedLinkError),
             updateConfirmationStatus = {
                 changedConfirmation = it
                 Unit.right()
             }
         )
 
-        val result = module(issue, NOW)
+        val result = module(issue, RIGHT_NOW)
 
         result.shouldBeRight(ModuleResponse)
         changedConfirmation.shouldBe("Community Consensus")
+    }
+
+    "should return FailedModuleResponse when getting an issue fails" {
+        val module = ConfirmParentModule(listOf("Unconfirmed", "Plausible"), "Community Consensus", 2.0)
+        val issue = mockIssue(
+            confirmationStatus = null,
+            links = listOf(duplicatedLinkError)
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft()
+        result.a should { it is FailedModuleResponse }
+        (result.a as FailedModuleResponse).exceptions.size shouldBe 1
     }
 })


### PR DESCRIPTION
## Purpose
Fix #378.
## Approach
By checking the duplicated links of the parent ticket until an error occurs or the amount of duplicates is above the threshold (`3`).
## Future work

#### Checklist
- [x] Included tests
- [x] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
