### PR TITLE
Disable LanguageModule temporarily

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -366,6 +366,7 @@ arisa:
       tag: MEQS_KEEP_PRIVATE
 
     language:
+      enabled: false
       resolutions:
         - Unresolved
       excludedStatuses:


### PR DESCRIPTION
## Purpose
The LanguageModule is currently causing significant connection issues and causes Arisa to stop working properly.

## Approach
Disable the LanguageModule temporarily, so that at least the other modules work for the time being.

## Future work
Investigate what actually causes the issue and reenable LanguageModule.

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
