### PR TITLE
TransferVersionsModule: Remove release date check

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/TransferVersionsModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/TransferVersionsModule.kt
@@ -2,7 +2,6 @@ package io.github.mojira.arisa.modules
 
 import io.github.mojira.arisa.domain.Issue
 import io.github.mojira.arisa.domain.LinkedIssue
-import io.github.mojira.arisa.domain.Version
 
 class TransferVersionsModule : AbstractTransferFieldModule() {
     override fun filterParents(linkedIssue: LinkedIssue, issue: Issue): Boolean {

--- a/src/main/kotlin/io/github/mojira/arisa/modules/TransferVersionsModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/TransferVersionsModule.kt
@@ -14,30 +14,11 @@ class TransferVersionsModule : AbstractTransferFieldModule() {
             val parentVersionIds = parent.affectedVersions
                 .map { it.id }
 
-            val oldestVersionWithKnownReleaseDateOnParent =
-                getOldestVersionWithKnownReleaseDate(parent.affectedVersions)
-
             issue.affectedVersions
-                .filter { it isReleasedAfter oldestVersionWithKnownReleaseDateOnParent }
                 .map { it.id }
                 .filter { it !in parentVersionIds }
                 .map { { parent.addAffectedVersion(it) } }
         }
-
-    private fun getOldestVersionWithKnownReleaseDate(field: List<Version>) = field
-        .filter { it.releaseDate != null }
-        .sortedBy { it.releaseDate }
-        .getOrNull(0)
-
-    /**
-     * Returns true only if:
-     * - The other version is `null`;
-     * - The other version has a `null` release date; OR
-     * - The current version has a non-`null` release date which is after the other version's release date.
-     */
-    private infix fun Version.isReleasedAfter(other: Version?) =
-        other?.releaseDate == null ||
-                (releaseDate != null && releaseDate.isAfter(other.releaseDate))
 
     private fun LinkedIssue.isSameProject(otherIssue: Issue) =
         key.getProject() == otherIssue.key.getProject()

--- a/src/test/kotlin/io/github/mojira/arisa/modules/TransferVersionsModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/TransferVersionsModuleTest.kt
@@ -17,10 +17,9 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import java.time.Instant
 
-private val VERSION_1 = getVersion(name = "v1", releaseDate = RIGHT_NOW.minusSeconds(300))
-private val VERSION_2 = getVersion(name = "v2", releaseDate = RIGHT_NOW.minusSeconds(200))
-private val VERSION_3 = getVersion(name = "v3", releaseDate = RIGHT_NOW.minusSeconds(100))
-private val VERSION_X = getVersion(name = "vX", releaseDate = null)
+private val VERSION_1 = getVersion(name = "v1")
+private val VERSION_2 = getVersion(name = "v2")
+private val VERSION_X = getVersion(name = "vX")
 private val A_SECOND_AGO = RIGHT_NOW.minusSeconds(1)
 
 class TransferVersionsModuleTest : StringSpec({
@@ -182,58 +181,6 @@ class TransferVersionsModuleTest : StringSpec({
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
-    "should return OperationNotNeededModuleResponse when the version is released before the parent's oldest version (#229)" {
-        val module = TransferVersionsModule()
-        val link = mockLink(
-            issue = mockLinkedIssue(
-                key = "MC-1",
-                getFullIssue = {
-                    mockIssue(
-                        affectedVersions = listOf(VERSION_2)
-                    ).right()
-                }
-            )
-        )
-        val changeLogItem = mockChangeLogItem(
-            created = RIGHT_NOW,
-            changedTo = "MC-1"
-        )
-        val issue = mockIssue(
-            links = listOf(link),
-            changeLog = listOf(changeLogItem),
-            affectedVersions = listOf(VERSION_1)
-        )
-        val result = module(issue, A_SECOND_AGO)
-
-        result.shouldBeLeft(OperationNotNeededModuleResponse)
-    }
-
-    "should return OperationNotNeededModuleResponse when the version's releaseDate is null (#250)" {
-        val module = TransferVersionsModule()
-        val link = mockLink(
-            issue = mockLinkedIssue(
-                key = "MC-1",
-                getFullIssue = {
-                    mockIssue(
-                        affectedVersions = listOf(VERSION_1)
-                    ).right()
-                }
-            )
-        )
-        val changeLogItem = mockChangeLogItem(
-            created = RIGHT_NOW,
-            changedTo = "MC-1"
-        )
-        val issue = mockIssue(
-            links = listOf(link),
-            changeLog = listOf(changeLogItem),
-            affectedVersions = listOf(VERSION_X)
-        )
-        val result = module(issue, A_SECOND_AGO)
-
-        result.shouldBeLeft(OperationNotNeededModuleResponse)
-    }
-
     "should transfer missing versions to open parents" {
         val module = TransferVersionsModule()
         val link = mockLink(
@@ -350,117 +297,6 @@ class TransferVersionsModuleTest : StringSpec({
         result.shouldBeRight(ModuleResponse)
         firstVersionAdded.shouldBeTrue()
         secondVersionAdded.shouldBeTrue()
-    }
-
-    "should only add versions released after the oldest version to parent (#229)" {
-        var version1Added = false
-        var version3Added = false
-        val module = TransferVersionsModule()
-        val link = mockLink(
-            issue = mockLinkedIssue(
-                key = "MC-1",
-                getFullIssue = {
-                    mockIssue(
-                        addAffectedVersion = { v ->
-                            when (v) {
-                                "v1" -> version1Added = true
-                                "v3" -> version3Added = true
-                            }
-                            Unit.right()
-                        },
-                        affectedVersions = listOf(VERSION_2)
-                    ).right()
-                }
-            )
-        )
-        val changeLogItem = mockChangeLogItem(
-            created = RIGHT_NOW,
-            changedTo = "MC-1"
-        )
-        val issue = mockIssue(
-            links = listOf(link),
-            changeLog = listOf(changeLogItem),
-            affectedVersions = listOf(VERSION_1, VERSION_3)
-        )
-        val result = module(issue, A_SECOND_AGO)
-
-        result.shouldBeRight(ModuleResponse)
-        version1Added.shouldBeFalse()
-        version3Added.shouldBeTrue()
-    }
-
-    "should only add versions which has a non-null releaseDate (#250)" {
-        var versionXAdded = false
-        var version2Added = false
-        val module = TransferVersionsModule()
-        val link = mockLink(
-            issue = mockLinkedIssue(
-                key = "MC-1",
-                getFullIssue = {
-                    mockIssue(
-                        addAffectedVersion = { v ->
-                            when (v) {
-                                "vx" -> versionXAdded = true
-                                "v2" -> version2Added = true
-                            }
-                            Unit.right()
-                        },
-                        affectedVersions = listOf(VERSION_1)
-                    ).right()
-                }
-            )
-        )
-        val changeLogItem = mockChangeLogItem(
-            created = RIGHT_NOW,
-            changedTo = "MC-1"
-        )
-        val issue = mockIssue(
-            links = listOf(link),
-            changeLog = listOf(changeLogItem),
-            affectedVersions = listOf(VERSION_X, VERSION_2)
-        )
-        val result = module(issue, A_SECOND_AGO)
-
-        result.shouldBeRight(ModuleResponse)
-        versionXAdded.shouldBeFalse()
-        version2Added.shouldBeTrue()
-    }
-
-    "should only add versions released after the oldest version with a known releaseData to parent (#250)" {
-        var version1Added = false
-        var version3Added = false
-        val module = TransferVersionsModule()
-        val link = mockLink(
-            issue = mockLinkedIssue(
-                key = "MC-1",
-                getFullIssue = {
-                    mockIssue(
-                        addAffectedVersion = { v ->
-                            when (v) {
-                                "v1" -> version1Added = true
-                                "v3" -> version3Added = true
-                            }
-                            Unit.right()
-                        },
-                        affectedVersions = listOf(VERSION_X, VERSION_2)
-                    ).right()
-                }
-            )
-        )
-        val changeLogItem = mockChangeLogItem(
-            created = RIGHT_NOW,
-            changedTo = "MC-1"
-        )
-        val issue = mockIssue(
-            links = listOf(link),
-            changeLog = listOf(changeLogItem),
-            affectedVersions = listOf(VERSION_1, VERSION_3)
-        )
-        val result = module(issue, A_SECOND_AGO)
-
-        result.shouldBeRight(ModuleResponse)
-        version1Added.shouldBeFalse()
-        version3Added.shouldBeTrue()
     }
 
     "should add versions to all parents" {

--- a/src/test/kotlin/io/github/mojira/arisa/modules/TransferVersionsModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/TransferVersionsModuleTest.kt
@@ -11,7 +11,6 @@ import io.github.mojira.arisa.utils.mockVersion
 import io.kotest.assertions.arrow.either.shouldBeLeft
 import io.kotest.assertions.arrow.either.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe


### PR DESCRIPTION
## Purpose
Remove the check in TransferVersionsModule that prevented any versions older than the oldest version on the parent ticket from being transferred over to the parent ticket. It was introduced because of #229.

This was more of a hinderance than a help. See also `/archives/G0NM0QG14/p1610724495034400` where this was discussed.

## Approach
I simply removed all the code related to this check.

## Future work
N/A

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
