### PR TITLE
Comment with information about removed attachment

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/AttachmentModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/AttachmentModule.kt
@@ -17,10 +17,14 @@ class AttachmentModule(
             val endsWithBlacklistedExtensionAdapter = ::endsWithBlacklistedExtensions.partially1(extensionBlackList)
             val functions = attachments
                 .filter { endsWithBlacklistedExtensionAdapter(it.name) }
-                .map { it.remove }
             assertNotEmpty(functions).bind()
-            functions.forEach { it.invoke() }
+            val username = functions.forEach { it.uploader!!.name }
+            val attachmentName = functions.forEach { it.name }
+            functions
+                .map { it.remove }
+                .forEach { it.invoke() }
             addComment(CommentOptions(attachmentRemovedMessage))
+            addRawRestrictedComment("Attachment Details:\nFilename: $attachmentName\nUploader: $username", "helper")
         }
     }
 


### PR DESCRIPTION
## Purpose
Add a restricted comment with information about the removed attachment whenever AttachmentModule executes
## Approach

## Future work

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
