### PR TITLE
Remove extra added versions to resolved tickets by users

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -230,6 +230,15 @@
           "Works As Intended"
         ]
       },
+      "removeVersion": {
+        "resolutions": [
+          "Duplicate",
+          "Incomplete",
+          "Invalid",
+          "Works as Intended",
+          "Won't Fix"
+        ]
+      },
       "crash": {
         "excludedStatuses": ["Postponed"],
         "crashExtensions": [

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -219,7 +219,7 @@ class ModuleRegistry(private val config: Config) {
                 config[Modules.FutureVersion.panel]
             )
         )
-        
+
         register(Modules.RemoveVersion, RemoveVersionModule())
 
         register(Modules.Command, CommandModule())

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -34,6 +34,7 @@ import io.github.mojira.arisa.modules.PrivacyModule
 import io.github.mojira.arisa.modules.RemoveIdenticalLinkModule
 import io.github.mojira.arisa.modules.RemoveNonStaffMeqsModule
 import io.github.mojira.arisa.modules.RemoveTriagedMeqsModule
+import io.github.mojira.arisa.modules.RemoveVersionModule
 import io.github.mojira.arisa.modules.ReopenAwaitingModule
 import io.github.mojira.arisa.modules.ReplaceTextModule
 import io.github.mojira.arisa.modules.ResolveTrashModule
@@ -218,6 +219,8 @@ class ModuleRegistry(private val config: Config) {
                 config[Modules.FutureVersion.panel]
             )
         )
