### PR TITLE
ReopenAwaitingModule: Don't reopen if commenter is a new user

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/domain/User.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/domain/User.kt
@@ -3,5 +3,6 @@ package io.github.mojira.arisa.domain
 data class User(
     val name: String?,
     val displayName: String?,
-    val getGroups: () -> List<String>?
+    val getGroups: () -> List<String>?,
+    val isNewUser: () -> Boolean
 )

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/JqlUtils.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/JqlUtils.kt
@@ -1,0 +1,12 @@
+package io.github.mojira.arisa.infrastructure
+
+fun escapeIssueFunction(username: String, template: (username: String) -> String): String {
+    val escapedUserName = when {
+        username.contains('\'') -> """\"$username\""""
+        username.contains('"') -> """\'$username\'"""
+        else -> "'$username'"
+    }
+    val delim = if (username.contains('"')) "'" else "\""
+
+    return delim + template(escapedUserName) + delim
+}

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
@@ -183,7 +183,7 @@ private fun getUserGroups(jiraClient: JiraClient, username: String) = getGroups(
 ).fold({ null }, { it })
 
 private fun isNewUser(jiraClient: JiraClient, username: String): Boolean {
-    val escapedUserName = if (username.contains('\'')) """\\"$username\\"""" else "'$username'"
+    val escapedUserName = if (username.contains('\'')) """\\"$username\\"""" else "'${username.replace("\"", "\\\"")}'"
     val commentJql = """issueFunction IN commented("by $escapedUserName before -24h")"""
 
     val oldCommentsExist = try {

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
@@ -183,7 +183,7 @@ private fun getUserGroups(jiraClient: JiraClient, username: String) = getGroups(
 ).fold({ null }, { it })
 
 private fun isNewUser(jiraClient: JiraClient, username: String): Boolean {
-    val escapedUserName = if (username.contains('\'')) "\"$username\"" else "'$username'"
+    val escapedUserName = if (username.contains('\'')) """\\"$username\\"""" else "'$username'"
     val commentJql = """issueFunction IN commented("by $escapedUserName before -24h")"""
 
     val oldCommentsExist = try {

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
@@ -17,6 +17,7 @@ import io.github.mojira.arisa.domain.LinkedIssue
 import io.github.mojira.arisa.domain.Project
 import io.github.mojira.arisa.domain.User
 import io.github.mojira.arisa.domain.Version
+import io.github.mojira.arisa.infrastructure.escapeIssueFunction
 import io.github.mojira.arisa.infrastructure.HelperMessageService
 import io.github.mojira.arisa.infrastructure.IssueUpdateContextCache
 import io.github.mojira.arisa.infrastructure.config.Arisa
@@ -183,8 +184,7 @@ private fun getUserGroups(jiraClient: JiraClient, username: String) = getGroups(
 ).fold({ null }, { it })
 
 private fun isNewUser(jiraClient: JiraClient, username: String): Boolean {
-    val escapedUserName = if (username.contains('\'')) """\\"$username\\"""" else "'${username.replace("\"", "\\\"")}'"
-    val commentJql = """issueFunction IN commented("by $escapedUserName before -24h")"""
+    val commentJql = "issueFunction IN commented(${ escapeIssueFunction(username) { "by $it before -24h" } })"
 
     val oldCommentsExist = try {
         jiraClient.countIssues(commentJql) > 0

--- a/src/main/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModule.kt
@@ -91,6 +91,7 @@ class ReopenAwaitingModule(
         lastRun: Instant
     ): List<Comment> = comments
         .filter { it.created.isAfter(resolveTime) && it.created.isAfter(lastRun) }
+        .filterNot { it.author.isNewUser() }
         .filter {
             val roles = it.getAuthorGroups()
             roles == null || roles.intersect(blacklistedRoles).isEmpty()

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveContentCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveContentCommand.kt
@@ -61,7 +61,7 @@ class RemoveContentCommand(
         issue: io.github.mojira.arisa.domain.Issue,
         userName: String
     ): Int {
-        val escapedUserName = if (userName.contains('\'')) "\"$userName\"" else "'$userName'"
+        val escapedUserName = if (userName.contains('\'')) """\\"$userName\\"""" else "'$userName'"
 
         val jql = """project != TRASH
             | AND issueFunction IN commented("by $escapedUserName")

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveContentCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveContentCommand.kt
@@ -61,11 +61,11 @@ class RemoveContentCommand(
         issue: io.github.mojira.arisa.domain.Issue,
         userName: String
     ): Int {
-        val escapedUserName = userName.replace("'", "\\'")
+        val escapedUserName = if (userName.contains('\'')) "\"$userName\"" else "'$userName'"
 
         val jql = """project != TRASH
-            | AND issueFunction IN commented("by '$escapedUserName'")
-            | OR issueFunction IN fileAttached("by '$escapedUserName'")"""
+            | AND issueFunction IN commented("by $escapedUserName")
+            | OR issueFunction IN fileAttached("by $escapedUserName")"""
             .trimMargin().replace("[\n\r]", "")
 
         val ticketIds = when (val either = searchIssues(jql, REMOVABLE_ACTIVITY_CAP)) {

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveContentCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveContentCommand.kt
@@ -1,6 +1,7 @@
 package io.github.mojira.arisa.modules.commands
 
 import arrow.core.Either
+import io.github.mojira.arisa.infrastructure.escapeIssueFunction
 import io.github.mojira.arisa.log
 import net.rcarz.jiraclient.Attachment
 import net.rcarz.jiraclient.Comment
@@ -61,11 +62,11 @@ class RemoveContentCommand(
         issue: io.github.mojira.arisa.domain.Issue,
         userName: String
     ): Int {
-        val escapedUserName = if (userName.contains('\'')) """\\"$userName\\"""" else "'$userName'"
+        val issueFunctionInner = escapeIssueFunction(userName) { "by $it" }
 
         val jql = """project != TRASH
-            | AND issueFunction IN commented("by $escapedUserName")
-            | OR issueFunction IN fileAttached("by $escapedUserName")"""
+            | AND issueFunction IN commented($issueFunctionInner)
+            | OR issueFunction IN fileAttached($issueFunctionInner)"""
             .trimMargin().replace("[\n\r]", "")
 
         val ticketIds = when (val either = searchIssues(jql, REMOVABLE_ACTIVITY_CAP)) {

--- a/src/test/kotlin/io/github/mojira/arisa/infrastructure/JqlUtilsTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/infrastructure/JqlUtilsTest.kt
@@ -1,0 +1,20 @@
+package io.github.mojira.arisa.infrastructure
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class JqlUtilsTest : StringSpec({
+    val template = { it: String -> "query $it user" }
+
+    "should properly quote regular user names" {
+        escapeIssueFunction("username", template) shouldBe """ "query 'username' user" """.trim()
+    }
+
+    "should properly quote user names with a double quote" {
+        escapeIssueFunction("user\"name", template) shouldBe """ 'query \'user"name\' user' """.trim()
+    }
+
+    "should properly quote user names with a single quote" {
+        escapeIssueFunction("user'name", template) shouldBe """ "query \"user'name\" user" """.trim()
+    }
+})

--- a/src/test/kotlin/io/github/mojira/arisa/modules/RemoveVersionModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/RemoveVersionModuleTest.kt
@@ -1,9 +1,9 @@
 package io.github.mojira.arisa.modules
 
-import io.github.mojira.arisa.domain.User
 import io.github.mojira.arisa.utils.RIGHT_NOW
 import io.github.mojira.arisa.utils.mockChangeLogItem
 import io.github.mojira.arisa.utils.mockIssue
+import io.github.mojira.arisa.utils.mockUser
 import io.github.mojira.arisa.utils.mockProject
 import io.github.mojira.arisa.utils.mockVersion
 import io.kotest.assertions.arrow.either.shouldBeLeft
@@ -19,11 +19,11 @@ private val VERSION = mockVersion(id = "1", released = true, archived = false)
 
 private val EXTRA_VERSION = mockVersion(id = "2", released = true, archived = false)
 
-private val ADD_VERSION = mockChangeLogItem(field = "Version", changedTo = "1", author = User("arisabot", null) { emptyList() })
+private val ADD_VERSION = mockChangeLogItem(field = "Version", changedTo = "1", author = mockUser(name = "arisabot"))
 private val VERSION_REMOVED =
-    mockChangeLogItem(field = "Version", changedFrom = "1", author = User("arisabot", null) { emptyList() })
+    mockChangeLogItem(field = "Version", changedFrom = "1", author = mockUser("arisabot"))
 private val VERSION_REMOVED_WITH_TO =
-    mockChangeLogItem(field = "Version", changedFrom = "1", changedTo = "1", author = User("arisabot", null) { emptyList() })
+    mockChangeLogItem(field = "Version", changedFrom = "1", changedTo = "1", author = mockUser("arisabot"))
 
 class RemoveVersionModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse when there is no change log" {

--- a/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
@@ -203,11 +203,13 @@ fun mockProject(
 fun mockUser(
     name: String = "user",
     displayName: String = "User",
-    getGroups: () -> List<String>? = { null }
+    getGroups: () -> List<String>? = { null },
+    isNewUser: () -> Boolean = { false }
 ) = User(
     name,
     displayName,
-    getGroups
+    getGroups,
+    isNewUser
 )
 
 fun mockVersion(


### PR DESCRIPTION
## Purpose
Don't reopen an AR bug report if the commenter both:
* doesn't have any comments older than 24 hours AND
* doesn't have any non-trash bug reports older than 24 hours

Also fixes #608 along the way. This also technically makes #600 redundant.

Note that some code here is untested (notably the `Mappers.kt` changes). However that's going to be refactored anyway so I didn't bother.

## Approach
I added a new method to `User` that is called and mocked

## Future work
N/A

#### Checklist
- [x] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
