### PR TITLE
Accept multiple commands in a single comment

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -282,7 +282,10 @@ class ModuleRegistry(private val config: Config) {
 
         register(
             Modules.Command,
-            CommandModule(config[Modules.Command.commandPrefix])
+            CommandModule(
+                config[Modules.Command.commandPrefix],
+                config[Credentials.username]
+            )
         )
 
         register(

--- a/src/main/kotlin/io/github/mojira/arisa/modules/CommandModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/CommandModule.kt
@@ -82,7 +82,7 @@ class CommandModule(
     /**
      * Edits the given comment (that was used to invoke some commands) with the given results.
      *
-     * @param results Command results mapped to the line number in the comment
+     * @param results The line numbers of the commands inside of the comment, mapped to the command's result
      */
     private fun editInvocationComment(comment: Comment, results: Map<Int, CommandResult>) {
         val newBody = comment.body?.lines().orEmpty()
@@ -93,7 +93,8 @@ class CommandModule(
                 }
             }
             .joinToString("\n")
-            .replace(Regex("""^\s*|\s*$"""), "")
+            .trim()
+            // If there are multiple consecutive empty lines, replace them with a single empty line
             .replace(Regex("""\n\n+"""), "\n\n")
 
         comment.update(newBody)

--- a/src/main/kotlin/io/github/mojira/arisa/modules/CommandModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/CommandModule.kt
@@ -2,7 +2,6 @@ package io.github.mojira.arisa.modules
 
 import arrow.core.Either
 import arrow.core.extensions.fx
-import arrow.core.left
 import arrow.core.right
 import arrow.syntax.function.partially1
 import com.mojang.brigadier.CommandDispatcher
@@ -13,8 +12,13 @@ import io.github.mojira.arisa.modules.commands.getCommandDispatcher
 import kotlinx.coroutines.runBlocking
 import java.time.Instant
 
+data class Command(val command: String, val source: CommandSource)
+
+private typealias CommandResult = Either<Throwable, Int>
+
 class CommandModule(
     private val prefix: String,
+    private val botUserName: String,
     private val getDispatcher: (String) -> CommandDispatcher<CommandSource> = ::getCommandDispatcher
 ) : Module {
     /**
@@ -34,42 +38,86 @@ class CommandModule(
                 .filter(::isUpdatedAfterLastRun.partially1(lastRun))
                 .filter(::isStaffRestricted)
                 .filter(::userIsVolunteer)
-                .filter(::isProbablyACommand)
             assertNotEmpty(staffComments).bind()
 
-            val results = staffComments
-                .map { it to executeCommand(it, this) }
-
-            if (results.isEmpty()) {
-                (OperationNotNeededModuleResponse.left() as Either<ModuleError, ModuleResponse>).bind()
-            }
-            results.forEach { (comment, result) ->
-                if (result.isLeft()) {
-                    comment.update("[~arisabot]: (x) ${(result as Either.Left).a.message}.\n----\n${comment.body}")
-                } else {
-                    comment.update("[~arisabot]: (/) ${(result as Either.Right).b}.\n----\n${comment.body}")
+            val commands = staffComments
+                .map { comment ->
+                    comment to extractCommands(issue, comment)
                 }
-            }
+                .filter { it.second.isNotEmpty() }
+                .onEach { invocation ->
+                    val commandResults = invocation.second
+                        .map { it.source.line to executeCommand(it) }
+                        .toMap()
+                    editInvocationComment(invocation.first, commandResults)
+                }
+            assertNotEmpty(commands).bind()
+
             ModuleResponse.right().bind()
         }
     }
 
-    @Suppress("SpreadOperator")
-    private fun executeCommand(comment: Comment, issue: Issue): Either<Throwable, Int> {
-        val source = CommandSource(issue, comment)
+    private fun executeCommand(command: Command): CommandResult {
         return runBlocking {
             Either.catch {
-                commandDispatcher.execute(comment.body, source)
+                commandDispatcher.execute(command.command, command.source)
             }
         }
     }
 
     private fun isUpdatedAfterLastRun(lastRun: Instant, comment: Comment) = comment.updated.isAfter(lastRun)
 
-    private fun isProbablyACommand(comment: Comment) =
-        !comment.body.isNullOrBlank() &&
-                comment.body.startsWith("${prefix}_") &&
-                (comment.body.count { it.isWhitespace() } > 0)
+    /**
+     * Extracts all commands from a comment.
+     */
+    private fun extractCommands(issue: Issue, comment: Comment) =
+        comment.body?.lines().orEmpty()
+            .mapIndexed { lineNr, line -> lineNr to line.trim() }
+            .filter { (_, line) -> line.startsWith("${prefix}_") }
+            .filter { (_, line) -> line.any { char -> char.isWhitespace() } }
+            .map { (lineNr, line) ->
+                Command(line, CommandSource(issue, comment, lineNr))
+            }
+
+    /**
+     * Edits the given comment (that was used to invoke some commands) with the given results.
+     *
+     * @param results Command results mapped to the line number in the comment
+     */
+    private fun editInvocationComment(comment: Comment, results: Map<Int, CommandResult>) {
+        val newBody = comment.body?.lines().orEmpty()
+            .mapIndexed { lineNr, line ->
+                when (val result = results[lineNr]) {
+                    null -> line
+                    else -> "\n${ getCommandFeedback(line, result) }\n"
+                }
+            }
+            .joinToString("\n")
+            .replace(Regex("""^\s*|\s*$"""), "")
+            .replace(Regex("""\n\n+"""), "\n\n")
+
+        comment.update(newBody)
+    }
+
+    /**
+     * Get the command feedback string for a command result.
+     */
+    private fun getCommandFeedback(command: String, result: CommandResult): String {
+        val badge = when (result) {
+            is Either.Left -> "(x)"
+            is Either.Right -> "(/)"
+        }
+
+        val feedback = when (result) {
+            is Either.Left -> result.a.message
+            is Either.Right -> "Command was executed successfully, with ${result.b} affected element(s)"
+        }
+
+        return """
+            |$badge $command
+            |→ {{$feedback}} ~??[~$botUserName]??~
+        """.trimMargin()
+    }
 
     private fun userIsVolunteer(comment: Comment) =
         comment.getAuthorGroups()?.any { it == "helper" || it == "global-moderators" || it == "staff" } ?: false

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/CommandExceptions.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/CommandExceptions.kt
@@ -37,6 +37,10 @@ object CommandExceptions {
         LiteralMessage("The version $it doesn't exist in this project")
     }
 
+    val TEST_EXCEPTION = DynamicCommandExceptionType {
+        LiteralMessage("Testing error message: $it")
+    }
+
     val VERSION_ALREADY_AFFECTED = DynamicCommandExceptionType {
         LiteralMessage("The version $it was already marked as affected")
     }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/CommandSource.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/CommandSource.kt
@@ -5,5 +5,6 @@ import io.github.mojira.arisa.domain.Issue
 
 data class CommandSource(
     val issue: Issue,
-    val comment: Comment
+    val comment: Comment,
+    val line: Int
 )

--- a/src/test/kotlin/io/github/mojira/arisa/modules/CommandModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/CommandModuleTest.kt
@@ -301,6 +301,6 @@ private fun getDispatcher(prefix: String) = CommandDispatcher<CommandSource>().a
             .then(
                 argument<CommandSource, String>("arg", greedyString())
                     .executes { throw CommandExceptions.TEST_EXCEPTION.create(RuntimeException()) }
-            ),
+            )
     )
 }

--- a/src/test/kotlin/io/github/mojira/arisa/modules/CommandModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/CommandModuleTest.kt
@@ -1,6 +1,7 @@
 package io.github.mojira.arisa.modules
 
 import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.arguments.IntegerArgumentType.integer
 import com.mojang.brigadier.arguments.StringArgumentType.greedyString
 import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
 import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
@@ -20,7 +21,7 @@ private val TWO_SECONDS_LATER = RIGHT_NOW.plusSeconds(2)
 
 class CommandModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse when no comments" {
-        val module = CommandModule("ARISA", ::getSuccessfulDispatcher)
+        val module = CommandModule("ARISA", "userName", ::getDispatcher)
         val issue = mockIssue()
 
         val result = module(issue, RIGHT_NOW)
@@ -29,7 +30,7 @@ class CommandModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse when user doesn't has group staff" {
-        val module = CommandModule("ARISA", ::getSuccessfulDispatcher)
+        val module = CommandModule("ARISA", "userName", ::getDispatcher)
         val comment = getComment(
             getAuthorGroups = { emptyList() }
         )
@@ -43,7 +44,7 @@ class CommandModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse when comment has group users" {
-        val module = CommandModule("ARISA", ::getSuccessfulDispatcher)
+        val module = CommandModule("ARISA", "userName", ::getDispatcher)
         val comment = getComment(
             visibilityType = "group",
             visibilityValue = "users"
@@ -58,7 +59,7 @@ class CommandModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse when comment doesnt have correct group" {
-        val module = CommandModule("ARISA", ::getSuccessfulDispatcher)
+        val module = CommandModule("ARISA", "userName", ::getDispatcher)
         val comment = getComment(
             visibilityType = "notagroup"
         )
@@ -72,7 +73,7 @@ class CommandModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse when comment doesnt have correct value" {
-        val module = CommandModule("ARISA", ::getSuccessfulDispatcher)
+        val module = CommandModule("ARISA", "userName", ::getDispatcher)
         val comment = getComment(
             visibilityValue = "notagroup"
         )
@@ -86,7 +87,7 @@ class CommandModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse when comment is not restricted" {
-        val module = CommandModule("ARISA", ::getSuccessfulDispatcher)
+        val module = CommandModule("ARISA", "userName", ::getDispatcher)
         val comment = getComment(
             visibilityType = null,
             visibilityValue = null
@@ -101,7 +102,7 @@ class CommandModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse when comment doesnt start with ARISA_" {
-        val module = CommandModule("ARISA", ::getSuccessfulDispatcher)
+        val module = CommandModule("ARISA", "userName", ::getDispatcher)
         val comment = getComment(
             body = "ARISA"
         )
@@ -115,9 +116,9 @@ class CommandModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse when comment doesnt have spaces" {
-        val module = CommandModule("ARISA", ::getSuccessfulDispatcher)
+        val module = CommandModule("ARISA", "userName", ::getDispatcher)
         val comment = getComment(
-            body = "ARISA_ADD_VERSION"
+            body = "ARISA_SUCCESS"
         )
         val issue = mockIssue(
             comments = listOf(comment)
@@ -130,7 +131,7 @@ class CommandModuleTest : StringSpec({
 
     "should return successfully when comment matches a command and it returns successfully" {
         var updatedComment = ""
-        val module = CommandModule("ARISA", ::getSuccessfulDispatcher)
+        val module = CommandModule("ARISA", "userName", ::getDispatcher)
         val comment = getComment(
             author = mockUser(
                 name = "SPTesting"
@@ -144,17 +145,44 @@ class CommandModuleTest : StringSpec({
         val result = module(issue, RIGHT_NOW)
 
         result.shouldBeRight()
-        updatedComment shouldBe "[~arisabot]: (/) 1.\n----\nARISA_ADD_VERSION something"
+        updatedComment shouldBe """
+            |(/) ARISA_SUCCESS arg
+            |→ {{Command was executed successfully, with 1 affected element(s)}} ~??[~userName]??~
+        """.trimMargin()
+    }
+
+    "should return with given return value when command executes successfully" {
+        var updatedComment = ""
+        val module = CommandModule("ARISA", "userName", ::getDispatcher)
+        val comment = getComment(
+            author = mockUser(
+                name = "SPTesting"
+            ),
+            update = { updatedComment = it },
+            body = "ARISA_VALUE 42"
+        )
+        val issue = mockIssue(
+            comments = listOf(comment)
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight()
+        updatedComment shouldBe """
+            |(/) ARISA_VALUE 42
+            |→ {{Command was executed successfully, with 42 affected element(s)}} ~??[~userName]??~
+        """.trimMargin()
     }
 
     "should return successfully but append the exception message when comment matches a command and it returns failed" {
         var updatedComment = ""
-        val module = CommandModule("ARISA", ::getFailingDispatcher)
+        val module = CommandModule("ARISA", "userName", ::getDispatcher)
         val comment = getComment(
             author = mockUser(
                 name = "SPTesting"
             ),
-            update = { updatedComment = it }
+            update = { updatedComment = it },
+            body = "ARISA_FAIL arg"
         )
         val issue = mockIssue(
             comments = listOf(comment)
@@ -163,8 +191,75 @@ class CommandModuleTest : StringSpec({
         val result = module(issue, RIGHT_NOW)
 
         result.shouldBeRight()
-        updatedComment shouldBe "[~arisabot]: (x) Something went wrong, but I'm too lazy to interpret the details " +
-                "for you (>ω<): java.lang.RuntimeException.\n----\nARISA_ADD_VERSION something"
+        updatedComment shouldBe """
+            |(x) ARISA_FAIL arg
+            |→ {{Testing error message: java.lang.RuntimeException}} ~??[~userName]??~
+        """.trimMargin()
+    }
+
+    "should work for other prefixes" {
+        var updatedComment = ""
+        val module = CommandModule("TESTING_COMMAND", "userName", ::getDispatcher)
+        val comment = getComment(
+            author = mockUser(
+                name = "SPTesting"
+            ),
+            update = { updatedComment = it },
+            body = "TESTING_COMMAND_SUCCESS arg"
+        )
+        val issue = mockIssue(
+            comments = listOf(comment)
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight()
+        updatedComment shouldBe """
+            |(/) TESTING_COMMAND_SUCCESS arg
+            |→ {{Command was executed successfully, with 1 affected element(s)}} ~??[~userName]??~
+        """.trimMargin()
+    }
+
+    "should be able to handle multiple commands in the same comment" {
+        var updatedComment = ""
+        val module = CommandModule("ARISA", "userName", ::getDispatcher)
+        val comment = getComment(
+            author = mockUser(
+                name = "SPTesting"
+            ),
+            update = { updatedComment = it },
+            body = """
+                |Hello Arisa please do the following commands
+                |ARISA_SUCCESS arg1
+                |ARISA_FAIL arg2
+                |and this one
+                |ARISA_SUCCESS arg3
+                |Thank you!
+            """.trimMargin()
+        )
+        val issue = mockIssue(
+            comments = listOf(comment)
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight()
+        updatedComment shouldBe """
+            |Hello Arisa please do the following commands
+            |
+            |(/) ARISA_SUCCESS arg1
+            |→ {{Command was executed successfully, with 1 affected element(s)}} ~??[~userName]??~
+            |
+            |(x) ARISA_FAIL arg2
+            |→ {{Testing error message: java.lang.RuntimeException}} ~??[~userName]??~
+            |
+            |and this one
+            |
+            |(/) ARISA_SUCCESS arg3
+            |→ {{Command was executed successfully, with 1 affected element(s)}} ~??[~userName]??~
+            |
+            |Thank you!
+        """.trimMargin()
     }
 })
 
@@ -172,7 +267,7 @@ private fun getComment(
     getAuthorGroups: () -> List<String> = { listOf("staff") },
     visibilityType: String? = "group",
     visibilityValue: String? = "staff",
-    body: String = "ARISA_ADD_VERSION something",
+    body: String = "ARISA_SUCCESS arg",
     author: User = mockUser(),
     update: (String) -> Unit = {}
 ) = mockComment(
@@ -186,22 +281,26 @@ private fun getComment(
     update = update
 )
 
-private fun getSuccessfulDispatcher(prefix: String) = CommandDispatcher<CommandSource>().apply {
+private fun getDispatcher(prefix: String) = CommandDispatcher<CommandSource>().apply {
     register(
-        literal<CommandSource>("${prefix}_ADD_VERSION")
+        literal<CommandSource>("${prefix}_SUCCESS")
             .then(
-                argument<CommandSource, String>("version", greedyString())
+                argument<CommandSource, String>("arg", greedyString())
                     .executes { 1 }
             )
     )
-}
-
-private fun getFailingDispatcher(prefix: String) = CommandDispatcher<CommandSource>().apply {
     register(
-        literal<CommandSource>("${prefix}_ADD_VERSION")
+        literal<CommandSource>("${prefix}_VALUE")
             .then(
-                argument<CommandSource, String>("version", greedyString())
-                    .executes { throw CommandExceptions.LEFT_EITHER.create(RuntimeException()) }
+                argument<CommandSource, Int>("arg", integer())
+                    .executes { it.getArgument("arg", Int::class.java) }
             )
+    )
+    register(
+        literal<CommandSource>("${prefix}_FAIL")
+            .then(
+                argument<CommandSource, String>("arg", greedyString())
+                    .executes { throw CommandExceptions.TEST_EXCEPTION.create(RuntimeException()) }
+            ),
     )
 }


### PR DESCRIPTION
## Purpose
Fix #533

## Approach
Read each line as a singular command!

Also I improved feedback and formatting a bit to make it more intuitive (which was also kinda required for preventing the bot from executing a comment twice if lastRun isn't updated correctly for whatever reason)

You can see how it looks here: https://bugs.mojang.com/browse/MC-193399 (obviously Arisa's username will appear instead of mine

## Future work
Run all the commands!!!

#### Checklist
- [x] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [x] Tested in MC-193399