### PR TITLE
Revoke changes done to Mojang Priority by non-mods/staff

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -299,6 +299,11 @@
           "MCE"
         ]
       },
+      "revokePriority": {
+        "whitelist": [
+          "MC"
+        ]
+      },
       "keepPrivate": {
         "resolutions": [
           "Awaiting Response",

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -38,6 +38,7 @@ import io.github.mojira.arisa.modules.ReopenAwaitingModule
 import io.github.mojira.arisa.modules.ReplaceTextModule
 import io.github.mojira.arisa.modules.ResolveTrashModule
 import io.github.mojira.arisa.modules.RevokeConfirmationModule
+import io.github.mojira.arisa.modules.RevokePriorityModule
 import io.github.mojira.arisa.modules.TransferLinksModule
 import io.github.mojira.arisa.modules.TransferVersionsModule
 import io.github.mojira.arisa.modules.UpdateLinkedModule
@@ -208,6 +209,8 @@ class ModuleRegistry(private val config: Config) {
         register(Modules.ReplaceText, ReplaceTextModule())
 
         register(Modules.RevokeConfirmation, RevokeConfirmationModule())
+        
+        register(Modules.RevokePriority, RevokePriorityModule())
 
         register(Modules.ResolveTrash, ResolveTrashModule())
 

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -209,7 +209,7 @@ class ModuleRegistry(private val config: Config) {
         register(Modules.ReplaceText, ReplaceTextModule())
 
         register(Modules.RevokeConfirmation, RevokeConfirmationModule())
-        
+
         register(Modules.RevokePriority, RevokePriorityModule())
 
         register(Modules.ResolveTrash, ResolveTrashModule())

--- a/src/main/kotlin/io/github/mojira/arisa/domain/Issue.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/domain/Issue.kt
@@ -33,6 +33,7 @@ data class Issue(
     val updateDescription: (description: String) -> Unit,
     val updateCHK: () -> Unit,
     val updateConfirmationStatus: (String) -> Unit,
+    val updatePriority: (String) -> Unit,
     val updateLinked: (Double) -> Unit,
     val setPrivate: () -> Unit,
     val addAffectedVersion: (id: String) -> Unit,

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
@@ -228,6 +228,8 @@ object Arisa : ConfigSpec() {
         }
 
         object RevokeConfirmation : ModuleConfigSpec()
+        
+        object RevokePriority : ModuleConfigSpec()
 
         object KeepPrivate : ModuleConfigSpec() {
             val message by required<String>(

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
@@ -228,7 +228,7 @@ object Arisa : ConfigSpec() {
         }
 
         object RevokeConfirmation : ModuleConfigSpec()
-        
+
         object RevokePriority : ModuleConfigSpec()
 
         object KeepPrivate : ModuleConfigSpec() {

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
@@ -56,6 +56,13 @@ fun updateConfirmation(context: Lazy<IssueUpdateContext>, confirmationField: Str
     context.value.hasUpdates = true
     context.value.update.field(confirmationField, jsonValue)
 }
+fun updatePriority(context: Lazy<IssueUpdateContext>, mojangPriorityField: String, value: String) {
+    val jsonValue = JSONObject()
+    jsonValue["value"] = value
+
+    context.value.hasUpdates = true
+    context.value.update.field(mojangPriorityField, jsonValue)
+}
 
 fun updateLinked(context: Lazy<IssueUpdateContext>, linkedField: String, value: Double) {
     context.value.hasUpdates = true

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
@@ -110,6 +110,7 @@ fun JiraIssue.toDomain(
         ::updateDescription.partially1(context),
         ::updateCHK.partially1(context).partially1(config[Arisa.CustomFields.chkField]),
         ::updateConfirmation.partially1(context).partially1(config[Arisa.CustomFields.confirmationField]),
+        ::updatePriority.partially1(context).partially1(config[Arisa.CustomFields.mojangPriorityField]),
         ::updateLinked.partially1(context).partially1(config[Arisa.CustomFields.linked]),
         ::updateSecurity.partially1(context).partially1(project.getSecurityLevelId(config)),
         ::addAffectedVersionById.partially1(context),

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RevokePriorityModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RevokePriorityModule.kt
@@ -1,0 +1,41 @@
+package io.github.mojira.arisa.modules
+
+import arrow.core.Either
+import arrow.core.extensions.fx
+import io.github.mojira.arisa.domain.ChangeLogItem
+import io.github.mojira.arisa.domain.Issue
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class RevokePriorityModule : Module {
+    override fun invoke(issue: Issue, lastRun: Instant): Either<ModuleError, ModuleResponse> = with(issue) {
+        Either.fx {
+            val prioritySet = changeLog
+                .filter(::isPriorityChange)
+                .filter(::changedByPermitted)
+                .lastOrNull()
+                ?.changedToString.getOrDefault("None")
+
+            assertNotEquals(priority.getOrDefault("None"), prioritySet).bind()
+            updatePriority(prioritySet)
+        }
+    }
+
+    private fun isPriorityChange(item: ChangeLogItem) =
+        item.field == "Mojang Priority"
+
+    private fun changedByPermitted(item: ChangeLogItem) = !updateIsRecent(item) ||
+            item.getAuthorGroups()?.any { it == "global-moderators" || it == "staff" } ?: true
+
+    private fun updateIsRecent(item: ChangeLogItem) =
+        item
+            .created
+            .plus(1, ChronoUnit.DAYS)
+            .isAfter(Instant.now())
+
+    private fun String?.getOrDefault(default: String) =
+        if (isNullOrBlank())
+            default
+        else
+            this!!
+}

--- a/src/test/kotlin/io/github/mojira/arisa/modules/RevokePriorityModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/RevokePriorityModuleTest.kt
@@ -1,0 +1,231 @@
+package io.github.mojira.arisa.modules
+
+import arrow.core.right
+import io.github.mojira.arisa.infrastructure.jira.updatePriority
+import io.github.mojira.arisa.utils.RIGHT_NOW
+import io.github.mojira.arisa.utils.mockChangeLogItem
+import io.github.mojira.arisa.utils.mockIssue
+import io.kotest.assertions.arrow.either.shouldBeLeft
+import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class RevokePriorityModuleTest : StringSpec({
+    "should return OperationNotNeededModuleResponse when Ticket has no priority and priority was never set" {
+        val module = RevokePriorityModule()
+        val issue = mockIssue(
+            priority = "None"
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when Ticket has a priority and was changed by staff" {
+        val module = RevokePriorityModule()
+        val changeLogItem = io.github.mojira.arisa.modules.mockChangeLogItem { listOf("staff") }
+        val issue = mockIssue(
+            priority = "Important",
+            changeLog = listOf(changeLogItem)
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when Ticket has a priority and was changed by global-moderator" {
+        val module = RevokePriorityModule()
+        val changeLogItem = io.github.mojira.arisa.modules.mockChangeLogItem { listOf("global-moderators") }
+        val issue = mockIssue(
+            priority = "Important",
+            changeLog = listOf(changeLogItem)
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when Ticket priority was set more than a day ago by a user who is no longer staff" {
+        val module = RevokePriorityModule()
+        val changeLogItem = io.github.mojira.arisa.modules.mockChangeLogItem(Instant.now().minus(2, ChronoUnit.DAYS))
+        val issue = mockIssue(
+            priority = "Important",
+            changeLog = listOf(changeLogItem)
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when Ticket has priority and groups are unknown" {
+        val module = RevokePriorityModule()
+        val changeLogItem = io.github.mojira.arisa.modules.mockChangeLogItem { null }
+        val issue = mockIssue(
+            priority = "Important",
+            changeLog = listOf(changeLogItem)
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when multiple permitted changed the mojang priority" {
+        val module = RevokePriorityModule()
+        val permittedChange = io.github.mojira.arisa.modules.mockChangeLogItem { listOf("staff") }
+        val otherPermittedChange = mockChangeLogItem(value = "None") { listOf("global-moderators") }
+        val issue = mockIssue(
+            priority = "None",
+            changeLog = listOf(permittedChange, otherPermittedChange)
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when ticket has no priority and priority was unset" {
+        val module = RevokePriorityModule()
+        val permittedChange = io.github.mojira.arisa.modules.mockChangeLogItem { listOf("staff") }
+        val otherPermittedChange = mockChangeLogItem(value = "") { listOf("global-moderators") }
+        val issue = mockIssue(
+            priority = "None",
+            changeLog = listOf(permittedChange, otherPermittedChange)
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when priority is null and was unset" {
+        val module = RevokePriorityModule()
+        val permittedChange = io.github.mojira.arisa.modules.mockChangeLogItem { listOf("staff") }
+        val otherPermittedChange = mockChangeLogItem(value = "") { listOf("global-moderators") }
+        val issue = mockIssue(
+            changeLog = listOf(permittedChange, otherPermittedChange)
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when priority is empty and was unset" {
+        val module = RevokePriorityModule()
+        val permittedChange = io.github.mojira.arisa.modules.mockChangeLogItem { listOf("staff") }
+        val otherPermittedChange = mockChangeLogItem(value = "") { listOf("global-moderators") }
+        val issue = mockIssue(
+            priority = "",
+            changeLog = listOf(permittedChange, otherPermittedChange)
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should set priority to None when ticket was created with a priority" {
+        var changedPriority = ""
+
+        val module = RevokePriorityModule()
+        val issue = mockIssue(
+            priority = "Important",
+            updatePriority = { changedPriority = it; Unit.right() }
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight(ModuleResponse)
+        changedPriority.shouldBe("None")
+    }
+
+    "should set to None when there is a changelog entry unrelated to mojang priority" {
+        var changedPriority = ""
+
+        val module = RevokePriorityModule()
+        val changeLogItem =
+            io.github.mojira.arisa.modules.mockChangeLogItem(field = "Totally Not Priority") { listOf("staff") }
+        val issue = mockIssue(
+            priority = "Important",
+            changeLog = listOf(changeLogItem),
+            updatePriority = { changedPriority = it; Unit.right() }
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight(ModuleResponse)
+        changedPriority.shouldBe("None")
+    }
+
+    "should set to None when ticket priority was changed by a non-permitted" {
+        var changedPriority = ""
+
+        val module = RevokePriorityModule()
+        val changeLogItem = io.github.mojira.arisa.modules.mockChangeLogItem()
+        val issue = mockIssue(
+            priority = "Important",
+            changeLog = listOf(changeLogItem),
+            updatePriority = { changedPriority = it; Unit.right() }
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight(ModuleResponse)
+        changedPriority.shouldBe("None")
+    }
+
+    "should set back to priority set by permitted, when regular user changes mojang priority" {
+        var changedPriority = ""
+
+        val module = RevokePriorityModule()
+        val permittedChange = io.github.mojira.arisa.modules.mockChangeLogItem { listOf("staff") }
+        val userChange = mockChangeLogItem(value = "None") { listOf("users") }
+        val issue = mockIssue(
+            priority = "None",
+            changeLog = listOf(permittedChange, userChange),
+            updatePriority = { changedPriority = it; Unit.right() }
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight(ModuleResponse)
+        changedPriority.shouldBe("Important")
+    }
+
+    "should set back to previous status when regular user changes confirmation status set by someone who no longer is a volunteer" {
+        var changedPriority = ""
+
+        val module = RevokePriorityModule()
+        val permittedChange = io.github.mojira.arisa.modules.mockChangeLogItem(Instant.now().minus(2, ChronoUnit.DAYS))
+        val userChange = mockChangeLogItem(value = "None") { listOf("users") }
+        val issue = mockIssue(
+            priority = "None",
+            changeLog = listOf(permittedChange, userChange),
+            updatePriority = { changedPriority = it; Unit.right() }
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight(ModuleResponse)
+        changedPriority.shouldBe("Important")
+    }
+})
+
+private fun mockChangeLogItem(
+    created: Instant = RIGHT_NOW,
+    field: String = "Mojang Priority",
+    value: String = "Important",
+    getAuthorGroups: () -> List<String>? = { emptyList() }
+) = mockChangeLogItem(
+    created = created,
+    field = field,
+    changedToString = value,
+    getAuthorGroups = getAuthorGroups
+)

--- a/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
@@ -105,6 +105,7 @@ fun mockIssue(
     updateDescription: (description: String) -> Unit = { Unit },
     updateCHK: () -> Unit = { Unit },
     updateConfirmationStatus: (String) -> Unit = { Unit },
+    updatePriority: (String) -> Unit = { Unit },
     updateLinked: (Double) -> Unit = { Unit },
     setPrivate: () -> Unit = { Unit },
     addAffectedVersion: (id: String) -> Unit = { Unit },

--- a/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
@@ -146,6 +146,7 @@ fun mockIssue(
     updateDescription,
     updateCHK,
     updateConfirmationStatus,
+    updatePriority,
     updateLinked,
     setPrivate,
     addAffectedVersion,


### PR DESCRIPTION
## Purpose
Revoke changes done to the Mojang Priority by those who do not have permissions
## Approach

## Future work

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
