### PR TITLE
Add more debug options

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/ArisaMain.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ArisaMain.kt
@@ -67,6 +67,9 @@ fun main() {
     val issueUpdateContextCache = Cache<IssueUpdateContext>()
     val moduleRegistry = ModuleRegistry(config)
 
+    val enabledModules = moduleRegistry.getModules().map { it.name }
+    log.debug("Enabled modules: $enabledModules")
+
     // Create module executor
     var moduleExecutor = ModuleExecutor(
         config, moduleRegistry, queryCache, issueUpdateContextCache,
@@ -83,7 +86,9 @@ fun main() {
             failedTickets.addAll(executionResults.failedTickets)
             val failed = failedTickets.joinToString("") { ",$it" } // even first entry should start with a comma
 
-            lastRunFile.writeText("${curRunTime.toEpochMilli()}$failed")
+            if (config[Arisa.Debug.updateLastRun]) {
+                lastRunFile.writeText("${curRunTime.toEpochMilli()}$failed")
+            }
             lastRunTime = curRunTime
         } else if (lastRelog.plus(1, ChronoUnit.MINUTES).isAfter(Instant.now())) {
             // If last relog was more than a minute before and execution failed with an exception, relog

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
@@ -89,8 +89,8 @@ class ModuleExecutor(
             .forEach { (issue, response) ->
                 response.second.fold({
                     when (it) {
-                        is OperationNotNeededModuleResponse -> if (config[Arisa.logOperationNotNeeded]) {
-                            log.info("[RESPONSE] [$issue] [${response.first}] Operation not needed")
+                        is OperationNotNeededModuleResponse -> if (config[Arisa.Debug.logOperationNotNeeded]) {
+                            log.debug("[RESPONSE] [$issue] [${response.first}] Operation not needed")
                         }
                         is FailedModuleResponse -> {
                             addFailedTicket(issue)
@@ -150,6 +150,8 @@ class ModuleExecutor(
         )
 
         queryCache.add(jql, issues)
+
+        log.debug("Returned issues for module ${ moduleConfig::class.simpleName }: ${ issues.map { it.key } }")
 
         return issues
             .filter { it.project.key in projects }

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/Arisa.kt
@@ -3,12 +3,13 @@ package io.github.mojira.arisa.infrastructure.config
 import com.uchuhimo.konf.ConfigSpec
 
 object Arisa : ConfigSpec() {
-    val logOperationNotNeeded by optional(false)
-
     object Credentials : ConfigSpec() {
         val username by required<String>()
         val password by required<String>()
-        val dandelionToken by required<String>(description = "Token for dandelion.eu")
+        val dandelionToken by optional(
+            "dummyKey",
+            description = "Token for dandelion.eu"
+        )
         val discordLogWebhook by optional<String?>(
             null,
             description = "Webhook to post log in a Discord channel"
@@ -49,6 +50,30 @@ object Arisa : ConfigSpec() {
     object HelperMessages : ConfigSpec() {
         val updateIntervalSeconds by required<Long>(
             description = "The interval in which the messages.json file is updated"
+        )
+    }
+
+    object Debug : ConfigSpec() {
+        val enabledModules by optional<List<String>?>(
+            null,
+            description = "Disable all modules except for those in the list. " +
+                    "Entries must be module names (e.g. 'ReopenAwaiting'). " +
+                    "All modules are enabled if this is not specified."
+        )
+
+        val logOperationNotNeeded by optional(false)
+
+        val ticketWhitelist by optional<List<String>?>(
+            null,
+            description = "Ignore all tickets except those mentioned here. " +
+                    "Entries must be valid Mojira ticket keys. " +
+                    "The whitelist is disabled if this is not specified."
+        )
+
+        val updateLastRun by optional(
+            true,
+            description = "Whether or not the lastRun file should be saved after each run. " +
+                    "Do not disable this unless you've enabled the ticket whitelist."
         )
     }
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -7,6 +7,9 @@
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs\arisakt.html</file>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>arisakt-%d{yyyy-MM-dd}.%i.txt</fileNamePattern>
             <maxFileSize>50MB</maxFileSize>
@@ -23,6 +26,9 @@
 
     <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
         <webhookUri />
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
         <layout class="ch.qos.logback.classic.PatternLayout">
             <pattern>`%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg`%n%replace(```%ex{full}```){'``````',''}%nopex</pattern>
         </layout>
@@ -37,6 +43,9 @@
 
     <appender name="ERROR_DISCORD" class="com.github.napstr.logback.DiscordAppender">
         <webhookUri />
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
         <layout class="ch.qos.logback.classic.PatternLayout">
             <pattern>`%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg`%n```%ex{full}```</pattern>
         </layout>
@@ -47,9 +56,6 @@
 
     <appender name="ASYNC_ERROR_DISCORD" class="ch.qos.logback.classic.AsyncAppender">
         <appender-ref ref="ERROR_DISCORD" />
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>ERROR</level>
-        </filter>
     </appender>
 
     <root level="debug">


### PR DESCRIPTION
## Purpose
It's currently not easy to test a specific module on Mojira without the fear of something going wrong large-scale.

## Approach
- Option to only enable selected modules
- Option to only monitor selected tickets
- Option to not update last run file
- No longer need to specify dandelion key
- Rewritten module registration code

These options can be set in the `arisa.yml` file locally so that they aren't pushed to remove.

## Open questions
I've added some `log.debug` method calls. I'm not sure how the logs are currently configured and if the production logs have debug level enabled. If they have, how can these loggers be changed to INFO debug level?

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
