### PR TITLE
Remove references to removed projects MCAPI and MCE

### DIFF
--- a/arisa.json
+++ b/arisa.json
@@ -5,10 +5,8 @@
         "MC",
         "MCTEST",
         "MCPE",
-        "MCAPI",
         "MCL",
         "MCD",
-        "MCE",
         "BDS",
         "REALMS",
         "WEB"
@@ -27,8 +25,7 @@
     "privateSecurityLevel": {
       "default": "10318",
       "special": {
-        "MCL": "10502",
-        "MCAPI": "10313"
+        "MCL": "10502"
       }
     },
     "helperMessages": {
@@ -394,8 +391,7 @@
           "MCL",
           "MCPE",
           "BDS",
-          "MCD",
-          "MCE"
+          "MCD"
         ]
       },
       "keepPrivate": {

--- a/src/test/kotlin/io/github/mojira/arisa/infrastructure/HelperMessagesTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/infrastructure/HelperMessagesTest.kt
@@ -69,7 +69,7 @@ class HelperMessagesTest : StringSpec({
                 ],
                 "normal-list-filter": [
                     {
-                        "project": ["mc", "mcd", "mcpe", "mcl", "mce"],
+                        "project": ["mc", "mcd", "mcpe", "mcl"],
                         "name": "Normal message with a list filter",
                         "message": "Normal message with a list filter",
                         "fillname": []
@@ -77,7 +77,7 @@ class HelperMessagesTest : StringSpec({
                 ],
                 "with-variable": [
                     {
-                        "project": ["mc", "mcd", "mcpe", "mcl", "mce"],
+                        "project": ["mc", "mcd", "mcpe", "mcl"],
                         "name": "With variable",
                         "message": "With %variable%",
                         "localizedMessages": {
@@ -88,7 +88,7 @@ class HelperMessagesTest : StringSpec({
                 ],
                 "with-placeholder": [
                     {
-                        "project": ["mc", "mcd", "mcpe", "mcl", "mce"],
+                        "project": ["mc", "mcd", "mcpe", "mcl"],
                         "name": "With placeholder",
                         "message": "With %s%",
                         "fillname": ["Placeholder"]
@@ -96,7 +96,7 @@ class HelperMessagesTest : StringSpec({
                 ],
                 "i-am-a-bot": [
                     {
-                        "project": ["mc", "mcd", "mcpe", "mcl", "mce"],
+                        "project": ["mc", "mcd", "mcpe", "mcl"],
                         "name": "I am a Bot",
                         "message": "~{color:#888}-- I am a bot.{color}~",
                         "localizedMessages": {


### PR DESCRIPTION
## Purpose
Projects MCAPI and MCE (Minecraft Earth) do not exist anymore. This pull request removes references to them.