### PR TITLE
Fix wrong e-mail regex of PrivacyModule

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/PrivacyModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/PrivacyModule.kt
@@ -12,7 +12,7 @@ class PrivacyModule(
 ) : Module {
     private val patterns: List<Regex> = listOf(
         """\(Session ID is token:""".toRegex(),
-        """(?<!\[~)\b[a-zA-Z0-9.-_]+@[a-zA-Z0-9.-_]+\.[a-zA-Z0-9.-^]{2,15}\b""".toRegex(),
+        """(?<!\[~)\b[a-zA-Z0-9.\-_]+@[a-zA-Z0-9.\-_]+\.[a-zA-Z0-9.\-]{2,15}\b""".toRegex(),
         """--accessToken ey""".toRegex()
     )
 


### PR DESCRIPTION
## Purpose
It appears the regex syntax has a peculiarity where `[…-]` matches the `-` literally (while `[…-…]` represents a range). When #403 added the `_` it accidentially converted `-` into ranges which match a bunch of characters which are not allowed by [RFC 952](https://tools.ietf.org/html/rfc952).