### PR TITLE
Make access token private

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/PrivacyModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/PrivacyModule.kt
@@ -12,7 +12,8 @@ class PrivacyModule(
 ) : Module {
     private val patterns: List<Regex> = listOf(
         """\(Session ID is token:""".toRegex(),
-        """(?<!\[~)\b[a-zA-Z0-9.-_]+@[a-zA-Z0-9.-_]+\.[a-zA-Z0-9.-_]{2,}\b(?!])""".toRegex()
+        """(?<!\[~)\b[a-zA-Z0-9.-_]+@[a-zA-Z0-9.-_]+\.[a-zA-Z0-9.-_]{2,}\b(?!])""".toRegex(),
+        """--accessToken ey""".toRegex()
     )
 
     override fun invoke(issue: Issue, lastRun: Instant): Either<ModuleError, ModuleResponse> = with(issue) {

--- a/src/test/kotlin/io/github/mojira/arisa/modules/PrivacyModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/PrivacyModuleTest.kt
@@ -252,7 +252,7 @@ class PrivacyModuleTest : StringSpec({
         result.shouldBeRight(ModuleResponse)
         hasSetPrivate shouldBe true
     }
-    
+
     "should mark as private when the attachment contains access token" {
         var hasSetPrivate = false
 

--- a/src/test/kotlin/io/github/mojira/arisa/modules/PrivacyModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/PrivacyModuleTest.kt
@@ -252,6 +252,24 @@ class PrivacyModuleTest : StringSpec({
         result.shouldBeRight(ModuleResponse)
         hasSetPrivate shouldBe true
     }
+    
+     "should mark as private when the attachment contains access token" {
+        var hasSetPrivate = false
+
+        val issue = mockIssue(
+            attachments = listOf(
+                mockAttachment(
+                    getContent = { "--uuid 1312dkkdk2kdart342 -accessToken eyJimfake.12345.fakestuff --userType mojang".toByteArray() }
+                )
+            ),
+            setPrivate = { hasSetPrivate = true }
+        )
+
+        val result = MODULE(issue, TWO_SECONDS_AGO)
+
+        result.shouldBeRight(ModuleResponse)
+        hasSetPrivate shouldBe true
+    }
 
     "should mark as private when the change log item contains email" {
         var hasSetPrivate = false

--- a/src/test/kotlin/io/github/mojira/arisa/modules/PrivacyModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/PrivacyModuleTest.kt
@@ -253,7 +253,7 @@ class PrivacyModuleTest : StringSpec({
         hasSetPrivate shouldBe true
     }
     
-     "should mark as private when the attachment contains access token" {
+    "should mark as private when the attachment contains access token" {
         var hasSetPrivate = false
 
         val issue = mockIssue(

--- a/src/test/kotlin/io/github/mojira/arisa/modules/PrivacyModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/PrivacyModuleTest.kt
@@ -259,7 +259,7 @@ class PrivacyModuleTest : StringSpec({
         val issue = mockIssue(
             attachments = listOf(
                 mockAttachment(
-                    getContent = { "--uuid 1312dkkdk2kdart342 -accessToken eyJimfake.12345.fakestuff --userType mojang".toByteArray() }
+                    getContent = { "--uuid 1312dkkdk2kdart342 --accessToken eyJimfake.12345.fakestuff --userType mojang".toByteArray() }
                 )
             ),
             setPrivate = { hasSetPrivate = true }


### PR DESCRIPTION
## Purpose
When a access token is detected in a attachment, make the ticket private

## Approach
Check for "--accessToken ey"
