### PR TITLE
Fix the warning about inferring the type of the return value of bind() to Nothing

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/CommandModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/CommandModule.kt
@@ -38,7 +38,7 @@ class CommandModule(
                 .map { it.author.name to executeCommand(it.body!!, this, userIsMod(it)) }
 
             if (results.isEmpty()) {
-                OperationNotNeededModuleResponse.left().bind()
+                (OperationNotNeededModuleResponse.left() as Either<ModuleError, ModuleResponse>).bind()
             }
             results.forEach { (username, result) ->
                 if (result.isLeft()) {


### PR DESCRIPTION
## Purpose
To not have the warning each time you try to commit CommandModule.kt

## Approach
Add casting for the OperationNotNeededModuleResponse.left() into an Either with the same types as the invoke's return type (as it has the Right type set)

## Future work

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
