### PR TITLE
Use JiraClient's HttpClient for opening attachment stream

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
@@ -27,7 +27,10 @@ import net.rcarz.jiraclient.User
 import net.rcarz.jiraclient.Version
 import net.sf.json.JSONObject
 import org.apache.http.HttpStatus
+import org.apache.http.client.methods.HttpGet
 import java.io.File
+import java.io.IOException
+import java.io.InputStream
 import java.net.URI
 import java.time.Instant
 import java.time.temporal.ChronoField
@@ -234,6 +237,20 @@ private fun applyFluentUpdate(edit: Issue.FluentUpdate) = runBlocking {
 private fun applyFluentTransition(update: Issue.FluentTransition, transitionName: String) = runBlocking {
     Either.catch {
         update.execute(transitionName)
+    }
+}
+
+fun openAttachmentStream(jiraClient: JiraClient, attachment: Attachment): InputStream {
+    val httpClient = jiraClient.restClient.httpClient
+    val request = HttpGet(attachment.contentUrl)
+
+    return runBlocking(Dispatchers.IO) {
+        val response = httpClient.execute(request)
+        val statusCode = response.statusLine.statusCode
+        if (statusCode != HttpStatus.SC_OK) {
+            throw IOException("Request for attachment ${attachment.id} content failed with status code $statusCode")
+        }
+        response.entity.content
     }
 }
 

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
@@ -21,11 +21,9 @@ import io.github.mojira.arisa.infrastructure.HelperMessageService
 import io.github.mojira.arisa.infrastructure.IssueUpdateContextCache
 import io.github.mojira.arisa.infrastructure.config.Arisa
 import io.github.mojira.arisa.infrastructure.escapeIssueFunction
-import io.github.mojira.arisa.modules.openHttpGetInputStream
 import net.rcarz.jiraclient.JiraClient
 import net.rcarz.jiraclient.JiraException
 import net.sf.json.JSONObject
-import java.net.URI
 import java.text.SimpleDateFormat
 import java.time.Instant
 import net.rcarz.jiraclient.Attachment as JiraAttachment
@@ -44,7 +42,7 @@ fun JiraAttachment.toDomain(jiraClient: JiraClient, issue: JiraIssue) = Attachme
     getCreationDate(issue, id, issue.createdDate.toInstant()),
     mimeType,
     ::deleteAttachment.partially1(issue.getUpdateContext(jiraClient)).partially1(this),
-    { openHttpGetInputStream(URI(contentUrl)) },
+    { openAttachmentStream(jiraClient, this) },
     this::download,
     author?.toDomain(jiraClient)
 )

--- a/src/main/kotlin/io/github/mojira/arisa/modules/ThumbnailModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ThumbnailModule.kt
@@ -5,7 +5,6 @@ import arrow.core.extensions.fx
 import io.github.mojira.arisa.domain.Issue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 import org.apache.commons.imaging.ImageReadException
 import org.apache.commons.imaging.Imaging
 import org.slf4j.Logger
@@ -82,19 +81,19 @@ class ThumbnailModule(
             }
             matchIndex++
 
-            val options = runBlocking { getImageOptions(issue, imageName) }
+            val options = getImageOptions(issue, imageName)
             if (options != null) "$imageName|$options" else imageName
         }
     }
 
-    private suspend fun getImageOptions(issue: Issue, imageName: String): String? {
+    private fun getImageOptions(issue: Issue, imageName: String): String? {
         // For now only support embedded attached images (but not embedded with URL)
         val attachment = issue.attachments.find { it.name == imageName }
         if (attachment == null) {
             log.info("Did not find attachment with name '$imageName' for issue ${issue.key}")
             return null
         }
-        return withContext(Dispatchers.IO) {
+        return runBlocking(Dispatchers.IO) {
             attachment.openContentStream().use {
                 try {
                     /*


### PR DESCRIPTION
## Purpose
The previous solution of using JDK's Http Client did not work for private issues and comments because it did not have the necessary session token.

## Approach
Use JiraClient's Apache HttpClient instance for requesting the attachment content stream, since that has the necessary token set.

## Future work

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [x] Tested in MCTEST-xxx
