### PR TITLE
Fix underlines in user names for Arisa command

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveUserCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveUserCommand.kt
@@ -22,7 +22,7 @@ class RemoveUserCommand : Command {
     override fun invoke(issue: Issue, vararg arguments: String): Either<ModuleError, ModuleResponse> = Either.fx {
         assertTrue(arguments.size > 1).bind()
         val name = arguments.asList().subList(1, arguments.size).joinToString(" ")
-        val streamName = name.replace("+", "_")
+        val streamName = name.replace("+", "_").replace("_", "%5C_")
         val request = BasicHttpRequest("GET", "/activity?maxResults=200&streams=user+IS+$streamName")
         credentials.authenticate(request)
         val inputStream = DefaultHttpClient().execute(HttpHost("bugs.mojang.com"), request).entity.content


### PR DESCRIPTION
## Purpose
Jira's inconsistency causes the username to be incorrect with underlines, this will fix that
