### PR TITLE
Fix exception in createLink

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
@@ -218,9 +218,12 @@ fun createLink(
         }
     } else {
         runBlocking {
-            Either.catch {
+            val either = Either.catch {
                 val key = context.value.jiraIssue.key
                 createLink(getContext(linkKey), getContext, linkType, key, true)
+            }
+            if (either.isLeft()) {
+                context.value.otherOperations.add { either }
             }
         }
     }

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
@@ -217,8 +217,12 @@ fun createLink(
             }
         }
     } else {
-        val key = context.value.jiraIssue.key
-        createLink(getContext(linkKey), getContext, linkType, key, true)
+        runBlocking {
+            Either.catch {
+                val key = context.value.jiraIssue.key
+                createLink(getContext(linkKey), getContext, linkType, key, true)
+            }
+        }
     }
 }
 

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
@@ -309,6 +309,7 @@ private fun JiraIssue.getFullIssue(
         }
     )
 
+// run with Either.catch {}!
 private fun JiraIssue.getOtherUpdateContext(
     jiraClient: JiraClient,
     cache: IssueUpdateContextCache,


### PR DESCRIPTION
## Issue
In createLink when you try to link a non-existing ticket with outwards = false, the exception is not caught into context cache and I'm not sure whether this kind of exception is handled well

## Approach
Catch any exceptions that happen when getContext is used, and add them into cache

## Future work

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx // frankly I'm scared to test it when faulty bot is running, as that may crash the bot and I don't trust myself to go through code and figure out whether it crashes
