### PR TITLE
Prevent Arisa from leaving empty comments

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -124,6 +124,9 @@ arisa:
         Won't Fix: duplicate-wf
 
     piracy:
+      projects:
+        - MC
+        - MCL
       resolutions:
         - Unresolved
       excludedStatuses:


### PR DESCRIPTION
## Purpose
Fix #435 
## Approach
The Piracy message is only available in MC and MCL, which causes Arisa to leave an empty comment when posting in a different project
## Future work

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
