### PR TITLE
Fix fetching user comments with spaces in user name

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/ArisaMain.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ArisaMain.kt
@@ -30,6 +30,7 @@ const val TIME_MINUTES = 5L
 const val MAX_RESULTS = 50
 lateinit var jiraClient: JiraClient
 lateinit var credentials: TokenCredentials
+@Suppress("LongMethod")
 fun main() {
     val config = readConfig()
     setWebhookOfLogger(config)

--- a/src/main/kotlin/io/github/mojira/arisa/modules/CommandModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/CommandModule.kt
@@ -18,7 +18,7 @@ import io.github.mojira.arisa.modules.commands.RemoveUserCommand
 import java.time.Instant
 
 // TODO if we get a lot of commands it might make sense to create a command registry
-@Suppress("LongParameterList","ComplexMethod")
+@Suppress("LongParameterList", "ComplexMethod")
 class CommandModule(
     val addLinksCommand: Command = AddLinksCommand(),
     val addVersionCommand: Command = AddVersionCommand(),

--- a/src/main/kotlin/io/github/mojira/arisa/modules/CommandModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/CommandModule.kt
@@ -18,6 +18,7 @@ import io.github.mojira.arisa.modules.commands.RemoveUserCommand
 import java.time.Instant
 
 // TODO if we get a lot of commands it might make sense to create a command registry
+@Supress("LongParameterList","ComplexMethod")
 class CommandModule(
     val addLinksCommand: Command = AddLinksCommand(),
     val addVersionCommand: Command = AddVersionCommand(),

--- a/src/main/kotlin/io/github/mojira/arisa/modules/CommandModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/CommandModule.kt
@@ -18,7 +18,7 @@ import io.github.mojira.arisa.modules.commands.RemoveUserCommand
 import java.time.Instant
 
 // TODO if we get a lot of commands it might make sense to create a command registry
-@Supress("LongParameterList","ComplexMethod")
+@Suppress("LongParameterList","ComplexMethod")
 class CommandModule(
     val addLinksCommand: Command = AddLinksCommand(),
     val addVersionCommand: Command = AddVersionCommand(),

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveUserCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveUserCommand.kt
@@ -52,7 +52,8 @@ class RemoveUserCommand : Command {
                         .filter { it.author.name == name }
                         .forEachIndexed { index, it ->
                             it.update("Removed by Arisa - Delete user $name", "group", "staff")
-                            if (index % 10 == 0) {
+                            const divisor = 10
+                            if (index % divisor == 0) {
                                 TimeUnit.SECONDS.sleep(1)
                             }
                         }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveUserCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveUserCommand.kt
@@ -22,7 +22,7 @@ class RemoveUserCommand : Command {
     override fun invoke(issue: Issue, vararg arguments: String): Either<ModuleError, ModuleResponse> = Either.fx {
         assertTrue(arguments.size > 1).bind()
         val name = arguments.asList().subList(1, arguments.size).joinToString(" ")
-        val streamName = name.replace("+","_")
+        val streamName = name.replace("+", "_")
         val request = BasicHttpRequest("GET", "/activity?maxResults=200&streams=user+IS+$streamName")
         credentials.authenticate(request)
         val inputStream = DefaultHttpClient().execute(HttpHost("bugs.mojang.com"), request).entity.content
@@ -58,7 +58,6 @@ class RemoveUserCommand : Command {
                             }
                         }
                 }
-
         }.start()
         ModuleResponse.right()
     }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveUserCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveUserCommand.kt
@@ -20,6 +20,7 @@ class RemoveUserCommand : Command {
     val regex = "\"https:\\/\\/bugs\\.mojang\\.com\\/browse\\/(.*)\">".toRegex()
     override fun invoke(issue: Issue, vararg arguments: String): Either<ModuleError, ModuleResponse> = Either.fx {
         assertTrue(arguments.size > 1).bind()
+        const divisor = 10
         val name = arguments.asList().subList(1, arguments.size).joinToString(" ")
         val streamName = name.replace("+","_")
         val request = BasicHttpRequest("GET", "/activity?maxResults=200&streams=user+IS+$streamName")
@@ -52,7 +53,6 @@ class RemoveUserCommand : Command {
                         .filter { it.author.name == name }
                         .forEachIndexed { index, it ->
                             it.update("Removed by Arisa - Delete user $name", "group", "staff")
-                            const divisor = 10
                             if (index % divisor == 0) {
                                 TimeUnit.SECONDS.sleep(1)
                             }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveUserCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveUserCommand.kt
@@ -20,7 +20,7 @@ class RemoveUserCommand : Command {
     val regex = "\"https:\\/\\/bugs\\.mojang\\.com\\/browse\\/(.*)\">".toRegex()
     override fun invoke(issue: Issue, vararg arguments: String): Either<ModuleError, ModuleResponse> = Either.fx {
         assertTrue(arguments.size > 1).bind()
-        const divisor = 10
+        val divisor = 10
         val name = arguments.asList().subList(1, arguments.size).joinToString(" ")
         val streamName = name.replace("+","_")
         val request = BasicHttpRequest("GET", "/activity?maxResults=200&streams=user+IS+$streamName")

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveUserCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveUserCommand.kt
@@ -21,7 +21,8 @@ class RemoveUserCommand : Command {
     override fun invoke(issue: Issue, vararg arguments: String): Either<ModuleError, ModuleResponse> = Either.fx {
         assertTrue(arguments.size > 1).bind()
         val name = arguments.asList().subList(1, arguments.size).joinToString(" ")
-        val request = BasicHttpRequest("GET", "/activity?maxResults=200&streams=user+IS+$name")
+        val streamName = name.replace("+","_")
+        val request = BasicHttpRequest("GET", "/activity?maxResults=200&streams=user+IS+$streamName")
         credentials.authenticate(request)
         val inputStream = DefaultHttpClient().execute(HttpHost("bugs.mojang.com"), request).entity.content
         val doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(inputStream)

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveUserCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveUserCommand.kt
@@ -16,11 +16,11 @@ import org.apache.http.message.BasicHttpRequest
 import java.util.concurrent.TimeUnit
 import javax.xml.parsers.DocumentBuilderFactory
 
+const val DIVISOR = 10
 class RemoveUserCommand : Command {
     val regex = "\"https:\\/\\/bugs\\.mojang\\.com\\/browse\\/(.*)\">".toRegex()
     override fun invoke(issue: Issue, vararg arguments: String): Either<ModuleError, ModuleResponse> = Either.fx {
         assertTrue(arguments.size > 1).bind()
-        val divisor = 10
         val name = arguments.asList().subList(1, arguments.size).joinToString(" ")
         val streamName = name.replace("+","_")
         val request = BasicHttpRequest("GET", "/activity?maxResults=200&streams=user+IS+$streamName")
@@ -53,7 +53,7 @@ class RemoveUserCommand : Command {
                         .filter { it.author.name == name }
                         .forEachIndexed { index, it ->
                             it.update("Removed by Arisa - Delete user $name", "group", "staff")
-                            if (index % divisor == 0) {
+                            if (index % DIVISOR == 0) {
                                 TimeUnit.SECONDS.sleep(1)
                             }
                         }


### PR DESCRIPTION
## Purpose
Fix fetching a user's comments if the user has a space in their username

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
