### PR TITLE
Fix #536 - Stop depending on jcenter and bintray

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,24 +12,22 @@ version = "1.0-SNAPSHOT"
 repositories {
     mavenCentral()
     maven("https://jitpack.io")
-    maven("https://dl.bintray.com/cbeust/maven")
     maven("https://libraries.minecraft.net")
-    jcenter()
 }
 
 buildscript {
     repositories {
         mavenCentral()
-        jcenter {
-            content {
-                // just allow to include kotlinx projects
-                // detekt needs 'kotlinx-html' for the html report
-                includeGroup("org.jetbrains.kotlinx")
-            }
-        }
     }
     dependencies {
         classpath("info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.5.1")
+    }
+}
+
+configurations {
+    all {
+        // Excluded due to being a dependency of detekt but not being in maven central
+        exclude("org.jetbrains.kotlinx", "kotlinx-html-jvm")
     }
 }
 
@@ -60,7 +58,7 @@ dependencies {
     implementation("io.arrow-kt", "arrow-core", arrowVersion)
     implementation("io.arrow-kt", "arrow-syntax", arrowVersion)
     implementation("io.arrow-kt", "arrow-fx", arrowVersion)
-    implementation("com.beust", "klaxon", "5.2")
+    implementation("com.beust", "klaxon", "5.4")
     implementation("com.mojang", "brigadier", "1.0.17")
 
     testImplementation("io.kotest", "kotest-assertions-core-jvm", kotestVersion)
@@ -96,10 +94,7 @@ detekt {
     buildUponDefaultConfig = true // preconfigure defaults
     parallel = true
     reports {
-        html {
-            destination = file("build/reports/detekt.html")
-            enabled = true // observe findings in your browser with structure and code snippets
-        }
+        html.enabled = false // Disabled due to requirement for kotlinx-html which is still in jcenter
         xml.enabled = false // checkstyle like format mainly for integrations like Jenkins
         txt.enabled = false // similar to the console output, contains issue signature to manually edit baseline files
     }


### PR DESCRIPTION
## Purpose
 Stop depending on jcenter and bintray
## Approach
Remove dependency from detekt by excluding, use new version of klaxon which is in maven central
## Future work

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
