### PR TITLE
Add deobfuscated crashes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,10 +70,10 @@ dependencies {
 
 tasks {
     compileKotlin {
-        kotlinOptions.jvmTarget = "1.8"
+        kotlinOptions.jvmTarget = "11"
     }
     compileTestKotlin {
-        kotlinOptions.jvmTarget = "1.8"
+        kotlinOptions.jvmTarget = "11"
     }
 
     test {
@@ -103,7 +103,7 @@ detekt {
 tasks {
     withType<io.gitlab.arturbosch.detekt.Detekt> {
         // Target version of the generated JVM bytecode. It is used for type resolution.
-        this.jvmTarget = "1.8"
+        this.jvmTarget = "11"
     }
 }
 

--- a/src/main/kotlin/io/github/mojira/arisa/domain/Issue.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/domain/Issue.kt
@@ -1,5 +1,6 @@
 package io.github.mojira.arisa.domain
 
+import java.io.File
 import java.time.Instant
 
 data class Issue(
@@ -45,5 +46,6 @@ data class Issue(
     val addNotEnglishComment: (language: String) -> Unit,
     val addRawRestrictedComment: (body: String, restriction: String) -> Unit,
     val markAsFixedWithSpecificVersion: (fixVersion: String) -> Unit,
-    val changeReporter: (reporter: String) -> Unit
+    val changeReporter: (reporter: String) -> Unit,
+    val addAttachment: (file: File) -> Unit
 )

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/AttachmentUtils.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/AttachmentUtils.kt
@@ -14,7 +14,8 @@ class AttachmentUtils(
 ) {
     data class TextDocument(
         val getContent: () -> String,
-        val created: Instant
+        val created: Instant,
+        val name: String
     )
 
     fun extractCrashesFromAttachments(issue: Issue): List<Pair<TextDocument, Crash>> = with(issue) {
@@ -23,7 +24,7 @@ class AttachmentUtils(
             .map(::fetchAttachment)
             .toMutableList()
         // also add description, so it's searched for crash reports
-        textDocuments.add(TextDocument({ description ?: "" }, created))
+        textDocuments.add(TextDocument({ description ?: "" }, created, "description"))
 
         textDocuments
             .asSequence()
@@ -43,7 +44,7 @@ class AttachmentUtils(
             String(data)
         }
 
-        return TextDocument(getText, attachment.created)
+        return TextDocument(getText, attachment.created, attachment.name)
     }
 
     private fun processCrash(it: TextDocument) = it to crashReader.processCrash(it.getContent().lines())

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
@@ -138,7 +138,8 @@ fun JiraIssue.toDomain(
         },
         addRawRestrictedComment = ::addRestrictedComment.partially1(context),
         ::markAsFixedWithSpecificVersion.partially1(context),
-        ::changeReporter.partially1(context)
+        ::changeReporter.partially1(context),
+        ::addAttachmentFile.partially1(context)
     )
 }
 

--- a/src/test/kotlin/io/github/mojira/arisa/modules/CrashModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/CrashModuleTest.kt
@@ -173,6 +173,69 @@ const val JAVA_CRASH = """#
 # See problematic frame for where to report the bug.
 #"""
 
+const val OBFUSCATED_CRASH = """---- Minecraft Crash Report ----
+// Don't do that.
+
+Time: 30/04/21 17:23
+Description: mouseClicked event handler
+
+java.lang.OutOfMemoryError: Java heap space
+	at java.util.ArrayList.<init>(ArrayList.java:152)
+	at com.google.common.collect.Lists.newArrayListWithCapacity(Lists.java:190)
+	at mj$1.a(SourceFile:47)
+	at mj$1.b(SourceFile:32)
+	at md.b(SourceFile:471)
+	at md.a(SourceFile:32)
+	at md$1.a(SourceFile:83)
+	at md$1.b(SourceFile:69)
+	at md.b(SourceFile:471)
+	at md.a(SourceFile:32)
+	at md$1.a(SourceFile:83)
+	at md$1.b(SourceFile:69)
+	at md.b(SourceFile:471)
+	at md.a(SourceFile:32)
+	at md$1.a(SourceFile:83)
+	at md$1.b(SourceFile:69)
+	at mn.a(SourceFile:108)
+	at mn.a(SourceFile:75)
+	at mn.a(SourceFile:32)
+	at mn.a(SourceFile:26)
+	at cyg.a(SourceFile:229)
+	at cygLambda$2987/857564250.apply(Unknown Source)
+	at cyg.a(SourceFile:178)
+	at cyg.b(SourceFile:157)
+	at dsm.a(SourceFile:91)
+	at dsm.<init>(SourceFile:83)
+	at dsj.b(SourceFile:48)
+	at dot.b(SourceFile:325)
+	at djz.a(SourceFile:922)
+	at doy.d(SourceFile:141)
+	at doyLambda$2670/1502984812.onPress(Unknown Source)
+	at dlj.b(SourceFile:33)
+
+-- System Details --
+Details:
+	Minecraft Version: 1.16.5
+	Minecraft Version ID: 1.16.5
+	Operating System: Windows 10 (amd64) version 10.0
+	Java Version: 1.8.0_51, Oracle Corporation
+	Java VM Version: Java HotSpot(TM) 64-Bit Server VM (mixed mode), Oracle Corporation
+	Memory: 546749712 bytes (521 MB) / 771751936 bytes (736 MB) up to 2147483648 bytes (2048 MB)
+	CPUs: 4
+	JVM Flags: 9 total; -XX:HeapDumpPath=MojangTricksIntelDriversForPerformance_javaw.exe_minecraft.exe.heapdump -Xss1M -Xmx2G -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:G1NewSizePercent=20 -XX:G1ReservePercent=20 -XX:MaxGCPauseMillis=50 -XX:G1HeapRegionSize=32M
+	Launched Version: 1.16.5
+	Backend library: LWJGL version 3.2.2 build 10
+	Backend API: GeForce GTX 1050 Ti/PCIe/SSE2 GL version 4.6.0 NVIDIA 456.71, NVIDIA Corporation
+	GL Caps: Using framebuffer using OpenGL 3.0
+	Using VBOs: Yes
+	Is Modded: Probably not. Jar signature remains and client brand is untouched.
+	Type: Client (map_client.txt)
+	Graphics mode: fast
+	Resource Packs: vanilla
+	Current Language: English (US)
+	CPU: 4x Intel(R) Core(TM) i5-7400 CPU @ 3.00GHz
+"""
+
 private val NOW = Instant.now()
 private val A_SECOND_AGO = NOW.minusSeconds(1)
 
@@ -496,6 +559,7 @@ class CrashModuleTest : StringSpec({
     "should resolve as invalid when reported server crash is modded" {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
+        var addedAttachement = false
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
@@ -513,6 +577,7 @@ class CrashModuleTest : StringSpec({
             priority = NoPriority,
             resolveAsDuplicate = { resolvedAsDupe = true },
             resolveAsInvalid = { resolvedAsInvalid = true },
+            addAttachment = { addedAttachement = true },
             addComment = { addedComment = it }
         )
 
@@ -520,6 +585,7 @@ class CrashModuleTest : StringSpec({
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeFalse()
+        addedAttachement.shouldBeFalse()
         resolvedAsInvalid.shouldBeTrue()
         addedComment shouldBe CommentOptions("modified-game")
     }
@@ -527,6 +593,7 @@ class CrashModuleTest : StringSpec({
     "should resolve as invalid when reported server crash is very likely modded" {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
+        var addedAttachement = false
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
@@ -544,13 +611,15 @@ class CrashModuleTest : StringSpec({
             priority = NoPriority,
             resolveAsDuplicate = { resolvedAsDupe = true },
             resolveAsInvalid = { resolvedAsInvalid = true },
-            addComment = { addedComment = it }
+            addComment = { addedComment = it },
+            addAttachment = { addedAttachement = true }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeFalse()
+        addedAttachement.shouldBeFalse()
         resolvedAsInvalid.shouldBeTrue()
         addedComment shouldBe CommentOptions("modified-game")
     }
@@ -558,6 +627,7 @@ class CrashModuleTest : StringSpec({
     "should resolve as invalid when reported crash is modded" {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
+        var addedAttachement = false
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
@@ -575,13 +645,15 @@ class CrashModuleTest : StringSpec({
             priority = NoPriority,
             resolveAsDuplicate = { resolvedAsDupe = true },
             resolveAsInvalid = { resolvedAsInvalid = true },
-            addComment = { addedComment = it }
+            addComment = { addedComment = it },
+            addAttachment = { addedAttachement = true }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeFalse()
+        addedAttachement.shouldBeFalse()
         resolvedAsInvalid.shouldBeTrue()
         addedComment shouldBe CommentOptions("modified-game")
     }
@@ -589,6 +661,7 @@ class CrashModuleTest : StringSpec({
     "should resolve as invalid when attached crash is modded" {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
+        var addedAttachement = false
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
@@ -610,13 +683,15 @@ class CrashModuleTest : StringSpec({
             priority = NoPriority,
             resolveAsDuplicate = { resolvedAsDupe = true },
             resolveAsInvalid = { resolvedAsInvalid = true },
-            addComment = { addedComment = it }
+            addComment = { addedComment = it },
+            addAttachment = { addedAttachement = true }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeFalse()
+        addedAttachement.shouldBeFalse()
         resolvedAsInvalid.shouldBeTrue()
         addedComment shouldBe CommentOptions("modified-game")
     }
@@ -624,6 +699,7 @@ class CrashModuleTest : StringSpec({
     "should resolve as dupe when reported crash is in configured list" {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
+        var addedAttachement = false
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
@@ -641,13 +717,15 @@ class CrashModuleTest : StringSpec({
             priority = NoPriority,
             resolveAsDuplicate = { resolvedAsDupe = true },
             resolveAsInvalid = { resolvedAsInvalid = true },
-            addComment = { addedComment = it }
+            addComment = { addedComment = it },
+            addAttachment = { addedAttachement = true }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeTrue()
+        addedAttachement.shouldBeFalse()
         resolvedAsInvalid.shouldBeFalse()
         addedComment shouldBe CommentOptions("duplicate-tech", "MC-297")
     }
@@ -655,6 +733,7 @@ class CrashModuleTest : StringSpec({
     "should resolve as dupe when attached crash is in configured list" {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
+        var addedAttachement = false
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
@@ -676,13 +755,15 @@ class CrashModuleTest : StringSpec({
             priority = NoPriority,
             resolveAsDuplicate = { resolvedAsDupe = true },
             resolveAsInvalid = { resolvedAsInvalid = true },
-            addComment = { addedComment = it }
+            addComment = { addedComment = it },
+            addAttachment = { addedAttachement = true }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeTrue()
+        addedAttachement.shouldBeFalse()
         resolvedAsInvalid.shouldBeFalse()
         addedComment shouldBe CommentOptions("duplicate-tech", "MC-297")
     }
@@ -690,6 +771,7 @@ class CrashModuleTest : StringSpec({
     "should resolve as dupe when the configured crash is a java crash" {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
+        var addedAttachement = false
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
@@ -707,20 +789,54 @@ class CrashModuleTest : StringSpec({
             priority = NoPriority,
             resolveAsDuplicate = { resolvedAsDupe = true },
             resolveAsInvalid = { resolvedAsInvalid = true },
-            addComment = { addedComment = it }
+            addComment = { addedComment = it },
+            addAttachment = { addedAttachement = true }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeTrue()
+        addedAttachement.shouldBeFalse()
         resolvedAsInvalid.shouldBeFalse()
         addedComment shouldBe CommentOptions("duplicate-tech", "MC-32606")
+    }
+
+    "should add attachment when deobfuscated" {
+        var resolvedAsDupe = false
+        var resolvedAsInvalid = false
+        var addedAttachement = false
+
+        val module = CrashModule(
+            listOf("txt"),
+            listOf(CrashDupeConfig("java", "ig75icd64\\.dll", "MC-32606")),
+            crashReader,
+            "duplicate-tech",
+            "modified-game"
+        )
+        val issue = mockIssue(
+            attachments = listOf(getAttachment(OBFUSCATED_CRASH)),
+            description = OBFUSCATED_CRASH,
+            created = NOW,
+            confirmationStatus = Unconfirmed,
+            priority = NoPriority,
+            resolveAsDuplicate = { resolvedAsDupe = true },
+            resolveAsInvalid = { resolvedAsInvalid = true },
+            addAttachment = { addedAttachement = true }
+        )
+
+        val result = module(issue, A_SECOND_AGO)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+        resolvedAsDupe.shouldBeFalse()
+        addedAttachement.shouldBeTrue()
+        resolvedAsInvalid.shouldBeFalse()
     }
 
     "should resolve as dupe when the configured crash uses regex" {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
+        var addedAttachement = false
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
@@ -738,13 +854,15 @@ class CrashModuleTest : StringSpec({
             priority = NoPriority,
             resolveAsDuplicate = { resolvedAsDupe = true },
             resolveAsInvalid = { resolvedAsInvalid = true },
-            addComment = { addedComment = it }
+            addComment = { addedComment = it },
+            addAttachment = { addedAttachement = true }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeTrue()
+        addedAttachement.shouldBeFalse()
         resolvedAsInvalid.shouldBeFalse()
         addedComment shouldBe CommentOptions("duplicate-tech", "MC-32606")
     }
@@ -752,6 +870,7 @@ class CrashModuleTest : StringSpec({
     "should link to configured ticket when resolving as dupe" {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
+        var addedAttachement = false
         var isLinked = false
 
         val module = CrashModule(
@@ -773,13 +892,15 @@ class CrashModuleTest : StringSpec({
                 type.shouldBe("Duplicate")
                 key.shouldBe("MC-297")
                 isLinked = true
-            }
+            },
+            addAttachment = { addedAttachement = true }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeTrue()
+        addedAttachement.shouldBeFalse()
         resolvedAsInvalid.shouldBeFalse()
         isLinked.shouldBeTrue()
     }
@@ -787,6 +908,7 @@ class CrashModuleTest : StringSpec({
     "should prefer crash that is not modded, if modded crash appears first" {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
+        var addedAttachement = false
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
@@ -813,13 +935,15 @@ class CrashModuleTest : StringSpec({
             priority = NoPriority,
             resolveAsDuplicate = { resolvedAsDupe = true },
             resolveAsInvalid = { resolvedAsInvalid = true },
-            addComment = { addedComment = it }
+            addComment = { addedComment = it },
+            addAttachment = { addedAttachement = true }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeTrue()
+        addedAttachement.shouldBeFalse()
         resolvedAsInvalid.shouldBeFalse()
         addedComment shouldBe CommentOptions("duplicate-tech", "MC-297")
     }
@@ -827,6 +951,7 @@ class CrashModuleTest : StringSpec({
     "should prefer crash that is not modded, if duped crash appears first" {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
+        var addedAttachement = false
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
@@ -853,13 +978,15 @@ class CrashModuleTest : StringSpec({
             priority = NoPriority,
             resolveAsDuplicate = { resolvedAsDupe = true },
             resolveAsInvalid = { resolvedAsInvalid = true },
-            addComment = { addedComment = it }
+            addComment = { addedComment = it },
+            addAttachment = { addedAttachement = true }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeTrue()
+        addedAttachement.shouldBeFalse()
         resolvedAsInvalid.shouldBeFalse()
         addedComment shouldBe CommentOptions("duplicate-tech", "MC-297")
     }
@@ -867,6 +994,7 @@ class CrashModuleTest : StringSpec({
     "should prefer more recent crash, if less recent crash appears first " {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
+        var addedAttachement = false
         var isLinked = false
 
         val module = CrashModule(
@@ -902,13 +1030,15 @@ class CrashModuleTest : StringSpec({
                 key.shouldBe("MC-297")
                 isLinked = true
             },
-            addComment = { Unit.right() }
+            addComment = { Unit.right() },
+            addAttachment = { addedAttachement = true }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeTrue()
+        addedAttachement.shouldBeFalse()
         resolvedAsInvalid.shouldBeFalse()
         isLinked.shouldBeTrue()
     }
@@ -916,6 +1046,7 @@ class CrashModuleTest : StringSpec({
     "should prefer more recent crash, if more recent crash appears first " {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
+        var addedAttachement = false
         var isLinked = false
 
         val module = CrashModule(
@@ -951,13 +1082,15 @@ class CrashModuleTest : StringSpec({
                 key.shouldBe("MC-297")
                 isLinked = true
             },
-            addComment = { Unit.right() }
+            addComment = { Unit.right() },
+            addAttachment = { addedAttachement = true }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeTrue()
+        addedAttachement.shouldBeFalse()
         resolvedAsInvalid.shouldBeFalse()
         isLinked.shouldBeTrue()
     }

--- a/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
@@ -12,6 +12,7 @@ import io.github.mojira.arisa.domain.LinkedIssue
 import io.github.mojira.arisa.domain.Project
 import io.github.mojira.arisa.domain.User
 import io.github.mojira.arisa.domain.Version
+import java.io.File
 import java.time.Instant
 
 val RIGHT_NOW: Instant = Instant.now()
@@ -120,7 +121,8 @@ fun mockIssue(
     addNotEnglishComment: (language: String) -> Unit = { },
     addRawRestrictedComment: (body: String, restrictions: String) -> Unit = { _, _ -> },
     markAsFixedInASpecificVersion: (version: String) -> Unit = { },
-    changeReporter: (reporter: String) -> Unit = { }
+    changeReporter: (reporter: String) -> Unit = { },
+    addAttachment: (file: File) -> Unit = { }
 ) = Issue(
     key,
     summary,
@@ -164,7 +166,8 @@ fun mockIssue(
     addNotEnglishComment,
     addRawRestrictedComment,
     markAsFixedInASpecificVersion,
-    changeReporter
+    changeReporter,
+    addAttachment
 )
 
 fun mockLink(


### PR DESCRIPTION
## Purpose
Fix #606
## Approach
Use newly added deobfuscation in mc-crash-lib and upload a new attachment with the suffix -deobfuscated.log to any new attachment + description
## Future work

#### Checklist
- [/] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
