### PR TITLE
Remove 1.0.8 from piracy module

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -148,7 +148,6 @@ arisa:
         - 'Launcher: 3.1.0'
         - 'Launcher: 3.1.1'
         - 'Launcher: 3.1.4'
-        - 1.0.8
         - uuid sessionId
         - auth_access_token
         - keicraft


### PR DESCRIPTION
## Purpose
This causes false positives due to its vague nature as a number, see https://bugs.mojang.com/browse/MC-225612 (private, see environment).