### PR TITLE
Fix License link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- shields -->
 [![](https://img.shields.io/github/issues/mojira/arisa-kt)](https://github.com/mojira/arisa-kt/issues)
 [![](https://img.shields.io/github/stars/mojira/arisa-kt)](https://github.com/mojira/arisa-kt/stargazers)
-[![](https://img.shields.io/github/license/mojira/arisa-kt)](https://github.com/mojira/arisa-kt/blob/master/LICENSE)
+[![](https://img.shields.io/github/license/mojira/arisa-kt)](https://github.com/mojira/arisa-kt/blob/master/LICENSE.md)
 
 # Arisa
 


### PR DESCRIPTION
## Purpose
The link to the license in README.md is to a file named LICENSE, which is non-existent. The correct file is LICENSE.md.
## Approach
Correct the name of this file within the link in the README.md file.