### PR TITLE
Add a Remove Version Command

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/CommandModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/CommandModule.kt
@@ -11,11 +11,13 @@ import io.github.mojira.arisa.modules.commands.Command
 import io.github.mojira.arisa.modules.commands.DeleteCommentsCommand
 import io.github.mojira.arisa.modules.commands.FixedCommand
 import io.github.mojira.arisa.modules.commands.PurgeAttachmentCommand
+import io.github.mojira.arisa.modules.commands.RemoveVersionCommand
 import java.time.Instant
 
 // TODO if we get a lot of commands it might make sense to create a command registry
 class CommandModule(
     val addVersionCommand: Command = AddVersionCommand(),
+    val removeVersionCommand: Command = RemoveVersionCommand(),
     val fixedCommand: Command = FixedCommand(),
     val purgeAttachmentCommand: Command = PurgeAttachmentCommand(),
     val deleteCommentsCommand: Command = DeleteCommentsCommand()
@@ -54,6 +56,7 @@ class CommandModule(
             // TODO this should be configurable if we move to a registry
             // TODO do we want to add the response of a module via editing the comment?
             "ARISA_ADD_VERSION" -> addVersionCommand(issue, *arguments)
+            "ARISA_REMOVE_VERSION" -> removeVersionCommand(issue, *arguments)
             "ARISA_FIXED" -> if (userIsMod) {
                 fixedCommand(issue, *arguments)
             } else OperationNotNeededModuleResponse.left()

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveVersionCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveVersionCommand.kt
@@ -1,0 +1,19 @@
+package io.github.mojira.arisa.modules.commands
+
+import arrow.core.Either
+import arrow.core.extensions.fx
+import io.github.mojira.arisa.domain.Issue
+import io.github.mojira.arisa.modules.ModuleError
+import io.github.mojira.arisa.modules.ModuleResponse
+import io.github.mojira.arisa.modules.assertTrue
+
+class RemoveVersionCommand : Command {
+    override fun invoke(issue: Issue, vararg arguments: String): Either<ModuleError, ModuleResponse> = Either.fx {
+        assertTrue(arguments.size > 1).bind()
+        val version = arguments.asList().subList(1, arguments.size).joinToString(" ")
+        assertTrue(issue.affectedVersions.any { it.name == version }).bind()
+        assertTrue(issue.project.versions.any { it.name == version }).bind()
+        val idNum = issue.affectedVersions.indexOf(version)
+        issue.affectedVersions[idNum].remove
+    }
+}

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveVersionCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveVersionCommand.kt
@@ -6,13 +6,13 @@ import io.github.mojira.arisa.domain.Issue
 import io.github.mojira.arisa.modules.ModuleError
 import io.github.mojira.arisa.modules.ModuleResponse
 import io.github.mojira.arisa.modules.assertTrue
+import io.github.mojira.arisa.modules.assertNotNull
 
 class RemoveVersionCommand : Command {
     override fun invoke(issue: Issue, vararg arguments: String): Either<ModuleError, ModuleResponse> = Either.fx {
         assertTrue(arguments.size > 1).bind()
         val version = arguments.asList().subList(1, arguments.size).joinToString(" ")
         assertTrue(issue.affectedVersions.any { it.name == version }).bind()
-        assertTrue(issue.project.versions.any { it.name == version }).bind()
         assertNotNull(issue.affectedVersions.indexOf(issue.project.versions.first { it.name == version })).bind()
         val idNum = issue.affectedVersions.indexOf(issue.project.versions.first { it.name == version })
         issue.affectedVersions[idNum].remove

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveVersionCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveVersionCommand.kt
@@ -13,7 +13,8 @@ class RemoveVersionCommand : Command {
         val version = arguments.asList().subList(1, arguments.size).joinToString(" ")
         assertTrue(issue.affectedVersions.any { it.name == version }).bind()
         assertTrue(issue.project.versions.any { it.name == version }).bind()
-        val idNum = issue.affectedVersions.indexOf(version)
+        assertNotNull(issue.affectedVersions.indexOf(issue.project.versions.first { it.name == version })).bind()
+        val idNum = issue.affectedVersions.indexOf(issue.project.versions.first { it.name == version })
         issue.affectedVersions[idNum].remove
     }
 }

--- a/src/test/kotlin/io/github/mojira/arisa/modules/commands/RemoveVersionCommandTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/commands/RemoveVersionCommandTest.kt
@@ -1,0 +1,93 @@
+package io.github.mojira.arisa.modules.commands
+
+import io.github.mojira.arisa.modules.ModuleResponse
+import io.github.mojira.arisa.modules.OperationNotNeededModuleResponse
+import io.github.mojira.arisa.utils.mockIssue
+import io.github.mojira.arisa.utils.mockProject
+import io.github.mojira.arisa.utils.mockVersion
+import io.kotest.assertions.arrow.either.shouldBeLeft
+import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.core.spec.style.StringSpec
+
+class RemoveVersionCommandTest : StringSpec({
+    "should return OperationNotNeededModuleResponse when no argument is passed" {
+        val command = RemoveVersionCommand()
+
+        val issue = mockIssue(
+            project = mockProject(
+                versions = listOf(getVersion(true, false))
+            )
+        )
+
+        val result = command(issue, "ARISA_REMOVE_VERSION")
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when version is not added" {
+        val command = RemoveVersionCommand()
+
+        val issue = mockIssue(
+            project = mockProject(
+                versions = listOf(
+                        getVersion(true, false, "1.15.3"),
+                        getVersion(true, false)
+                )
+            ),
+            affectedVersions = listOf(getVersion(true, false, "1.15.3"))
+        )
+
+        val result = command(issue, "ARISA_REMOVE_VERSION", "12w34a")
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should remove version" {
+        val command = RemoveVersionCommand()
+
+        val issue = mockIssue(
+            project = mockProject(
+                versions = listOf(
+                    getVersion(true, false, "12w34b")
+                )
+            ),
+            affectedVersions = listOf(getVersion(true, false, "12w34b"))
+        )
+
+        val result = command(issue, "ARISA_REMOVE_VERSION", "12w34b")
+
+        result.shouldBeRight(ModuleResponse)
+    }
+
+    "should remove version with spaces" {
+        val command = RemoveVersionCommand()
+
+        val issue = mockIssue(
+            project = mockProject(
+                versions = listOf(
+                    getVersion(true, false),
+                    getVersion(true, false, "Minecraft 12w34b")
+                )
+            ),
+            affectedVersions = listOf(getVersion(true, false, "Minecraft 12w34b"))
+        )
+
+        val result = command(issue, "ARISA_REMOVE_VERSION", "Minecraft", "12w34b")
+
+        result.shouldBeRight(ModuleResponse)
+    }
+})
+
+private fun getVersion(
+    released: Boolean,
+    archived: Boolean,
+    name: String = "12w34a",
+    add: () -> Unit = { Unit },
+    remove: () -> Unit = { Unit }
+) = mockVersion(
+    name = name,
+    released = released,
+    archived = archived,
+    add = add,
+    remove = remove
+)


### PR DESCRIPTION
## Purpose
You can't remove archived versions from a ticket, and this fixes that. (Could be used to undo accidental adding affected versions through the add version command)
## Approach
Copied add version command and tweaked it.
#### Checklist
- [x] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
