### PR TITLE
Add ARISA_PURGE_ATTACHMENT command

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -187,6 +187,20 @@
         "excludedStatuses": ["Postponed"],
         "message": "incomplete"
       },
+      "command": {
+        "resolutions": [
+          "Awaiting Response",
+          "Cannot Reproduce",
+          "Done",
+          "Duplicate",
+          "Fixed",
+          "Incomplete",
+          "Invalid",
+          "Unresolved",
+          "Won't Fix",
+          "Works As Intended"
+        ]
+      },
       "crash": {
         "excludedStatuses": ["Postponed"],
         "crashExtensions": [

--- a/src/main/kotlin/io/github/mojira/arisa/domain/Attachment.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/domain/Attachment.kt
@@ -3,6 +3,7 @@ package io.github.mojira.arisa.domain
 import java.time.Instant
 
 data class Attachment(
+    val id: String,
     val name: String,
     val created: Instant,
     val mimeType: String,

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
@@ -157,7 +157,7 @@ fun createComment(
                 val newPostedComments = newPostedCommentCache.getOrAdd(key, mutableSetOf())
 
                 if (oldPostedComments != null && oldPostedComments.contains(comment)) {
-                    log.warn("The comment has already been posted under $key in last run: $comment")
+                    log.error("The comment has already been posted under $key in last run: $comment")
                 } else {
                     context.value.jiraIssue.addComment(comment)
                 }

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
@@ -36,6 +36,7 @@ import net.rcarz.jiraclient.User as JiraUser
 import net.rcarz.jiraclient.Version as JiraVersion
 
 fun JiraAttachment.toDomain(jiraClient: JiraClient, issue: JiraIssue, cache: IssueUpdateContextCache) = Attachment(
+    id,
     fileName,
     createdDate.toInstant(),
     mimeType,

--- a/src/main/kotlin/io/github/mojira/arisa/modules/AttachmentModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/AttachmentModule.kt
@@ -16,7 +16,7 @@ class AttachmentModule(
         Either.fx {
             val endsWithBlacklistedExtensionAdapter = ::endsWithBlacklistedExtensions.partially1(extensionBlackList)
             val functions = attachments
-                .filter { (name, _) -> endsWithBlacklistedExtensionAdapter(name) }
+                .filter { endsWithBlacklistedExtensionAdapter(it.name) }
                 .map { it.remove }
             assertNotEmpty(functions).bind()
             functions.forEach { it.invoke() }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/CommandModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/CommandModule.kt
@@ -3,21 +3,25 @@ package io.github.mojira.arisa.modules
 import arrow.core.Either
 import arrow.core.extensions.fx
 import arrow.core.left
+import arrow.syntax.function.partially1
 import io.github.mojira.arisa.domain.Comment
 import io.github.mojira.arisa.domain.Issue
 import io.github.mojira.arisa.modules.commands.AddVersionCommand
 import io.github.mojira.arisa.modules.commands.Command
 import io.github.mojira.arisa.modules.commands.FixedCommand
+import io.github.mojira.arisa.modules.commands.PurgeAttachmentCommand
 import java.time.Instant
 
 // TODO if we get a lot of commands it might make sense to create a command registry
 class CommandModule(
     val addVersionCommand: Command = AddVersionCommand(),
-    val fixedCommand: Command = FixedCommand()
+    val fixedCommand: Command = FixedCommand(),
+    val purgeAttachmentCommand: Command = PurgeAttachmentCommand()
 ) : Module {
     override fun invoke(issue: Issue, lastRun: Instant): Either<ModuleError, ModuleResponse> = Either.fx {
         with(issue) {
             val staffComments = comments
+                .filter(::isUpdatedAfterLastRun.partially1(lastRun))
                 .filter(::isStaffRestricted)
                 .filter(::userIsVolunteer)
                 .filter(::isProbablyACommand)
@@ -51,9 +55,14 @@ class CommandModule(
             "ARISA_FIXED" -> if (userIsMod) {
                 fixedCommand(issue, *arguments)
             } else OperationNotNeededModuleResponse.left()
+            "ARISA_PURGE_ATTACHMENT" -> if (userIsMod) {
+                purgeAttachmentCommand(issue, *arguments)
+            } else OperationNotNeededModuleResponse.left()
             else -> OperationNotNeededModuleResponse.left()
         }
     }
+
+    private fun isUpdatedAfterLastRun(lastRun: Instant, comment: Comment) = comment.updated.isAfter(lastRun)
 
     private fun isProbablyACommand(comment: Comment) =
         !comment.body.isNullOrBlank() &&

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/PurgeAttachmentCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/PurgeAttachmentCommand.kt
@@ -10,8 +10,10 @@ import io.github.mojira.arisa.modules.toFailedModuleEither
 import kotlinx.coroutines.runBlocking
 
 class PurgeAttachmentCommand : Command {
+    private val argumentAmount = 3
+
     override fun invoke(issue: Issue, vararg arguments: String): Either<ModuleError, ModuleResponse> = Either.fx {
-        assertTrue(arguments.size <= 3).bind()
+        assertTrue(arguments.size <= argumentAmount).bind()
         val startID = arguments.getOrNull(1)?.toIntEither()?.bind() ?: 0
         val endID = arguments.getOrNull(2)?.toIntEither()?.bind() ?: Int.MAX_VALUE
         for (attachment in issue.attachments) {

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/PurgeAttachmentCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/PurgeAttachmentCommand.kt
@@ -1,0 +1,30 @@
+package io.github.mojira.arisa.modules.commands
+
+import arrow.core.Either
+import arrow.core.extensions.fx
+import io.github.mojira.arisa.domain.Issue
+import io.github.mojira.arisa.modules.ModuleError
+import io.github.mojira.arisa.modules.ModuleResponse
+import io.github.mojira.arisa.modules.assertTrue
+import io.github.mojira.arisa.modules.toFailedModuleEither
+import kotlinx.coroutines.runBlocking
+
+class PurgeAttachmentCommand : Command {
+    override fun invoke(issue: Issue, vararg arguments: String): Either<ModuleError, ModuleResponse> = Either.fx {
+        assertTrue(arguments.size <= 3).bind()
+        val startID = arguments.getOrNull(1)?.toIntEither()?.bind() ?: 0
+        val endID = arguments.getOrNull(2)?.toIntEither()?.bind() ?: Int.MAX_VALUE
+        for (attachment in issue.attachments) {
+            val attachmentID = attachment.id.toIntEither().bind()
+            if (attachmentID in startID..endID) {
+                attachment.remove()
+            }
+        }
+    }
+
+    private fun String.toIntEither() = runBlocking {
+        Either.catch {
+            toInt()
+        }
+    }.toFailedModuleEither()
+}

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/PurgeAttachmentCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/PurgeAttachmentCommand.kt
@@ -10,10 +10,9 @@ import io.github.mojira.arisa.modules.toFailedModuleEither
 import kotlinx.coroutines.runBlocking
 
 class PurgeAttachmentCommand : Command {
-    private val argumentAmount = 3
-
+    @Suppress("MagicNumber")
     override fun invoke(issue: Issue, vararg arguments: String): Either<ModuleError, ModuleResponse> = Either.fx {
-        assertTrue(arguments.size <= argumentAmount).bind()
+        assertTrue(arguments.size <= 3).bind()
         val startID = arguments.getOrNull(1)?.toIntEither()?.bind() ?: 0
         val endID = arguments.getOrNull(2)?.toIntEither()?.bind() ?: Int.MAX_VALUE
         for (attachment in issue.attachments) {

--- a/src/test/kotlin/io/github/mojira/arisa/modules/CommandModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/CommandModuleTest.kt
@@ -14,6 +14,8 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
+private val TWO_SECONDS_LATER = RIGHT_NOW.plusSeconds(2)
+
 class CommandModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse when no comments" {
         val module = CommandModule(mockUnitCommand, mockUnitCommand)
@@ -169,6 +171,8 @@ private fun getComment(
     visibilityValue: String? = "staff",
     body: String = "ARISA_ADD_VERSION something"
 ) = mockComment(
+    created = TWO_SECONDS_LATER,
+    updated = TWO_SECONDS_LATER,
     getAuthorGroups = getAuthorGroups,
     visibilityType = visibilityType,
     visibilityValue = visibilityValue,

--- a/src/test/kotlin/io/github/mojira/arisa/modules/commands/PurgeAttachmentCommandTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/commands/PurgeAttachmentCommandTest.kt
@@ -1,0 +1,131 @@
+package io.github.mojira.arisa.modules.commands
+
+import io.github.mojira.arisa.modules.FailedModuleResponse
+import io.github.mojira.arisa.modules.ModuleResponse
+import io.github.mojira.arisa.modules.OperationNotNeededModuleResponse
+import io.github.mojira.arisa.utils.mockAttachment
+import io.github.mojira.arisa.utils.mockIssue
+import io.kotest.assertions.arrow.either.shouldBeLeft
+import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+class PurgeAttachmentCommandTest : StringSpec({
+    "should return OperationNotNeededModuleResponse when there are too many arguments" {
+        val command = PurgeAttachmentCommand()
+
+        val issue = mockIssue()
+
+        val result = command(issue, "ARISA_PURGE_ATTACHMENT", "0", "1", "2")
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should purge all attachments when no ID is specified" {
+        var attachment0Removed = false
+        var attachment1Removed = false
+        var attachment2Removed = false
+        val command = PurgeAttachmentCommand()
+
+        val issue = mockIssue(
+            attachments = listOf(
+                mockAttachment(
+                    id = "0",
+                    remove = { attachment0Removed = true }
+                ),
+                mockAttachment(
+                    id = "1",
+                    remove = { attachment1Removed = true }
+                ),
+                mockAttachment(
+                    id = "2",
+                    remove = { attachment2Removed = true }
+                )
+            )
+        )
+
+        val result = command(issue, "ARISA_PURGE_ATTACHMENT")
+
+        result.shouldBeRight(ModuleResponse)
+        attachment0Removed.shouldBeTrue()
+        attachment1Removed.shouldBeTrue()
+        attachment2Removed.shouldBeTrue()
+    }
+
+    "should purge all attachments after 1" {
+        var attachment0Removed = false
+        var attachment1Removed = false
+        var attachment2Removed = false
+        val command = PurgeAttachmentCommand()
+
+        val issue = mockIssue(
+            attachments = listOf(
+                mockAttachment(
+                    id = "0",
+                    remove = { attachment0Removed = true }
+                ),
+                mockAttachment(
+                    id = "1",
+                    remove = { attachment1Removed = true }
+                ),
+                mockAttachment(
+                    id = "2",
+                    remove = { attachment2Removed = true }
+                )
+            )
+        )
+
+        val result = command(issue, "ARISA_PURGE_ATTACHMENT", "1")
+
+        result.shouldBeRight(ModuleResponse)
+        attachment0Removed.shouldBeFalse()
+        attachment1Removed.shouldBeTrue()
+        attachment2Removed.shouldBeTrue()
+    }
+
+    "should purge all attachments between 0 and 1" {
+        var attachment0Removed = false
+        var attachment1Removed = false
+        var attachment2Removed = false
+        val command = PurgeAttachmentCommand()
+
+        val issue = mockIssue(
+            attachments = listOf(
+                mockAttachment(
+                    id = "0",
+                    remove = { attachment0Removed = true }
+                ),
+                mockAttachment(
+                    id = "1",
+                    remove = { attachment1Removed = true }
+                ),
+                mockAttachment(
+                    id = "2",
+                    remove = { attachment2Removed = true }
+                )
+            )
+        )
+
+        val result = command(issue, "ARISA_PURGE_ATTACHMENT", "0", "1")
+
+        result.shouldBeRight(ModuleResponse)
+        attachment0Removed.shouldBeTrue()
+        attachment1Removed.shouldBeTrue()
+        attachment2Removed.shouldBeFalse()
+    }
+
+    "should return FailedModuleResponse when the argument is illegal" {
+        val command = PurgeAttachmentCommand()
+
+        val issue = mockIssue()
+
+        val result = command(issue, "ARISA_PURGE_ATTACHMENT", "illegal")
+
+        result.shouldBeLeft()
+        result.a should { it is FailedModuleResponse }
+        (result.a as FailedModuleResponse).exceptions.size shouldBe 1
+    }
+})

--- a/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
@@ -17,12 +17,14 @@ import java.time.Instant
 val RIGHT_NOW: Instant = Instant.now()
 
 fun mockAttachment(
+    id: String = "0",
     name: String = "",
     created: Instant = RIGHT_NOW,
     mimeType: String = "text/plain",
     remove: () -> Unit = { Unit },
     getContent: () -> ByteArray = { ByteArray(0) }
 ) = Attachment(
+    id,
     name,
     created,
     mimeType,


### PR DESCRIPTION
## Purpose
Fix #306.
## Approach
By adding a new `ARISA_PURGE_ATTACHMENT <start ID> [<stop ID>]` command.
## Future work

#### Checklist
- [x] Included tests
- [x] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [x] Tested in [MCTEST-98](https://bugs.mojang.com/browse/MCTEST-98) and [MC-196464](https://bugs.mojang.com/browse/MC-196464)
