### PR TITLE
Improve language detection API logging

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/LanguageDetectionApi.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/LanguageDetectionApi.kt
@@ -2,12 +2,14 @@ package io.github.mojira.arisa.infrastructure
 
 import arrow.core.Either
 import com.beust.klaxon.Klaxon
-import io.github.mojira.arisa.modules.openHttpPostInputStream
-import java.net.URI
+import org.apache.http.HttpStatus
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URL
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets.UTF_8
 
-const val BASE_URL = "https://api.dandelion.eu/datatxt/li/v1/"
+private const val BASE_URL = "https://api.dandelion.eu/datatxt/li/v1/"
 
 data class Response(val detectedLangs: List<LangDetection>)
 data class LangDetection(val lang: String, val confidence: Double)
@@ -17,9 +19,19 @@ fun getLanguage(token: String?, text: String): Either<Error, Map<String, Double>
     if (token == null) return Either.left(Error("Dandelion token is undefined"))
 
     val request = "token=" + URLEncoder.encode(token, UTF_8) + "&text=" + URLEncoder.encode(text, UTF_8)
-    openHttpPostInputStream(URI(BASE_URL), request).use { inputStream ->
-        val result = Klaxon().parse<Response>(inputStream)
-            ?: return Either.left(Error("Couldn't deserialize response"))
+    with(URL(BASE_URL).openConnection() as HttpURLConnection) {
+        requestMethod = "POST"
+        doOutput = true
+
+        val wr = OutputStreamWriter(outputStream, UTF_8)
+        wr.write(request)
+        wr.flush()
+
+        if (responseCode != HttpStatus.SC_OK) {
+            return Either.left(Error("$responseCode from translation API"))
+        }
+
+        val result = Klaxon().parse<Response>(inputStream) ?: return Either.left(Error("Couldn't deserialize response"))
 
         return Either.right(result.detectedLangs.associate { it.lang to it.confidence })
     }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/Helpers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/Helpers.kt
@@ -253,14 +253,6 @@ fun openHttpGetInputStream(uri: URI): InputStream {
     return openHttpInputStream(request)
 }
 
-fun openHttpPostInputStream(uri: URI, body: String): InputStream {
-    val request = HttpRequest.newBuilder()
-        .uri(uri)
-        .POST(HttpRequest.BodyPublishers.ofString(body))
-        .build()
-    return openHttpInputStream(request)
-}
-
 private const val HTTP_STATUS_OK = 200
 
 fun openHttpInputStream(request: HttpRequest): InputStream {

--- a/src/main/kotlin/io/github/mojira/arisa/modules/LanguageModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/LanguageModule.kt
@@ -9,12 +9,12 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.Instant
 
-const val MINIMUM_PERCENTAGE = 0.7
+private const val MINIMUM_PERCENTAGE = 0.7
 
 class LanguageModule(
     private val allowedLanguages: List<String> = listOf("en"),
     private val lengthThreshold: Int = 0,
-    private val getLanguage: (String) -> Either<Any, Map<String, Double>>
+    private val getLanguage: (String) -> Map<String, Double>
 ) : Module {
     val log: Logger = LoggerFactory.getLogger("LanguageModule")
 
@@ -61,16 +61,11 @@ class LanguageModule(
         this.replace("""(?:https?://|www\.)[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)+\S*""".toRegex(), "")
 
     private fun getDetectedLanguage(
-        getLanguage: (String) -> Either<Any, Map<String, Double>>,
+        getLanguage: (String) -> Map<String, Double>,
         text: String
     ): String? {
         val detected = getLanguage(text)
-        return detected.fold(
-            { null },
-            { languages ->
-                languages.filter { it.value > MINIMUM_PERCENTAGE }.maxByOrNull { it.value }?.key
-            }
-        )
+        return detected.filter { it.value > MINIMUM_PERCENTAGE }.maxByOrNull { it.value }?.key
     }
 
     private fun assertExceedLengthThreshold(text: String) = when {

--- a/src/main/kotlin/io/github/mojira/arisa/modules/ThumbnailModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ThumbnailModule.kt
@@ -20,7 +20,7 @@ class ThumbnailModule(
     private val maxImagesCount: Int
 ) : Module {
 
-    private val log: Logger = LoggerFactory.getLogger(ThumbnailModule::class.java)
+    private val log: Logger = LoggerFactory.getLogger("ThumbnailModule")
 
     override fun invoke(issue: Issue, lastRun: Instant): Either<ModuleError, ModuleResponse> = with(issue) {
         Either.fx {

--- a/src/test/kotlin/io/github/mojira/arisa/modules/LanguageModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/LanguageModuleTest.kt
@@ -1,6 +1,5 @@
 package io.github.mojira.arisa.modules
 
-import arrow.core.right
 import io.github.mojira.arisa.utils.RIGHT_NOW
 import io.github.mojira.arisa.utils.mockIssue
 import io.kotest.assertions.arrow.either.shouldBeLeft
@@ -14,7 +13,7 @@ private val A_SECOND_AGO = RIGHT_NOW.minusSeconds(1)
 class LanguageModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse when ticket was created before the last run" {
         val module = LanguageModule(
-            getLanguage = { mapOf("de" to 1.0).right() }
+            getLanguage = { mapOf("de" to 1.0) }
         )
         val issue = mockIssue(
             created = A_SECOND_AGO,
@@ -29,7 +28,7 @@ class LanguageModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when there is no description, summary or environment" {
         val module = LanguageModule(
-            getLanguage = { emptyMap<String, Double>().right() }
+            getLanguage = { emptyMap() }
         )
         val issue = mockIssue(
             created = RIGHT_NOW
@@ -42,7 +41,7 @@ class LanguageModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when description, summary and environment are empty" {
         val module = LanguageModule(
-            getLanguage = { emptyMap<String, Double>().right() }
+            getLanguage = { emptyMap() }
         )
         val issue = mockIssue(
             created = RIGHT_NOW,
@@ -57,7 +56,7 @@ class LanguageModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when no language matches" {
         val module = LanguageModule(
-            getLanguage = { emptyMap<String, Double>().right() }
+            getLanguage = { emptyMap() }
         )
         val issue = mockIssue(
             created = RIGHT_NOW,
@@ -73,7 +72,7 @@ class LanguageModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse when the combined text does not exceed the threshold" {
         val module = LanguageModule(
             lengthThreshold = 100,
-            getLanguage = { mapOf("de" to 1.0).right() }
+            getLanguage = { mapOf("de" to 1.0) }
         )
         val issue = mockIssue(
             created = RIGHT_NOW,
@@ -89,7 +88,7 @@ class LanguageModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse when the combined text only contains a URL" {
         val module = LanguageModule(
             lengthThreshold = 2,
-            getLanguage = { mapOf("de" to 1.0).right() }
+            getLanguage = { mapOf("de" to 1.0) }
         )
         val issue = mockIssue(
             created = RIGHT_NOW,
@@ -106,7 +105,7 @@ class LanguageModuleTest : StringSpec({
         var commentLanguage = ""
         var resolved = false
         val module = LanguageModule(
-            getLanguage = { mapOf("de" to 1.0).right() }
+            getLanguage = { mapOf("de" to 1.0) }
         )
         val issue = mockIssue(
             created = RIGHT_NOW,
@@ -125,7 +124,7 @@ class LanguageModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse if ticket is in English" {
         val module = LanguageModule(
-            getLanguage = { mapOf("en" to 1.0).right() }
+            getLanguage = { mapOf("en" to 1.0) }
         )
         val issue = mockIssue(
             created = RIGHT_NOW,
@@ -140,7 +139,7 @@ class LanguageModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse if ticket is mostly in English" {
         val module = LanguageModule(
-            getLanguage = { mapOf("en" to 0.8).right() }
+            getLanguage = { mapOf("en" to 0.8) }
         )
         val issue = mockIssue(
             created = RIGHT_NOW,
@@ -157,7 +156,7 @@ class LanguageModuleTest : StringSpec({
         var commentLanguage = ""
         var resolved = false
         val module = LanguageModule(
-            getLanguage = { mapOf("en" to 0.6, "de" to 0.8).right() }
+            getLanguage = { mapOf("en" to 0.6, "de" to 0.8) }
         )
         val issue = mockIssue(
             created = RIGHT_NOW,
@@ -178,7 +177,7 @@ class LanguageModuleTest : StringSpec({
         var isApiExecuted = false
 
         val module = LanguageModule(
-            getLanguage = { it shouldBe "Summary. Description."; isApiExecuted = true; mapOf("en" to 1.0).right() }
+            getLanguage = { it shouldBe "Summary. Description."; isApiExecuted = true; mapOf("en" to 1.0) }
         )
         val issue = mockIssue(
             created = RIGHT_NOW,
@@ -196,7 +195,7 @@ class LanguageModuleTest : StringSpec({
         var isApiExecuted = false
 
         val module = LanguageModule(
-            getLanguage = { it shouldBe "Summary. Description."; isApiExecuted = true; mapOf("en" to 1.0).right() }
+            getLanguage = { it shouldBe "Summary. Description."; isApiExecuted = true; mapOf("en" to 1.0) }
         )
         val issue = mockIssue(
             created = RIGHT_NOW,
@@ -214,7 +213,7 @@ class LanguageModuleTest : StringSpec({
         var isApiExecuted = false
 
         val module = LanguageModule(
-            getLanguage = { it shouldBe "Summary."; isApiExecuted = true; mapOf("en" to 1.0).right() }
+            getLanguage = { it shouldBe "Summary."; isApiExecuted = true; mapOf("en" to 1.0) }
         )
         val issue = mockIssue(
             created = RIGHT_NOW,
@@ -231,7 +230,7 @@ class LanguageModuleTest : StringSpec({
         var isApiExecuted = false
 
         val module = LanguageModule(
-            getLanguage = { it shouldBe "Description."; isApiExecuted = true; mapOf("en" to 1.0).right() }
+            getLanguage = { it shouldBe "Description."; isApiExecuted = true; mapOf("en" to 1.0) }
         )
         val issue = mockIssue(
             created = RIGHT_NOW,
@@ -251,7 +250,7 @@ class LanguageModuleTest : StringSpec({
             getLanguage = {
                 it shouldBe "pillager doesn’t aim child villager.\\n\\nReproduce:\\n\\n1.Summon pillager."
                 isApiExecuted = true
-                mapOf("en" to 1.0).right()
+                mapOf("en" to 1.0)
             }
         )
         val issue = mockIssue(
@@ -273,7 +272,7 @@ class LanguageModuleTest : StringSpec({
             getLanguage = {
                 it shouldBe "pillager doesn’t aim child villager.\\n\\nReproduce:\\n\\n1.Summon pillager."
                 isApiExecuted = true
-                mapOf("en" to 1.0).right()
+                mapOf("en" to 1.0)
             }
         )
         val issue = mockIssue(
@@ -290,7 +289,7 @@ class LanguageModuleTest : StringSpec({
 
     "should return OperationNotNeeded if ticket is private" {
         val module = LanguageModule(
-            getLanguage = { mapOf("en" to 0.6, "de" to 0.8).right() }
+            getLanguage = { mapOf("en" to 0.6, "de" to 0.8) }
         )
         val issue = mockIssue(
             securityLevel = "private",
@@ -305,7 +304,7 @@ class LanguageModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse if ticket contains only a crash report" {
         val module = LanguageModule(
-            getLanguage = { mapOf("en" to 1.0).right() }
+            getLanguage = { mapOf("en" to 1.0) }
         )
         val issue = mockIssue(
             created = RIGHT_NOW,


### PR DESCRIPTION
## Purpose
Improve logging of language API requests.

## Approach
Depends on #649

When logging when calling the language API:
- Log quota information, see https://dandelion.eu/docs/api/#api-response-headers
- Log error response body
:warning: This might reveal sensitive information; for example when the token is invalid it looks like the reponse contains the token. Maybe that is not desired?

Also changes the `LanguageDetectionApi.kt` function to throw exceptions instead of using `Either`. Previously the language module would siltently ignore `Either.left`, without logging the exception. Additionally switches from `Error` to `IllegalArgumentException` / `IOException`; `Error` is usually only used for really critical exceptions, see [documentation](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Error.html).

Please note that have only tested this with invalid tokens yet because I don't have a valid language API token.

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
