### PR TITLE
Use the forward duplicate message when the parent was created after the child 

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -111,6 +111,7 @@ arisa:
         - Duplicate
       commentDelayMinutes: 5
       message: duplicate
+      forwardMessage: duplicate-forward
       ticketMessages:
         MC-297: duplicate-of-mc-297
         MC-128302: duplicate-of-mc-128302

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -164,6 +164,7 @@ class ModuleRegistry(private val config: Config) {
             DuplicateMessageModule(
                 config[Modules.DuplicateMessage.commentDelayMinutes],
                 config[Modules.DuplicateMessage.message],
+                config[Modules.DuplicateMessage.forwardMessage],
                 config[Modules.DuplicateMessage.ticketMessages],
                 config[Modules.DuplicateMessage.privateMessage],
                 config[Modules.DuplicateMessage.resolutionMessages]

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
@@ -117,6 +117,10 @@ object Arisa : ConfigSpec() {
             val message by required<String>(
                 description = "The key of the message that is posted under duplicate tickets."
             )
+            val forwardMessage by required<String>(
+                description = "The key of the message that is posted under duplicate tickets that are " +
+                        "newer than the current one."
+            )
             val ticketMessages by required<Map<String, String>>(
                 description = "A map from ticket keys to keys of messages that are posted for specific parents"
             )

--- a/src/main/kotlin/io/github/mojira/arisa/modules/DuplicateMessageModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/DuplicateMessageModule.kt
@@ -47,7 +47,8 @@ class DuplicateMessageModule(
                 val fullParents = fullParentEitherList
                     .map { (it as Either.Right).b }
 
-                messageKey = getPrivateMessageOrNull(fullParents) ?: getResolutionMessageOrNull(fullParents) ?: getForwardResolvedOrNot(issue, fullParents)!!
+                messageKey = getPrivateMessageOrNull(fullParents) ?: getResolutionMessageOrNull(fullParents) ?:
+                        getForwardResolvedOrNot(issue, fullParents)!!
             }
 
             val filledText = parents.getFilledText()

--- a/src/main/kotlin/io/github/mojira/arisa/modules/DuplicateMessageModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/DuplicateMessageModule.kt
@@ -47,8 +47,8 @@ class DuplicateMessageModule(
                 val fullParents = fullParentEitherList
                     .map { (it as Either.Right).b }
 
-                messageKey = getPrivateMessageOrNull(fullParents) ?: getResolutionMessageOrNull(fullParents) ?:
-                        getForwardResolvedOrNot(issue, fullParents)!!
+                messageKey = getPrivateMessageOrNull(fullParents)
+                        ?: getResolutionMessageOrNull(fullParents) ?: getForwardResolvedOrNot(issue, fullParents)!!
             }
 
             val filledText = parents.getFilledText()

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveUserCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveUserCommand.kt
@@ -20,8 +20,8 @@ class RemoveUserCommand : Command1<String> {
         val name = URLEncoder.encode(
             arg,
             StandardCharsets.UTF_8.toString()
-        ).replace("%20", "+")
-        val streamName = name.replace("_", "%5C_").replace("+", "_")
+        ).replace("%20", "+").replace("%21", "!")
+        val streamName = name.replace("_", "%5C_").replace("+", "_").replace("!", "%21")
         val request = BasicHttpRequest("GET", "/activity?maxResults=200&streams=user+IS+$streamName")
         credentials.authenticate(request)
         val inputStream = DefaultHttpClient().execute(HttpHost("bugs.mojang.com"), request).entity.content

--- a/src/test/kotlin/io/github/mojira/arisa/modules/DuplicateMessageModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/DuplicateMessageModuleTest.kt
@@ -19,6 +19,7 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 private val TWO_SECONDS_AGO = RIGHT_NOW.minusSeconds(2)
+private val TEN_SECONDS_LATER = RIGHT_NOW.plusSeconds(10)
 private val TEN_THOUSAND_YEARS_LATER = RIGHT_NOW.plusSeconds(315360000000)
 
 class DuplicateMessageModuleTest : StringSpec({
@@ -876,7 +877,7 @@ class DuplicateMessageModuleTest : StringSpec({
         val issue = getIssue(
                 changeLog = listOf(
                         mockChangeLogItem(
-                                created = TWO_SECONDS_AGO,
+                                created = TEN_SECONDS_LATER,
                                 field = "Link",
                                 changedTo = "MC-1",
                                 changedToString = "This issue duplicates MC-1"


### PR DESCRIPTION
## Purpose
Fix #478 
## Approach

## Future work

#### Checklist
- [x] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
