### PR TITLE
ReopenAwaitingModule: Ignore comments from helpers

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -259,6 +259,7 @@ arisa:
       resolutions:
         - Awaiting Response
       blacklistedRoles:
+        - helper
         - staff
         - global-moderators
       blacklistedVisibilities:


### PR DESCRIPTION
## Purpose
Helpers usually don't want a ticket to be reopened when they post a comment on an AR tickets. Thus they should probably be ignored.

## Approach
Add `helper` to `blacklistedRoles` config

## Future work
N/A