### PR TITLE
Add sh, command, and cmd to extension blacklist

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -62,6 +62,9 @@
           "doc",
           "docx",
           "odt",
+          "sh",
+          "command",
+          "cmd",
           "rtf"
         ],
         "comment": "attach-new-attachment"


### PR DESCRIPTION
sh, command, and cmd are file types that essentially serve the same purpose as bat files, so they should be removed from tickets automatically as well.