### PR TITLE
Delete temporary crashes directory after upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,15 +2,17 @@
 /.gradle/
 /build/
 .idea/
-helper-messages.json
 /.kotest
 /bin/
 /lib/
 /out/
-/logs/
-last-run
-mc-mappings/
 
 # Old credentials config file
 arisa.yml
 /config/local.yml
+
+# Files and folders created when running Arisa
+/logs/
+last-run
+helper-messages.json
+mc-mappings/

--- a/src/main/kotlin/io/github/mojira/arisa/domain/Issue.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/domain/Issue.kt
@@ -49,5 +49,5 @@ data class Issue(
     val addRawRestrictedComment: (body: String, restriction: String) -> Unit,
     val markAsFixedWithSpecificVersion: (fixVersion: String) -> Unit,
     val changeReporter: (reporter: String) -> Unit,
-    val addAttachment: (file: File) -> Unit
+    val addAttachment: (file: File, cleanupCallback: () -> Unit) -> Unit
 )

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
@@ -260,7 +260,7 @@ fun deleteAttachment(context: Lazy<IssueUpdateContext>, attachment: Attachment) 
     }
 }
 
-fun addAttachmentFile(context: Lazy<IssueUpdateContext>, file: File) {
+fun addAttachmentFile(context: Lazy<IssueUpdateContext>, file: File, cleanupCallback: () -> Unit) {
     context.value.otherOperations.add {
         runBlocking {
             Either.catch {
@@ -276,9 +276,7 @@ fun addAttachmentFile(context: Lazy<IssueUpdateContext>, file: File) {
                             throw e
                         }
                     } finally {
-                        if (file.exists()) {
-                            file.delete()
-                        }
+                        cleanupCallback()
                     }
                 }
             }

--- a/src/test/kotlin/io/github/mojira/arisa/modules/CrashModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/CrashModuleTest.kt
@@ -559,7 +559,7 @@ class CrashModuleTest : StringSpec({
     "should resolve as invalid when reported server crash is modded" {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
-        var addedAttachement = false
+        var addedAttachment = false
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
@@ -577,15 +577,18 @@ class CrashModuleTest : StringSpec({
             priority = NoPriority,
             resolveAsDuplicate = { resolvedAsDupe = true },
             resolveAsInvalid = { resolvedAsInvalid = true },
-            addAttachment = { addedAttachement = true },
-            addComment = { addedComment = it }
+            addComment = { addedComment = it },
+            addAttachment = { _, cleanupCallback ->
+                addedAttachment = true
+                cleanupCallback()
+            }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeFalse()
-        addedAttachement.shouldBeFalse()
+        addedAttachment.shouldBeFalse()
         resolvedAsInvalid.shouldBeTrue()
         addedComment shouldBe CommentOptions("modified-game")
     }
@@ -593,7 +596,7 @@ class CrashModuleTest : StringSpec({
     "should resolve as invalid when reported server crash is very likely modded" {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
-        var addedAttachement = false
+        var addedAttachment = false
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
@@ -612,14 +615,17 @@ class CrashModuleTest : StringSpec({
             resolveAsDuplicate = { resolvedAsDupe = true },
             resolveAsInvalid = { resolvedAsInvalid = true },
             addComment = { addedComment = it },
-            addAttachment = { addedAttachement = true }
+            addAttachment = { _, cleanupCallback ->
+                addedAttachment = true
+                cleanupCallback()
+            }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeFalse()
-        addedAttachement.shouldBeFalse()
+        addedAttachment.shouldBeFalse()
         resolvedAsInvalid.shouldBeTrue()
         addedComment shouldBe CommentOptions("modified-game")
     }
@@ -627,7 +633,7 @@ class CrashModuleTest : StringSpec({
     "should resolve as invalid when reported crash is modded" {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
-        var addedAttachement = false
+        var addedAttachment = false
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
@@ -646,14 +652,17 @@ class CrashModuleTest : StringSpec({
             resolveAsDuplicate = { resolvedAsDupe = true },
             resolveAsInvalid = { resolvedAsInvalid = true },
             addComment = { addedComment = it },
-            addAttachment = { addedAttachement = true }
+            addAttachment = { _, cleanupCallback ->
+                addedAttachment = true
+                cleanupCallback()
+            }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeFalse()
-        addedAttachement.shouldBeFalse()
+        addedAttachment.shouldBeFalse()
         resolvedAsInvalid.shouldBeTrue()
         addedComment shouldBe CommentOptions("modified-game")
     }
@@ -661,7 +670,7 @@ class CrashModuleTest : StringSpec({
     "should resolve as invalid when attached crash is modded" {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
-        var addedAttachement = false
+        var addedAttachment = false
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
@@ -684,14 +693,17 @@ class CrashModuleTest : StringSpec({
             resolveAsDuplicate = { resolvedAsDupe = true },
             resolveAsInvalid = { resolvedAsInvalid = true },
             addComment = { addedComment = it },
-            addAttachment = { addedAttachement = true }
+            addAttachment = { _, cleanupCallback ->
+                addedAttachment = true
+                cleanupCallback()
+            }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeFalse()
-        addedAttachement.shouldBeFalse()
+        addedAttachment.shouldBeFalse()
         resolvedAsInvalid.shouldBeTrue()
         addedComment shouldBe CommentOptions("modified-game")
     }
@@ -699,7 +711,7 @@ class CrashModuleTest : StringSpec({
     "should resolve as dupe when reported crash is in configured list" {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
-        var addedAttachement = false
+        var addedAttachment = false
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
@@ -718,14 +730,17 @@ class CrashModuleTest : StringSpec({
             resolveAsDuplicate = { resolvedAsDupe = true },
             resolveAsInvalid = { resolvedAsInvalid = true },
             addComment = { addedComment = it },
-            addAttachment = { addedAttachement = true }
+            addAttachment = { _, cleanupCallback ->
+                addedAttachment = true
+                cleanupCallback()
+            }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeTrue()
-        addedAttachement.shouldBeFalse()
+        addedAttachment.shouldBeFalse()
         resolvedAsInvalid.shouldBeFalse()
         addedComment shouldBe CommentOptions("duplicate-tech", "MC-297")
     }
@@ -733,7 +748,7 @@ class CrashModuleTest : StringSpec({
     "should resolve as dupe when attached crash is in configured list" {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
-        var addedAttachement = false
+        var addedAttachment = false
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
@@ -756,14 +771,17 @@ class CrashModuleTest : StringSpec({
             resolveAsDuplicate = { resolvedAsDupe = true },
             resolveAsInvalid = { resolvedAsInvalid = true },
             addComment = { addedComment = it },
-            addAttachment = { addedAttachement = true }
+            addAttachment = { _, cleanupCallback ->
+                addedAttachment = true
+                cleanupCallback()
+            }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeTrue()
-        addedAttachement.shouldBeFalse()
+        addedAttachment.shouldBeFalse()
         resolvedAsInvalid.shouldBeFalse()
         addedComment shouldBe CommentOptions("duplicate-tech", "MC-297")
     }
@@ -771,7 +789,7 @@ class CrashModuleTest : StringSpec({
     "should resolve as dupe when the configured crash is a java crash" {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
-        var addedAttachement = false
+        var addedAttachment = false
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
@@ -790,14 +808,17 @@ class CrashModuleTest : StringSpec({
             resolveAsDuplicate = { resolvedAsDupe = true },
             resolveAsInvalid = { resolvedAsInvalid = true },
             addComment = { addedComment = it },
-            addAttachment = { addedAttachement = true }
+            addAttachment = { _, cleanupCallback ->
+                addedAttachment = true
+                cleanupCallback()
+            }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeTrue()
-        addedAttachement.shouldBeFalse()
+        addedAttachment.shouldBeFalse()
         resolvedAsInvalid.shouldBeFalse()
         addedComment shouldBe CommentOptions("duplicate-tech", "MC-32606")
     }
@@ -805,7 +826,7 @@ class CrashModuleTest : StringSpec({
     "should add attachment when deobfuscated" {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
-        var addedAttachement = false
+        var addedAttachment = false
 
         val module = CrashModule(
             listOf("txt"),
@@ -822,21 +843,24 @@ class CrashModuleTest : StringSpec({
             priority = NoPriority,
             resolveAsDuplicate = { resolvedAsDupe = true },
             resolveAsInvalid = { resolvedAsInvalid = true },
-            addAttachment = { addedAttachement = true }
+            addAttachment = { _, cleanupCallback ->
+                addedAttachment = true
+                cleanupCallback()
+            }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeLeft(OperationNotNeededModuleResponse)
         resolvedAsDupe.shouldBeFalse()
-        addedAttachement.shouldBeTrue()
+        addedAttachment.shouldBeTrue()
         resolvedAsInvalid.shouldBeFalse()
     }
 
     "should resolve as dupe when the configured crash uses regex" {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
-        var addedAttachement = false
+        var addedAttachment = false
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
@@ -855,14 +879,17 @@ class CrashModuleTest : StringSpec({
             resolveAsDuplicate = { resolvedAsDupe = true },
             resolveAsInvalid = { resolvedAsInvalid = true },
             addComment = { addedComment = it },
-            addAttachment = { addedAttachement = true }
+            addAttachment = { _, cleanupCallback ->
+                addedAttachment = true
+                cleanupCallback()
+            }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeTrue()
-        addedAttachement.shouldBeFalse()
+        addedAttachment.shouldBeFalse()
         resolvedAsInvalid.shouldBeFalse()
         addedComment shouldBe CommentOptions("duplicate-tech", "MC-32606")
     }
@@ -870,7 +897,7 @@ class CrashModuleTest : StringSpec({
     "should link to configured ticket when resolving as dupe" {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
-        var addedAttachement = false
+        var addedAttachment = false
         var isLinked = false
 
         val module = CrashModule(
@@ -893,14 +920,17 @@ class CrashModuleTest : StringSpec({
                 key.shouldBe("MC-297")
                 isLinked = true
             },
-            addAttachment = { addedAttachement = true }
+            addAttachment = { _, cleanupCallback ->
+                addedAttachment = true
+                cleanupCallback()
+            }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeTrue()
-        addedAttachement.shouldBeFalse()
+        addedAttachment.shouldBeFalse()
         resolvedAsInvalid.shouldBeFalse()
         isLinked.shouldBeTrue()
     }
@@ -908,7 +938,7 @@ class CrashModuleTest : StringSpec({
     "should prefer crash that is not modded, if modded crash appears first" {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
-        var addedAttachement = false
+        var addedAttachment = false
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
@@ -936,14 +966,17 @@ class CrashModuleTest : StringSpec({
             resolveAsDuplicate = { resolvedAsDupe = true },
             resolveAsInvalid = { resolvedAsInvalid = true },
             addComment = { addedComment = it },
-            addAttachment = { addedAttachement = true }
+            addAttachment = { _, cleanupCallback ->
+                addedAttachment = true
+                cleanupCallback()
+            }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeTrue()
-        addedAttachement.shouldBeFalse()
+        addedAttachment.shouldBeFalse()
         resolvedAsInvalid.shouldBeFalse()
         addedComment shouldBe CommentOptions("duplicate-tech", "MC-297")
     }
@@ -951,7 +984,7 @@ class CrashModuleTest : StringSpec({
     "should prefer crash that is not modded, if duped crash appears first" {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
-        var addedAttachement = false
+        var addedAttachment = false
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
@@ -979,14 +1012,17 @@ class CrashModuleTest : StringSpec({
             resolveAsDuplicate = { resolvedAsDupe = true },
             resolveAsInvalid = { resolvedAsInvalid = true },
             addComment = { addedComment = it },
-            addAttachment = { addedAttachement = true }
+            addAttachment = { _, cleanupCallback ->
+                addedAttachment = true
+                cleanupCallback()
+            }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeTrue()
-        addedAttachement.shouldBeFalse()
+        addedAttachment.shouldBeFalse()
         resolvedAsInvalid.shouldBeFalse()
         addedComment shouldBe CommentOptions("duplicate-tech", "MC-297")
     }
@@ -994,7 +1030,7 @@ class CrashModuleTest : StringSpec({
     "should prefer more recent crash, if less recent crash appears first " {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
-        var addedAttachement = false
+        var addedAttachment = false
         var isLinked = false
 
         val module = CrashModule(
@@ -1031,14 +1067,17 @@ class CrashModuleTest : StringSpec({
                 isLinked = true
             },
             addComment = { Unit.right() },
-            addAttachment = { addedAttachement = true }
+            addAttachment = { _, cleanupCallback ->
+                addedAttachment = true
+                cleanupCallback()
+            }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeTrue()
-        addedAttachement.shouldBeFalse()
+        addedAttachment.shouldBeFalse()
         resolvedAsInvalid.shouldBeFalse()
         isLinked.shouldBeTrue()
     }
@@ -1046,7 +1085,7 @@ class CrashModuleTest : StringSpec({
     "should prefer more recent crash, if more recent crash appears first " {
         var resolvedAsDupe = false
         var resolvedAsInvalid = false
-        var addedAttachement = false
+        var addedAttachment = false
         var isLinked = false
 
         val module = CrashModule(
@@ -1083,14 +1122,17 @@ class CrashModuleTest : StringSpec({
                 isLinked = true
             },
             addComment = { Unit.right() },
-            addAttachment = { addedAttachement = true }
+            addAttachment = { _, cleanupCallback ->
+                addedAttachment = true
+                cleanupCallback()
+            }
         )
 
         val result = module(issue, A_SECOND_AGO)
 
         result.shouldBeRight(ModuleResponse)
         resolvedAsDupe.shouldBeTrue()
-        addedAttachement.shouldBeFalse()
+        addedAttachment.shouldBeFalse()
         resolvedAsInvalid.shouldBeFalse()
         isLinked.shouldBeTrue()
     }

--- a/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
@@ -124,7 +124,7 @@ fun mockIssue(
     addRawRestrictedComment: (body: String, restrictions: String) -> Unit = { _, _ -> },
     markAsFixedInASpecificVersion: (version: String) -> Unit = { },
     changeReporter: (reporter: String) -> Unit = { },
-    addAttachment: (file: File) -> Unit = { }
+    addAttachment: (file: File, cleanupCallback: () -> Unit) -> Unit = { _, cleanupCallback -> cleanupCallback() }
 ) = Issue(
     key,
     summary,


### PR DESCRIPTION
## Purpose
Follow-up for #641

Delete the temporary folder containing the crash report once the uploaded finished.

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
