### PR TITLE
ReopenAwaiting: Fix Arisa not reopening if reporter comments and reporter is a new user

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModule.kt
@@ -30,7 +30,7 @@ class ReopenAwaitingModule(
             assertCreationIsNotRecent(updated.toEpochMilli(), created.toEpochMilli()).bind()
 
             val resolveTime = changeLog.last(::isAwaitingResolve).created
-            val validComments = getValidComments(comments, resolveTime, lastRun)
+            val validComments = getValidComments(comments, reporter, resolveTime, lastRun)
             val validChangeLog = getValidChangeLog(changeLog, reporter, resolveTime)
 
             assertEither(
@@ -87,11 +87,12 @@ class ReopenAwaitingModule(
 
     private fun getValidComments(
         comments: List<Comment>,
+        reporter: User?,
         resolveTime: Instant,
         lastRun: Instant
     ): List<Comment> = comments
         .filter { it.created.isAfter(resolveTime) && it.created.isAfter(lastRun) }
-        .filterNot { it.author.isNewUser() }
+        .filter { !it.author.isNewUser() || it.author.name == reporter?.name }
         .filter {
             val roles = it.getAuthorGroups()
             roles == null || roles.intersect(blacklistedRoles).isEmpty()

--- a/src/test/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModuleTest.kt
@@ -756,6 +756,29 @@ class ReopenAwaitingModuleTest : StringSpec({
         hasCommented shouldBe false
     }
 
+    "should reopen when the commenter is a new user but also the reporter" {
+        var hasReopened = false
+        var hasCommented = false
+
+        val comment = getComment(author = NEWBIE)
+        val updated = RIGHT_NOW.plusSeconds(3)
+        val issue = mockIssue(
+            resolution = "Awaiting Response",
+            updated = updated,
+            reporter = NEWBIE,
+            comments = listOf(comment),
+            changeLog = listOf(AWAITING_RESOLVE),
+            reopen = { hasReopened = true; Unit.right() },
+            addComment = { hasCommented = true; Unit.right() }
+        )
+
+        val result = MODULE(issue, TEN_SECONDS_AGO)
+
+        result.shouldBeRight(ModuleResponse)
+        hasReopened shouldBe true
+        hasCommented shouldBe false
+    }
+
     "should comment the message when there is a keep AR tag" {
         var hasReopened = false
         var hasCommented = false


### PR DESCRIPTION
## Purpose
I noticed this bug when writing the docs into the wiki.
Arisa would not reopen if the reporter comments and the reporter is a new user. It should do that, there's no reason for it not to.

## Approach
Don't filter comments from reporter from the comments

## Future work

#### Checklist
- [x] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
