### PR TITLE
Revert to using HttpURLConnection for language API call

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/LanguageDetectionApi.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/LanguageDetectionApi.kt
@@ -2,12 +2,14 @@ package io.github.mojira.arisa.infrastructure
 
 import arrow.core.Either
 import com.beust.klaxon.Klaxon
-import io.github.mojira.arisa.modules.openHttpPostInputStream
-import java.net.URI
+import org.apache.http.HttpStatus
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URL
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets.UTF_8
 
-const val BASE_URL = "https://api.dandelion.eu/datatxt/li/v1/"
+private const val BASE_URL = "https://api.dandelion.eu/datatxt/li/v1/"
 
 data class Response(val detectedLangs: List<LangDetection>)
 data class LangDetection(val lang: String, val confidence: Double)
@@ -17,9 +19,19 @@ fun getLanguage(token: String?, text: String): Either<Error, Map<String, Double>
     if (token == null) return Either.left(Error("Dandelion token is undefined"))
 
     val request = "token=" + URLEncoder.encode(token, UTF_8) + "&text=" + URLEncoder.encode(text, UTF_8)
-    openHttpPostInputStream(URI(BASE_URL), request).use { inputStream ->
-        val result = Klaxon().parse<Response>(inputStream)
-            ?: return Either.left(Error("Couldn't deserialize response"))
+    with(URL(BASE_URL).openConnection() as HttpURLConnection) {
+        requestMethod = "POST"
+        doOutput = true
+
+        val wr = OutputStreamWriter(outputStream, UTF_8)
+        wr.write(request)
+        wr.flush()
+
+        if (responseCode != HttpStatus.SC_OK) {
+            return Either.left(Error("$responseCode from translation API"))
+        }
+
+        val result = Klaxon().parse<Response>(inputStream) ?: return Either.left(Error("Couldn't deserialize response"))
 
         return Either.right(result.detectedLangs.associate { it.lang to it.confidence })
     }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/Helpers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/Helpers.kt
@@ -253,14 +253,6 @@ fun openHttpGetInputStream(uri: URI): InputStream {
     return openHttpInputStream(request)
 }
 
-fun openHttpPostInputStream(uri: URI, body: String): InputStream {
-    val request = HttpRequest.newBuilder()
-        .uri(uri)
-        .POST(HttpRequest.BodyPublishers.ofString(body))
-        .build()
-    return openHttpInputStream(request)
-}
-
 private const val HTTP_STATUS_OK = 200
 
 fun openHttpInputStream(request: HttpRequest): InputStream {


### PR DESCRIPTION
## Purpose
Reverts the LanguageDetectionApi.kt changes done by 02bca459eaf707efd6819ca727c57c0e9ebac2cf. For some reason the requests did not work properly and the server complained about missing token value.

E.g. when using an invalid token the error response was:
```
{"error":true,"status":403,"code":"error.notAllowed","message":"token param is missing","data":{"parameter":"token"}}
```

Now with the reverted changes the error response is:
```
{"error":true,"status":401,"code":"error.invalidParameter","message":"no such token 'abcdef'","data":{"parameter":"token"}}
```

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