+        
+        register(Modules.RemoveVersion, RemoveVersionModule())
 
         register(Modules.Command, CommandModule())
 

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
@@ -253,6 +253,8 @@ object Arisa : ConfigSpec() {
         object ReplaceText : ModuleConfigSpec()
 
         object RemoveIdenticalLink : ModuleConfigSpec()
+        
+        object RemoveVersion : ModuleConfigSpec()
 
         object Command : ModuleConfigSpec()
     }

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
@@ -253,7 +253,7 @@ object Arisa : ConfigSpec() {
         object ReplaceText : ModuleConfigSpec()
 
         object RemoveIdenticalLink : ModuleConfigSpec()
-        
+
         object RemoveVersion : ModuleConfigSpec()
 
         object Command : ModuleConfigSpec()

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
@@ -19,9 +19,7 @@ class RemoveVersionModule : Module {
 
     private fun Issue.getExtraVersionsLatelyAddedByNonVolunteers(lastRun: Instant): List<String> =
         if (created.isAfter(lastRun)) {
-            if (isVolunteer(reporter?.getGroups?.invoke())) {
-                emptyList()
-            } else if (resolution == "Unresolved") {
+            if (resolution == "Unresolved" || isVolunteer(reporter?.getGroups?.invoke())) {
                 emptyList()
             } else {
                 affectedVersions.map { ver -> ver.id }
@@ -30,6 +28,8 @@ class RemoveVersionModule : Module {
             changeLog
                 .asSequence()
                 .filter { it.created.isAfter(lastRun) }
+                .filter { it.field.toLowerCase() == "resolution" }
+                .filterNot { it.changedToString == "Unresolved" }
                 .filter { it.field.toLowerCase() == "version" }
                 .filterNot { isVolunteer(it.getAuthorGroups()) }
                 .mapNotNull { it.changedTo }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
@@ -19,7 +19,7 @@ class RemoveVersionModule(
     }
 
     private fun Issue.getExtraVersionsLatelyAddedByNonVolunteers(lastRun: Instant): List<String> =
-        if (created.isAfter(lastRun) && (resolution == "Invalid" || resolution == "Won't Fix" || resolution == "Works As Intended" || resolution == "Duplicate" || resolution == "Incomplete")) {
+        if (created.isAfter(lastRun)) {
             if (isVolunteer(reporter?.getGroups?.invoke())) {
                 emptyList()
             } else {

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
@@ -19,7 +19,7 @@ class RemoveVersionModule : Module {
 
     private fun Issue.getExtraVersionsLatelyAddedByNonVolunteers(lastRun: Instant): List<String> =
         if (created.isAfter(lastRun)) {
-            if (isVolunteer(reporter?.getGroups?.invoke()) || resolution == "Unresolved") {
+            if (resolution == "Unresolved" || isVolunteer(reporter?.getGroups?.invoke())) {
                 emptyList()
             } else {
                 affectedVersions.map { ver -> ver.id }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
@@ -28,7 +28,7 @@ class RemoveVersionModule : Module {
             changeLog
                 .asSequence()
                 .filter { it.created.isAfter(lastRun) }
-                .filter { it.field.toLowerCase(locale: ENGLISH) == "version" }
+                .filter { it.field.toLowerCase(Locale.ENGLISH) == "version" }
                 .filterNot { isVolunteer(it.getAuthorGroups()) }
                 .mapNotNull { it.changedTo }
                 .toList()

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
@@ -5,7 +5,7 @@ import arrow.core.extensions.fx
 import io.github.mojira.arisa.domain.Issue
 import java.time.Instant
 
-class RemoveVersionModule: Module {
+class RemoveVersionModule : Module {
     override fun invoke(issue: Issue, lastRun: Instant): Either<ModuleError, ModuleResponse> = with(issue) {
         Either.fx {
             val addedVersions = getExtraVersionsLatelyAddedByNonVolunteers(lastRun)
@@ -28,7 +28,7 @@ class RemoveVersionModule: Module {
             changeLog
                 .asSequence()
                 .filter { it.created.isAfter(lastRun) }
-                .filter { it.field.toLowerCase() == "version" }
+                .filter { it.field.toLowerCase(locale: ENGLISH) == "version" }
                 .filterNot { isVolunteer(it.getAuthorGroups()) }
                 .mapNotNull { it.changedTo }
                 .toList()

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
@@ -28,7 +28,7 @@ class RemoveVersionModule : Module {
             changeLog
                 .asSequence()
                 .filter { it.created.isAfter(lastRun) }
-                .filter { it.field.toLowerCase(Locale(ENGLISH)) == "version" }
+                .filter { it.field.toLowerCase() == "version" }
                 .filterNot { isVolunteer(it.getAuthorGroups()) }
                 .mapNotNull { it.changedTo }
                 .toList()

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
@@ -34,7 +34,7 @@ class RemoveVersionModule : Module {
                 .mapNotNull { it.changedTo }
                 .toList()
         }
-    
+
     private fun isResolved(item: io.github.mojira.arisa.domain.ChangeLogItem) =
         item.field == "Resolution" && item.changedTo != null &&
         item.changedToString != null && item.changedToString != "Unresolved"

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
@@ -28,16 +28,11 @@ class RemoveVersionModule : Module {
             changeLog
                 .asSequence()
                 .filter { it.created.isAfter(lastRun) }
-                .filter(::isResolved)
                 .filter { it.field.toLowerCase() == "version" }
                 .filterNot { isVolunteer(it.getAuthorGroups()) }
                 .mapNotNull { it.changedTo }
                 .toList()
         }
-
-    private fun isResolved(item: io.github.mojira.arisa.domain.ChangeLogItem) =
-        item.field == "Resolution" && item.changedTo != null &&
-        item.changedToString != null && item.changedToString != "Unresolved"
 
     private fun isVolunteer(groups: List<String>?) =
         groups?.any { it == "helper" || it == "global-moderators" || it == "staff" } ?: false

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
@@ -5,8 +5,7 @@ import arrow.core.extensions.fx
 import io.github.mojira.arisa.domain.Issue
 import java.time.Instant
 
-class RemoveVersionModule(
-) : Module {
+class RemoveVersionModule: Module {
     override fun invoke(issue: Issue, lastRun: Instant): Either<ModuleError, ModuleResponse> = with(issue) {
         Either.fx {
             val addedVersions = getExtraVersionsLatelyAddedByNonVolunteers(lastRun)

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
@@ -28,13 +28,16 @@ class RemoveVersionModule : Module {
             changeLog
                 .asSequence()
                 .filter { it.created.isAfter(lastRun) }
-                .filter { it.field.toLowerCase() == "resolution" }
-                .filterNot { it.changedToString == "Unresolved" }
+                .filter(::isResolved)
                 .filter { it.field.toLowerCase() == "version" }
                 .filterNot { isVolunteer(it.getAuthorGroups()) }
                 .mapNotNull { it.changedTo }
                 .toList()
         }
+    
+    private fun isResolved(item: io.github.mojira.arisa.domain.ChangeLogItem) =
+        item.field == "Resolution" && item.changedTo != null &&
+        item.changedToString != null && item.changedToString != "Unresolved"
 
     private fun isVolunteer(groups: List<String>?) =
         groups?.any { it == "helper" || it == "global-moderators" || it == "staff" } ?: false

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
@@ -34,5 +34,6 @@ class RemoveVersionModule : Module {
                 .toList()
         }
 
-    private fun isVolunteer(groups: List<String>?) = groups?.any { it == "helper" || it == "global-moderators" || it == "staff" } ?: false
+    private fun isVolunteer(groups: List<String>?) = 
+        groups?.any { it == "helper" || it == "global-moderators" || it == "staff" } ?: false
 }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
@@ -19,7 +19,7 @@ class RemoveVersionModule : Module {
 
     private fun Issue.getExtraVersionsLatelyAddedByNonVolunteers(lastRun: Instant): List<String> =
         if (created.isAfter(lastRun)) {
-            if (isVolunteer(reporter?.getGroups?.invoke())) {
+            if (isVolunteer(reporter?.getGroups?.invoke()) || resolution == "Unresolved") {
                 emptyList()
             } else {
                 affectedVersions.map { ver -> ver.id }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
@@ -19,7 +19,9 @@ class RemoveVersionModule : Module {
 
     private fun Issue.getExtraVersionsLatelyAddedByNonVolunteers(lastRun: Instant): List<String> =
         if (created.isAfter(lastRun)) {
-            if (resolution == "Unresolved" || isVolunteer(reporter?.getGroups?.invoke())) {
+            if (isVolunteer(reporter?.getGroups?.invoke())) {
+                emptyList()
+            } else if (resolution == "Unresolved") {
                 emptyList()
             } else {
                 affectedVersions.map { ver -> ver.id }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
@@ -19,7 +19,7 @@ class RemoveVersionModule : Module {
 
     private fun Issue.getExtraVersionsLatelyAddedByNonVolunteers(lastRun: Instant): List<String> =
         if (created.isAfter(lastRun)) {
-            if (resolution == "Unresolved" || isVolunteer(reporter?.getGroups?.invoke())) {
+            if (isVolunteer(reporter?.getGroups?.invoke())) {
                 emptyList()
             } else {
                 affectedVersions.map { ver -> ver.id }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
@@ -34,6 +34,6 @@ class RemoveVersionModule : Module {
                 .toList()
         }
 
-    private fun isVolunteer(groups: List<String>?) = 
+    private fun isVolunteer(groups: List<String>?) =
         groups?.any { it == "helper" || it == "global-moderators" || it == "staff" } ?: false
 }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
@@ -28,7 +28,7 @@ class RemoveVersionModule : Module {
             changeLog
                 .asSequence()
                 .filter { it.created.isAfter(lastRun) }
-                .filter { it.field.toLowerCase(Locale.ENGLISH) == "version" }
+                .filter { it.field.toLowerCase(Locale(ENGLISH)) == "version" }
                 .filterNot { isVolunteer(it.getAuthorGroups()) }
                 .mapNotNull { it.changedTo }
                 .toList()

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RemoveVersionModule.kt
@@ -34,5 +34,5 @@ class RemoveVersionModule : Module {
                 .toList()
         }
 
-    private fun isVolunteer(groups: List<String>?) = "helper" in (groups ?: emptyList())
+    private fun isVolunteer(groups: List<String>?) = groups?.any { it == "helper" || it == "global-moderators" || it == "staff" } ?: false
 }

--- a/src/test/kotlin/io/github/mojira/arisa/modules/RemoveVersionModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/RemoveVersionModuleTest.kt
@@ -120,28 +120,6 @@ class RemoveVersionModuleTest : StringSpec({
 
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
-    "should return OperationNotNeededModuleResponse when the ticket is unresolved" {
-        val module = RemoveVersionModule()
-        val issue = mockIssue(
-                created = FIVE_SECONDS_AGO,
-                affectedVersions = listOf(VERSION),
-                resolution = "Unresolved",
-                changeLog = listOf(
-                        mockChangeLogItem(
-                                field = "Version",
-                                changedTo = "1",
-                                getAuthorGroups = { listOf("user") }
-                        )
-                ),
-                project = mockProject(
-                        versions = listOf(VERSION)
-                )
-        )
-
-        val result = module(issue, TWO_SECONDS_AGO)
-
-        result.shouldBeLeft(OperationNotNeededModuleResponse)
-    }
 
     "should return OperationNotNeededModuleResponse when affected versions are empty" {
         val module = RemoveVersionModule()

--- a/src/test/kotlin/io/github/mojira/arisa/modules/RemoveVersionModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/RemoveVersionModuleTest.kt
@@ -12,7 +12,7 @@ import io.kotest.core.spec.style.StringSpec
 private val TWO_SECONDS_AGO = RIGHT_NOW.minusSeconds(2)
 private val FIVE_SECONDS_AGO = RIGHT_NOW.minusSeconds(10)
 
-private val VERSION = mockVersion(id = "2", released = true, archived = false)
+private val VERSION = mockVersion(id = "1", released = true, archived = false)
 
 private val ADD_VERSION = mockChangeLogItem(field = "Version", changedTo = "1")
 

--- a/src/test/kotlin/io/github/mojira/arisa/modules/RemoveVersionModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/RemoveVersionModuleTest.kt
@@ -1,0 +1,249 @@
+package io.github.mojira.arisa.modules
+
+import arrow.core.left
+import io.github.mojira.arisa.utils.RIGHT_NOW
+import io.github.mojira.arisa.utils.mockChangeLogItem
+import io.github.mojira.arisa.utils.mockIssue
+import io.github.mojira.arisa.utils.mockProject
+import io.github.mojira.arisa.utils.mockUser
+import io.github.mojira.arisa.utils.mockVersion
+import io.kotest.assertions.arrow.either.shouldBeLeft
+import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+
+private val TWO_SECONDS_AGO = RIGHT_NOW.minusSeconds(2)
+private val FIVE_SECONDS_AGO = RIGHT_NOW.minusSeconds(10)
+
+private val VERSION = mockVersion(id = "2", released = true, archived = false)
+
+private val ADD_VERSION = mockChangeLogItem(field = "Version", changedTo = "1")
+
+class RemoveVersionModuleTest : StringSpec({
+    "should return OperationNotNeededModuleResponse when there is no change log" {
+        val module = RemoveVersionModule()
+        val issue = mockIssue(
+            created = FIVE_SECONDS_AGO,
+            affectedVersions = listOf(VERSION),
+            project = mockProject(
+                versions = listOf(VERSION)
+            )
+        )
+
+        val result = module(issue, TWO_SECONDS_AGO)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when there are no version changes" {
+        val module = RemoveVersionModule()
+        val issue = mockIssue(
+            created = FIVE_SECONDS_AGO,
+            affectedVersions = listOf(VERSION),
+            resolution = "Invalid",
+            changeLog = listOf(
+                mockChangeLogItem(
+                    field = "description"
+                )
+            ),
+            project = mockProject(
+                versions = listOf(VERSION)
+            )
+        )
+
+        val result = module(issue, TWO_SECONDS_AGO)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when the version change is before last run" {
+        val module = RemoveVersionModule()
+        val issue = mockIssue(
+            created = FIVE_SECONDS_AGO,
+            affectedVersions = listOf(VERSION),
+            resolution = "Invalid",
+            changeLog = listOf(
+                mockChangeLogItem(
+                    field = "Version",
+                    created = FIVE_SECONDS_AGO,
+                    changedTo = "1"
+                )
+            ),
+            project = mockProject(
+                versions = listOf(VERSION)
+            )
+        )
+
+        val result = module(issue, TWO_SECONDS_AGO)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when the version change is an removal" {
+        val module = RemoveVersionModule()
+        val issue = mockIssue(
+            created = FIVE_SECONDS_AGO,
+            affectedVersions = listOf(VERSION),
+            resolution = "Invalid",
+            changeLog = listOf(
+                mockChangeLogItem(
+                    field = "Version",
+                    changedTo = null
+                )
+            ),
+            project = mockProject(
+                versions = listOf(VERSION)
+            )
+        )
+
+        val result = module(issue, TWO_SECONDS_AGO)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when the future version is added by a volunteer" {
+        val module = RemoveVersionModule()
+        val issue = mockIssue(
+            created = FIVE_SECONDS_AGO,
+            affectedVersions = listOf(VERSION),
+            resolution = "Invalid",
+            changeLog = listOf(
+                mockChangeLogItem(
+                    field = "Version",
+                    changedTo = "1",
+                    getAuthorGroups = { listOf("helper") }
+                )
+            ),
+            project = mockProject(
+                versions = listOf(VERSION)
+            )
+        )
+
+        val result = module(issue, TWO_SECONDS_AGO)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+    "should return OperationNotNeededModuleResponse when the ticket is unresolved" {
+        val module = RemoveVersionModule()
+        val issue = mockIssue(
+                created = FIVE_SECONDS_AGO,
+                affectedVersions = listOf(VERSION),
+                resolution = "Unresolved",
+                changeLog = listOf(
+                        mockChangeLogItem(
+                                field = "Version",
+                                changedTo = "1",
+                                getAuthorGroups = { listOf("user") }
+                        )
+                ),
+                project = mockProject(
+                        versions = listOf(VERSION)
+                )
+        )
+
+        val result = module(issue, TWO_SECONDS_AGO)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when affected versions are empty" {
+        val module = RemoveVersionModule()
+        val issue = mockIssue(
+            project = mockProject(
+                versions = listOf(VERSION)
+            )
+        )
+
+        val result = module(issue, TWO_SECONDS_AGO)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when project versions are empty" {
+        val module = RemoveVersionModule()
+        val issue = mockIssue(
+            affectedVersions = listOf(VERSION),
+            changeLog = listOf(ADD_VERSION)
+        )
+
+        val result = module(issue, TWO_SECONDS_AGO)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when project versions are null" {
+        val module = RemoveVersionModule()
+        val issue = mockIssue(
+            affectedVersions = listOf(VERSION),
+            changeLog = listOf(ADD_VERSION)
+        )
+
+        val result = module(issue, TWO_SECONDS_AGO)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should remove extra versions added via editing" {
+        val module = RemoveVersionModule()
+        val issue = mockIssue(
+            created = FIVE_SECONDS_AGO,
+            resolution = "Invalid",
+            affectedVersions = listOf(VERSION),
+            changeLog = listOf(ADD_VERSION),
+            project = mockProject(
+                versions = listOf(VERSION)
+            )
+        )
+
+        val result = module(issue, TWO_SECONDS_AGO)
+
+        result.shouldBeRight(ModuleResponse)
+    }
+
+    "should remove extra versions added by users via editing" {
+        val module = RemoveVersionModule()
+        val issue = mockIssue(
+            created = FIVE_SECONDS_AGO,
+            affectedVersions = listOf(VERSION),
+            resolution = "Invalid",
+            changeLog = listOf(
+                mockChangeLogItem(
+                    field = "Version",
+                    changedTo = "1",
+                    getAuthorGroups = { listOf("user") }
+                )
+            ),
+            project = mockProject(
+                versions = listOf(VERSION)
+            )
+        )
+
+        val result = module(issue, TWO_SECONDS_AGO)
+
+        result.shouldBeRight(ModuleResponse)
+    }
+
+    "should remove extra versions added by users without a group via editing" {
+        val module = RemoveVersionModule()
+        val issue = mockIssue(
+            created = FIVE_SECONDS_AGO,
+            affectedVersions = listOf(VERSION),
+            resolution = "Invalid",
+            changeLog = listOf(
+                mockChangeLogItem(
+                    field = "Version",
+                    changedTo = "1",
+                    getAuthorGroups = { null }
+                )
+            ),
+            project = mockProject(
+                versions = listOf(VERSION)
+            )
+        )
+
+        val result = module(issue, TWO_SECONDS_AGO)
+
+        result.shouldBeRight(ModuleResponse)
+    }
+})

--- a/src/test/kotlin/io/github/mojira/arisa/modules/RemoveVersionModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/RemoveVersionModuleTest.kt
@@ -156,30 +156,6 @@ class RemoveVersionModuleTest : StringSpec({
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
-    "should return OperationNotNeededModuleResponse when project versions are empty" {
-        val module = RemoveVersionModule()
-        val issue = mockIssue(
-            affectedVersions = listOf(VERSION),
-            changeLog = listOf(ADD_VERSION)
-        )
-
-        val result = module(issue, TWO_SECONDS_AGO)
-
-        result.shouldBeLeft(OperationNotNeededModuleResponse)
-    }
-
-    "should return OperationNotNeededModuleResponse when project versions are null" {
-        val module = RemoveVersionModule()
-        val issue = mockIssue(
-            affectedVersions = listOf(VERSION),
-            changeLog = listOf(ADD_VERSION)
-        )
-
-        val result = module(issue, TWO_SECONDS_AGO)
-
-        result.shouldBeLeft(OperationNotNeededModuleResponse)
-    }
-
     "should remove extra versions added via editing" {
         val module = RemoveVersionModule()
         val issue = mockIssue(

--- a/src/test/kotlin/io/github/mojira/arisa/modules/RemoveVersionModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/RemoveVersionModuleTest.kt
@@ -1,17 +1,13 @@
 package io.github.mojira.arisa.modules
 
-import arrow.core.left
 import io.github.mojira.arisa.utils.RIGHT_NOW
 import io.github.mojira.arisa.utils.mockChangeLogItem
 import io.github.mojira.arisa.utils.mockIssue
 import io.github.mojira.arisa.utils.mockProject
-import io.github.mojira.arisa.utils.mockUser
 import io.github.mojira.arisa.utils.mockVersion
 import io.kotest.assertions.arrow.either.shouldBeLeft
 import io.kotest.assertions.arrow.either.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.booleans.shouldBeFalse
-import io.kotest.matchers.booleans.shouldBeTrue
 
 private val TWO_SECONDS_AGO = RIGHT_NOW.minusSeconds(2)
 private val FIVE_SECONDS_AGO = RIGHT_NOW.minusSeconds(10)


### PR DESCRIPTION
## Purpose
Closes #406 
## Approach
Allows volunteers to add affected versions to resolved tickets, but removes them if added by a normal user