### PR TITLE
Remove all comments from user

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/ArisaMain.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ArisaMain.kt
@@ -16,6 +16,7 @@ import io.github.mojira.arisa.infrastructure.getHelperMessages
 import io.github.mojira.arisa.infrastructure.jira.connectToJira
 import io.github.mojira.arisa.infrastructure.jira.toDomain
 import net.rcarz.jiraclient.JiraClient
+import net.rcarz.jiraclient.TokenCredentials
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.File
@@ -27,17 +28,20 @@ val log: Logger = LoggerFactory.getLogger("Arisa")
 
 const val TIME_MINUTES = 5L
 const val MAX_RESULTS = 50
-
+lateinit var jiraClient: JiraClient
+lateinit var credentials: TokenCredentials
 fun main() {
     val config = readConfig()
     setWebhookOfLogger(config)
 
-    var jiraClient =
+    val pair =
         connectToJira(
             config[Arisa.Credentials.username],
             config[Arisa.Credentials.password],
             config[Arisa.Issues.url]
         )
+    jiraClient = pair.first
+    credentials = pair.second
     log.info("Connected to jira")
 
     // Get tickets for re-run and last run time
@@ -79,11 +83,14 @@ fun main() {
             lastRunTime = curRunTime
         } else if (lastRelog.plus(1, ChronoUnit.MINUTES).isAfter(Instant.now())) {
             // If last relog was more than a minute before and execution failed with an exception, relog
-            jiraClient = connectToJira(
-                config[Arisa.Credentials.username],
-                config[Arisa.Credentials.password],
-                config[Arisa.Issues.url]
-            )
+            val pair =
+                connectToJira(
+                    config[Arisa.Credentials.username],
+                    config[Arisa.Credentials.password],
+                    config[Arisa.Issues.url]
+                )
+            jiraClient = pair.first
+            credentials = pair.second
             moduleExecutor = ModuleExecutor(
                 config, moduleRegistry, queryCache, issueUpdateContextCache,
                 getSearchIssues(jiraClient, helperMessages, config, issueUpdateContextCache)

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
@@ -27,8 +27,10 @@ import java.net.URI
 import java.time.Instant
 import java.time.temporal.ChronoField
 
-fun connectToJira(username: String, password: String, url: String) =
-    JiraClient(url, TokenCredentials(username, password))
+fun connectToJira(username: String, password: String, url: String): Pair<JiraClient, TokenCredentials> {
+    val credentials = TokenCredentials(username, password)
+    return JiraClient(url, credentials) to credentials
+}
 
 fun getIssue(jiraClient: JiraClient, key: String) = runBlocking {
     Either.catch {

--- a/src/main/kotlin/io/github/mojira/arisa/modules/CommandModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/CommandModule.kt
@@ -14,6 +14,7 @@ import io.github.mojira.arisa.modules.commands.DeleteCommentsCommand
 import io.github.mojira.arisa.modules.commands.DeleteLinksCommand
 import io.github.mojira.arisa.modules.commands.FixedCommand
 import io.github.mojira.arisa.modules.commands.PurgeAttachmentCommand
+import io.github.mojira.arisa.modules.commands.RemoveUserCommand
 import java.time.Instant
 
 // TODO if we get a lot of commands it might make sense to create a command registry
@@ -23,7 +24,8 @@ class CommandModule(
     val fixedCommand: Command = FixedCommand(),
     val purgeAttachmentCommand: Command = PurgeAttachmentCommand(),
     val deleteCommentsCommand: Command = DeleteCommentsCommand(),
-    val deleteLinksCommand: Command = DeleteLinksCommand()
+    val deleteLinksCommand: Command = DeleteLinksCommand(),
+    val removeUserCommand: Command = RemoveUserCommand()
 ) : Module {
     override fun invoke(issue: Issue, lastRun: Instant): Either<ModuleError, ModuleResponse> = Either.fx {
         with(issue) {
@@ -74,6 +76,9 @@ class CommandModule(
             } else OperationNotNeededModuleResponse.left()
             "ARISA_REMOVE_LINKS" -> if (userIsMod) {
                 deleteLinksCommand(issue, *arguments)
+            } else OperationNotNeededModuleResponse.left()
+            "ARISA_REMOVE_USER" -> if (userIsMod) {
+                removeUserCommand(issue, *arguments)
             } else OperationNotNeededModuleResponse.left()
             else -> OperationNotNeededModuleResponse.left()
         }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveUserCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveUserCommand.kt
@@ -1,0 +1,65 @@
+package io.github.mojira.arisa.modules.commands
+
+import arrow.core.Either
+import arrow.core.extensions.fx
+import arrow.core.right
+import io.github.mojira.arisa.credentials
+import io.github.mojira.arisa.domain.Issue
+import io.github.mojira.arisa.infrastructure.jira.getIssue
+import io.github.mojira.arisa.jiraClient
+import io.github.mojira.arisa.modules.ModuleError
+import io.github.mojira.arisa.modules.ModuleResponse
+import io.github.mojira.arisa.modules.assertTrue
+import org.apache.http.HttpHost
+import org.apache.http.impl.client.DefaultHttpClient
+import org.apache.http.message.BasicHttpRequest
+import java.util.concurrent.TimeUnit
+import javax.xml.parsers.DocumentBuilderFactory
+
+class RemoveUserCommand : Command {
+    val regex = "\"https:\\/\\/bugs\\.mojang\\.com\\/browse\\/(.*)\">".toRegex()
+    override fun invoke(issue: Issue, vararg arguments: String): Either<ModuleError, ModuleResponse> = Either.fx {
+        assertTrue(arguments.size > 1).bind()
+        val name = arguments.asList().subList(1, arguments.size).joinToString(" ")
+        val request = BasicHttpRequest("GET", "/activity?maxResults=10&streams=user+IS+$name")
+        credentials.authenticate(request)
+        val inputStream = DefaultHttpClient().execute(HttpHost("bugs.mojang.com"), request).entity.content
+        val doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(inputStream)
+        val entries = doc.getElementsByTagName("entry")
+
+        val tickets = mutableListOf<String>()
+        for (i in 0 until entries.length) {
+            tickets.add(entries.item(i).childNodes.item(1).textContent.parseTitle())
+        }
+
+
+        Thread {
+            tickets
+                .filter { it.startsWith("TRASH-") }
+                .map {
+                    val either = getIssue(jiraClient, it)
+                    if (either.isLeft()) {
+                        null
+                    } else {
+                        (either as Either.Right).b
+                    }
+                }
+                .filterNotNull()
+                .forEach {
+                    it.comments
+                        .filter { it.visibility.type != "staff" }
+                        .filter { it.author.name == name }
+                        .forEachIndexed { index, it ->
+                            it.update("Removed by Arisa - Delete user $name", "group", "staff")
+                            if (index % 10 == 0) {
+                                TimeUnit.SECONDS.sleep(1)
+                            }
+                        }
+                }
+
+        }.start()
+        ModuleResponse.right()
+    }
+
+    private fun String.parseTitle() = regex.find(this)!!.groupValues[1]
+}

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveUserCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveUserCommand.kt
@@ -32,10 +32,10 @@ class RemoveUserCommand : Command {
             tickets.add(entries.item(i).childNodes.item(1).textContent.parseTitle())
         }
 
-
         Thread {
             tickets
-                .filter { it.startsWith("TRASH-") }
+                .toSet()
+                .filterNot { it.startsWith("TRASH-") }
                 .map {
                     val either = getIssue(jiraClient, it)
                     if (either.isLeft()) {
@@ -47,7 +47,7 @@ class RemoveUserCommand : Command {
                 .filterNotNull()
                 .forEach {
                     it.comments
-                        .filter { it.visibility.type != "staff" }
+                        .filter { it.visibility?.type != "staff" }
                         .filter { it.author.name == name }
                         .forEachIndexed { index, it ->
                             it.update("Removed by Arisa - Delete user $name", "group", "staff")

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveUserCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveUserCommand.kt
@@ -21,7 +21,7 @@ class RemoveUserCommand : Command {
     override fun invoke(issue: Issue, vararg arguments: String): Either<ModuleError, ModuleResponse> = Either.fx {
         assertTrue(arguments.size > 1).bind()
         val name = arguments.asList().subList(1, arguments.size).joinToString(" ")
-        val request = BasicHttpRequest("GET", "/activity?maxResults=10&streams=user+IS+$name")
+        val request = BasicHttpRequest("GET", "/activity?maxResults=200&streams=user+IS+$name")
         credentials.authenticate(request)
         val inputStream = DefaultHttpClient().execute(HttpHost("bugs.mojang.com"), request).entity.content
         val doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(inputStream)


### PR DESCRIPTION
## Purpose
Remove all comments from certain users by issuing a command
## Approach
When command is triggered, look for the name in the arguments, call the jira api using the credentials to get their status, find all comments they ever did and set them to staff only
## Future work
Tested in TRASH-26834, needs unit tests, I ran out of time, but should work. Needs cleanup and tests