### PR TITLE
Add link to language API site to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ This project depends on the following projects, thanks to every developer who ma
 - [mc-crash-lib](https://github.com/urielsalis/mc-crash-lib)
 - [Apache Commons Imaging](https://commons.apache.org/proper/commons-imaging/)
 
+Language detection [powered by Dandelion API](https://dandelion.eu/).
+
 ## Contributing
 
 You're very welcome to contribute to this project! Please note that this project uses [ktlint](https://github.com/pinterest/ktlint) to ensure consistent code.


### PR DESCRIPTION
## Purpose
See https://dandelion.eu/accounts/tos/, "Attribution"
> When using Dandelion, or content generated via a Dandelion's API, for any purpose with a Free Plan, you agree to:
> Provide a clickable hyperlink to http://dandelion.eu/ with the text "Powered by Dandelion API" within your website or application
