### PR TITLE
Only allow the keep AR message once per ticket

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModule.kt
@@ -40,7 +40,9 @@ class ReopenAwaitingModule(
                 reopen()
             } else {
                 assertNotEquals(changeLog.maxByOrNull { it.created }?.author?.name, "arisabot")
-                addComment(CommentOptions(message))
+                if (comments.none(::isKeepARMessage)) {
+                    addComment(CommentOptions(message))
+                }
             }
         }
     }
@@ -61,6 +63,9 @@ class ReopenAwaitingModule(
     private fun isKeepARTag(comment: Comment) = comment.visibilityType == "group" &&
             comment.visibilityValue == "staff" &&
             (comment.body?.contains(keepARTag) ?: false)
+
+    private fun isKeepARMessage(comment: Comment) = comment.author?.name == "arisabot" &&
+            (comment.body?.contains(message) ?: false)
 
     private fun getValidComments(
         comments: List<Comment>,

--- a/src/test/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModuleTest.kt
@@ -737,6 +737,37 @@ class ReopenAwaitingModuleTest : StringSpec({
         hasReopened shouldBe false
         hasCommented shouldBe false
     }
+
+    "should comment the message when there is a keep AR tag and another user has already commented the message" {
+        var hasReopened = false
+        var hasCommented = false
+
+        val updated = RIGHT_NOW.plusSeconds(3)
+        val tagComment = getComment(
+            body = "MEQS_KEEP_AR",
+            visibilityType = "group",
+            visibilityValue = "staff"
+        )
+        val fakeComment = getComment(
+            body = "not-reopen-ar",
+            author = RANDOM_USER
+        )
+        val issue = mockIssue(
+            resolution = "Awaiting Response",
+            updated = updated,
+            reporter = REPORTER,
+            comments = listOf(tagComment, fakeComment),
+            changeLog = listOf(AWAITING_RESOLVE),
+            reopen = { hasReopened = true; Unit.right() },
+            addComment = { hasCommented = true; Unit.right() }
+        )
+
+        val result = MODULE(issue, TEN_SECONDS_AGO)
+
+        result.shouldBeRight(ModuleResponse)
+        hasReopened shouldBe false
+        hasCommented shouldBe true
+    }
 })
 
 private fun getComment(

--- a/src/test/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModuleTest.kt
@@ -705,6 +705,38 @@ class ReopenAwaitingModuleTest : StringSpec({
         hasReopened shouldBe false
         hasCommented shouldBe true
     }
+
+    "should not comment the message when there is a keep AR tag and arisa has already commented" {
+        var hasReopened = false
+        var hasCommented = false
+
+        val updated = RIGHT_NOW.plusSeconds(3)
+        val tagComment = getComment(
+            body = "MEQS_KEEP_AR",
+            visibilityType = "group",
+            visibilityValue = "staff"
+        )
+        val arisaComment = getComment(
+            body = "not-reopen-ar",
+            author = ARISA
+        )
+        val normalComment = getComment()
+        val issue = mockIssue(
+            resolution = "Awaiting Response",
+            updated = updated,
+            reporter = REPORTER,
+            comments = listOf(tagComment, arisaComment, normalComment),
+            changeLog = listOf(AWAITING_RESOLVE),
+            reopen = { hasReopened = true; Unit.right() },
+            addComment = { hasCommented = true; Unit.right() }
+        )
+
+        val result = MODULE(issue, TEN_SECONDS_AGO)
+
+        result.shouldBeRight(ModuleResponse)
+        hasReopened shouldBe false
+        hasCommented shouldBe false
+    }
 })
 
 private fun getComment(


### PR DESCRIPTION
## Purpose
Fix #301
## Approach
Add a function to check for the keepAR message and don't comment again if one exists
## Future work

#### Checklist
- [x] Included tests
- [x] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
