### PR TITLE
Null-sanitize calls to rcarz Issue class

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
@@ -133,7 +133,9 @@ class ModuleExecutor(
 
         queryCache.add(jql, issues)
 
-        log.debug("Returned issues for module ${ moduleConfig::class.simpleName }: ${ issues.map { it.key } }")
+        if (config[Arisa.Debug.logReturnedIssues]) {
+            log.debug("Returned issues for module ${ moduleConfig::class.simpleName }: ${ issues.map { it.key } }")
+        }
 
         return issues
             .filter { it.project.key in projects }

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
@@ -66,6 +66,8 @@ object Arisa : ConfigSpec() {
 
         val logOperationNotNeeded by optional(false)
 
+        val logReturnedIssues by optional(false)
+
         val ticketWhitelist by optional<List<String>?>(
             null,
             description = "Ignore all tickets except those mentioned here. " +

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveUserCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveUserCommand.kt
@@ -29,16 +29,16 @@ class RemoveUserCommand(
     // They should be removed with a future refactor.
 
     val getCommentsFromIssue: (String, Issue) -> List<Pair<String, Comment>> = { _, issue ->
-        issue.comments.map { it.id to it }
+        issue.comments.mapNotNull { it.id to it }
     },
     val getVisibilityValueOfComment: (Pair<String, Comment>) -> String = { (_, comment) ->
-        comment.visibility.value
+        comment.visibility?.value ?: ""
     },
     val getAuthorOfComment: (Pair<String, Comment>) -> String = { (_, comment) ->
-        comment.author.name
+        comment.author?.name ?: ""
     },
     val getBodyOfComment: (Pair<String, Comment>) -> String = { (_, comment) ->
-        comment.body
+        comment.body ?: ""
     },
     val updateComment: (Pair<String, Comment>, content: String) -> Unit = { (_, comment), content ->
         comment.update(
@@ -48,7 +48,7 @@ class RemoveUserCommand(
         )
     },
     val getAttachmentsFromIssue: (String, Issue) -> List<Pair<String, Attachment>> = { _, issue ->
-        issue.attachments.map { it.id to it }
+        issue.attachments.mapNotNull { it.id to it }
     },
     val getAuthorNameFromAttachment: (Pair<String, Attachment>) -> String? = { (_, attachment) ->
         attachment.author?.name


### PR DESCRIPTION
## Purpose
The RemoveUserCommand didn't work because apparently Java classes are able to return non-null types even if they can be null and thus I wasn't required to check whether things returned from the rcarz Issue class were null?

## Approach
Null-sanitize default functions in `RemoveUserCommand`

Also I disabled logging of returned issues by default. It's spamming the log quite a bit.

## Future work

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
