### PR TITLE
Remove asterisks from the attachment details

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/AttachmentModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/AttachmentModule.kt
@@ -44,8 +44,8 @@ class AttachmentModule(
         .run {
             when (size) {
                 1 -> get(0)
-                2 -> "${get(0)}* and *${get(1)}"
-                else -> "${subList(0, lastIndex).joinToString("*, *")}*, and *${last()}"
+                2 -> "${get(0)} and ${get(1)}"
+                else -> "${subList(0, lastIndex).joinToString(", ")}, and ${last()}"
             }
         }
 


### PR DESCRIPTION
This was originally copied directly from the Duplicate Message module, and I noticed that I left some asterisks that were used in formatting the ticket names, but are useless in the Attachment Module.