### PR TITLE
Fix #551 by using empty string if input is null

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/PiracyModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/PiracyModule.kt
@@ -17,7 +17,7 @@ class PiracyModule(
             assertAfter(issue.created, lastRun).bind()
             assertContainsSignatures(
                 piracySignatures,
-                "$description $environment $summary"
+                "${description ?: ""} ${environment ?: ""} ${summary ?: ""}"
             ).bind()
             resolveAsInvalid()
             addComment(CommentOptions(message))

--- a/src/test/kotlin/io/github/mojira/arisa/modules/PiracyModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/PiracyModuleTest.kt
@@ -147,4 +147,17 @@ class PiracyModuleTest : StringSpec({
         result.shouldBeRight(ModuleResponse)
         hasCommented shouldBe true
     }
+
+    "should sanitize null inputs" {
+        val module = PiracyModule(listOf("null null null"), "message")
+        val issue = mockIssue(
+            environment = null,
+            summary = null,
+            description = null
+        )
+
+        val result = module(issue, A_SECOND_AGO)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
 })


### PR DESCRIPTION
## Purpose
Fix #551

## Approach
Use empty string by default if input is null

## Future work
N/A

#### Checklist
- [x] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
