### PR TITLE
Remove 'nova' from pirated launcher list

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -105,7 +105,6 @@
           "iridium",
           "mcdonalds",
           "uranium",
-          "nova",
           "divinity",
           "gemini",
           "mineshafter",


### PR DESCRIPTION
## Purpose
'Nova' is considered a pirated launcher. This causes reports mentioning Huawei Nova mobile devices to be automatically invalidated. This may be a big issue, unless I'm missing something and just using one of those devices really means that you're pirating the game. Additionally, as stated in #435, using the word 'nova' in a report triggers both the piracy module and the language module at once, which causes Arisa to make an empty comment. This will fix the main cause of that issue.

Example ticket: https://bugs.mojang.com/browse/MCPE-101708
## Approach
Remove nova from arisa.json.