### PR TITLE
Add .saver and .definition files to disallow list

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -80,6 +80,8 @@
           ".cpgz",
           ".iso",
           ".action",
+          ".saver",
+          ".definition",
           ".esh",
           ".isu",
           ".prg",


### PR DESCRIPTION
Fixes #483. Like Jack McKalling said in a comment in that issue, focusing on only the allowed file types may be beneficial in the future. However, I don't think this should be changed without further discussion (I don't know if discussion is already being done internally).
This pull request blocks .saver and .definition files, which both can contain malicious code.
## Approach
Add these file extensions to `arisa.json`.