### PR TITLE
General improvements to crash module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ helper-messages.json
 /out/
 /logs/
 last-run
+mc-mappings/
 
 # Old credentials config file
 arisa.yml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
 
     implementation("com.uchuhimo", "konf", "0.22.1")
     implementation("com.github.rcarz", "jira-client", "master-SNAPSHOT")
-    implementation("me.urielsalis", "mc-crash-lib", "master-SNAPSHOT")
+    implementation("me.urielsalis", "mc-crash-lib", "1.0.4")
     implementation("com.github.napstr", "logback-discord-appender", "1.0.0")
     implementation("org.slf4j", "slf4j-api", "1.7.25")
     implementation("ch.qos.logback", "logback-classic", logBackVersion)

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/AttachmentUtils.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/AttachmentUtils.kt
@@ -6,12 +6,19 @@ import io.github.mojira.arisa.domain.Issue
 import me.urielsalis.mccrashlib.Crash
 import me.urielsalis.mccrashlib.CrashReader
 import me.urielsalis.mccrashlib.parser.ParserError
+import java.io.File
 import java.time.Instant
 
 class AttachmentUtils(
     private val crashReportExtensions: List<String>,
     private val crashReader: CrashReader
 ) {
+    private val mappingsDir by lazy {
+        val file = File("mc-mappings")
+        if (!file.exists()) file.mkdir()
+        file
+    }
+
     data class TextDocument(
         val getContent: () -> String,
         val created: Instant,
@@ -47,7 +54,7 @@ class AttachmentUtils(
         return TextDocument(getText, attachment.created, attachment.name)
     }
 
-    private fun processCrash(it: TextDocument) = it to crashReader.processCrash(it.getContent().lines())
+    private fun processCrash(it: TextDocument) = it to crashReader.processCrash(it.getContent().lines(), mappingsDir)
 
     private fun extractCrash(it: Pair<TextDocument, Either<ParserError, Crash>>) =
         it.first to (it.second as Either.Right<Crash>).b


### PR DESCRIPTION
## Purpose
- Download mappings only once
- Save crashes to a temp directory in case deleting fails
- Check for zip slip

## Future work

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
