### PR TITLE
Fix triggering GitHub action twice

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,5 +1,11 @@
 name: "Validate Gradle Wrapper"
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   validation:


### PR DESCRIPTION
## Purpose
Fix triggering the validate action twice for the same commit.

![image](https://user-images.githubusercontent.com/15277496/108955228-6ed82200-7633-11eb-80a8-2d454dd0a297.png)

## Approach
https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662

## Future work

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
