### PR TITLE
Add dylib and bundle files to the excluded list

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -103,6 +103,8 @@
           ".msh1xml",
           ".msh2xml",
           ".scf",
+          ".bundle",
+          ".dylib",
           ".rtf"
         ],
         "comment": "attach-new-attachment"


### PR DESCRIPTION
## Purpose
Add .dylib and .bundle files to the excluded list, which may be malicious and have been attached to tickets recently. (see https://discord.com/channels/647810384031645728/647810384622911490/768120496306389043)
## Approach
Add these extensions to the excluded extensions list.
