### PR TITLE
Fix removing both Relates links

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/RemoveIdenticalLinkModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RemoveIdenticalLinkModule.kt
@@ -27,5 +27,5 @@ class RemoveIdenticalLinkModule : Module {
         }
     }
 
-    private fun isRelatesLink(link: Link): Boolean = link.type.toLowerCase() === "relates"
+    private fun isRelatesLink(link: Link): Boolean = link.type.toLowerCase() == "relates"
 }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RemoveIdenticalLinkModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RemoveIdenticalLinkModule.kt
@@ -3,40 +3,29 @@ package io.github.mojira.arisa.modules
 import arrow.core.Either
 import arrow.core.extensions.fx
 import io.github.mojira.arisa.domain.Issue
+import io.github.mojira.arisa.domain.Link
 import java.time.Instant
 
 class RemoveIdenticalLinkModule : Module {
-    data class GroupingLink(
-        val type: String,
-        val outwards: Boolean,
-        val key: String
-    )
-
     override fun invoke(issue: Issue, lastRun: Instant): Either<ModuleError, ModuleResponse> = with(issue) {
         Either.fx {
             assertNotEmpty(links).bind()
 
             val removeLinkFunctions = links
-                .groupBy {
-                    GroupingLink(
-                        it.type,
-                        if (it.type.toLowerCase() == "relates") {
-                            true
-                        } else {
-                            it.outwards
-                        },
-                        it.issue.key
-                    )
-                }
-                .filterValues { it.size > 1 }
-                .values
-                .flatMap { list ->
-                    list.subList(1, list.size).map { it.remove }
+                .filter(::isRelatesLink)
+                .groupBy { it.issue.key }
+                .filterValues { it.size == 2 }
+                .map {
+                    // Always remove the outwards link belonging to the smaller ticket key,
+                    // so that when this module is triggered on both tickets, only one link is removed.
+                    it.value.find { l -> if (key < it.key) l.outwards else !l.outwards }?.remove
                 }
 
             assertNotEmpty(removeLinkFunctions).bind()
 
-            removeLinkFunctions.forEach { it.invoke() }
+            removeLinkFunctions.forEach { it?.invoke() }
         }
     }
+
+    private fun isRelatesLink(link: Link): Boolean = link.type.toLowerCase() === "relates"
 }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RemoveIdenticalLinkModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RemoveIdenticalLinkModule.kt
@@ -18,12 +18,12 @@ class RemoveIdenticalLinkModule : Module {
                 .map {
                     // Always remove the outwards link belonging to the smaller ticket key,
                     // so that when this module is triggered on both tickets, only one link is removed.
-                    it.value.find { l -> if (key < it.key) l.outwards else !l.outwards }?.remove
+                    it.value.find { l -> if (key < it.key) l.outwards else !l.outwards }!!.remove
                 }
 
             assertNotEmpty(removeLinkFunctions).bind()
 
-            removeLinkFunctions.forEach { it?.invoke() }
+            removeLinkFunctions.forEach { it.invoke() }
         }
     }
 

--- a/src/test/kotlin/io/github/mojira/arisa/modules/RemoveIdenticalLinkModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/RemoveIdenticalLinkModuleTest.kt
@@ -100,8 +100,8 @@ class RemoveIdenticalLinkModuleTest : StringSpec({
         val result = module(issue, RIGHT_NOW)
 
         result.shouldBeRight(ModuleResponse)
-        hasRemovedLink1 shouldBe false
-        hasRemovedLink2 shouldBe true
+        hasRemovedLink1 shouldBe true
+        hasRemovedLink2 shouldBe false
     }
 
     "should remove the extra Relates link pointing out from the target when the target is smaller" {
@@ -133,7 +133,7 @@ class RemoveIdenticalLinkModuleTest : StringSpec({
         val result = module(issue, RIGHT_NOW)
 
         result.shouldBeRight(ModuleResponse)
-        hasRemovedLink1 shouldBe true
-        hasRemovedLink2 shouldBe false
+        hasRemovedLink1 shouldBe false
+        hasRemovedLink2 shouldBe true
     }
 })


### PR DESCRIPTION
## Purpose
Fix #487.

## Approach
By always removing the outwards link belonging to the smaller ticket key.

## Future work

#### Checklist
- [x] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
