### PR TITLE
Improve helper messages fetching

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/ArisaMain.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ArisaMain.kt
@@ -23,11 +23,11 @@ import java.util.concurrent.TimeUnit
 
 val log: Logger = LoggerFactory.getLogger("Arisa")
 
-const val TIME_MINUTES = 5L
+private const val TIME_MINUTES = 5L
 const val MAX_RESULTS = 50
-const val MINUTES_FOR_THROTTLED_LOG = 30L
+private const val MINUTES_FOR_THROTTLED_LOG = 30L
 lateinit var jiraClient: JiraClient
-var throttledLog = 0L
+private var throttledLog = 0L
 
 @Suppress("LongMethod")
 fun main() {


### PR DESCRIPTION
## Purpose
Improve fetching, parsing and storing of helper messages. Most importantly:
- Fix the following logic being wrong, writing the helper messages before they have been deserialized:
https://github.com/mojira/arisa-kt/blob/02bca459eaf707efd6819ca727c57c0e9ebac2cf/src/main/kotlin/io/github/mojira/arisa/infrastructure/HelperMessages.kt#L135-L136
- Fix no exceptions being logged / start not failing without helper messages; previously `updateHelperMessages(...)` returned an `Either<Error, ...>` but the caller never inspected the result. Now instead throw exceptions instead of using `Either`.

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
