### PR TITLE
Add .img and .smi to disallow list

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -56,6 +56,8 @@
           ".bat",
           ".msi",
           ".dmg",
+          ".img",
+          ".smi",
           ".run",
           ".lnk",
           ".inf",


### PR DESCRIPTION
Fixes mojira#480.

## Purpose
Add .iso and .smi to the disallow list, as these file types are similar to dmg files and may be malicious.
## Approach
Add these extensions to the arisa.json file.