### PR TITLE
Update mc-crash-lib to maven central version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
 
     implementation("com.uchuhimo", "konf", "0.22.1")
     implementation("com.github.rcarz", "jira-client", "master-SNAPSHOT")
-    implementation("com.urielsalis", "mc-crash-lib", "1.0.5")
+    implementation("com.urielsalis", "mc-crash-lib", "2.0.1")
     implementation("com.github.napstr", "logback-discord-appender", "1.0.0")
     implementation("org.slf4j", "slf4j-api", "1.7.25")
     implementation("ch.qos.logback", "logback-classic", logBackVersion)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
 
     implementation("com.uchuhimo", "konf", "0.22.1")
     implementation("com.github.rcarz", "jira-client", "master-SNAPSHOT")
-    implementation("me.urielsalis", "mc-crash-lib", "1.0.4")
+    implementation("com.urielsalis", "mc-crash-lib", "1.0.5")
     implementation("com.github.napstr", "logback-discord-appender", "1.0.0")
     implementation("org.slf4j", "slf4j-api", "1.7.25")
     implementation("ch.qos.logback", "logback-classic", logBackVersion)

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import arrow.core.left
 import arrow.syntax.function.partially1
 import com.uchuhimo.konf.Config
+import com.urielsalis.mccrashlib.CrashReader
 import io.github.mojira.arisa.domain.Issue
 import io.github.mojira.arisa.infrastructure.config.Arisa
 import io.github.mojira.arisa.infrastructure.config.Arisa.Credentials
@@ -39,11 +40,10 @@ import io.github.mojira.arisa.modules.ReopenAwaitingModule
 import io.github.mojira.arisa.modules.ReplaceTextModule
 import io.github.mojira.arisa.modules.ResolveTrashModule
 import io.github.mojira.arisa.modules.RevokeConfirmationModule
+import io.github.mojira.arisa.modules.ThumbnailModule
 import io.github.mojira.arisa.modules.TransferLinksModule
 import io.github.mojira.arisa.modules.TransferVersionsModule
 import io.github.mojira.arisa.modules.UpdateLinkedModule
-import io.github.mojira.arisa.modules.ThumbnailModule
-import me.urielsalis.mccrashlib.CrashReader
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/AttachmentUtils.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/AttachmentUtils.kt
@@ -1,11 +1,11 @@
 package io.github.mojira.arisa.infrastructure
 
 import arrow.core.Either
+import com.urielsalis.mccrashlib.Crash
+import com.urielsalis.mccrashlib.CrashReader
+import com.urielsalis.mccrashlib.parser.ParserError
 import io.github.mojira.arisa.domain.Attachment
 import io.github.mojira.arisa.domain.Issue
-import me.urielsalis.mccrashlib.Crash
-import me.urielsalis.mccrashlib.CrashReader
-import me.urielsalis.mccrashlib.parser.ParserError
 import java.io.File
 import java.time.Instant
 

--- a/src/main/kotlin/io/github/mojira/arisa/modules/CrashModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/CrashModule.kt
@@ -6,13 +6,13 @@ import arrow.core.firstOrNone
 import arrow.core.left
 import arrow.core.right
 import arrow.syntax.function.partially2
+import com.urielsalis.mccrashlib.Crash
+import com.urielsalis.mccrashlib.CrashReader
+import com.urielsalis.mccrashlib.deobfuscator.getSafeChildPath
 import io.github.mojira.arisa.domain.CommentOptions
 import io.github.mojira.arisa.domain.Issue
 import io.github.mojira.arisa.infrastructure.AttachmentUtils
 import io.github.mojira.arisa.infrastructure.config.CrashDupeConfig
-import me.urielsalis.mccrashlib.Crash
-import me.urielsalis.mccrashlib.CrashReader
-import me.urielsalis.mccrashlib.deobfuscator.getSafeChildPath
 import java.nio.file.Files
 import java.time.Instant
 

--- a/src/main/kotlin/io/github/mojira/arisa/modules/CrashModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/CrashModule.kt
@@ -12,8 +12,7 @@ import io.github.mojira.arisa.infrastructure.AttachmentUtils
 import io.github.mojira.arisa.infrastructure.config.CrashDupeConfig
 import me.urielsalis.mccrashlib.Crash
 import me.urielsalis.mccrashlib.CrashReader
-import me.urielsalis.mccrashlib.deobfuscator.isZipSlip
-import java.io.File
+import me.urielsalis.mccrashlib.deobfuscator.getSafeChildPath
 import java.nio.file.Files
 import java.time.Instant
 
@@ -66,12 +65,12 @@ class CrashModule(
             }
         minecraftCrashesWithDeobf.forEach {
             val tempDir = Files.createTempDirectory("arisa-crash-upload").toFile()
-            if (isZipSlip(getDeobfName(it.first), tempDir)) {
+            val safePath = getSafeChildPath(tempDir, getDeobfName(it.first))
+            if (safePath == null) {
                 tempDir.delete()
             } else {
-                val file = File(tempDir, getDeobfName(it.first))
-                file.writeText(it.second!!)
-                issue.addAttachment(file) {
+                safePath.writeText(it.second!!)
+                issue.addAttachment(safePath) {
                     // Once uploaded, delete the temp directory containing the crash report
                     tempDir.deleteRecursively()
                 }

--- a/src/test/kotlin/io/github/mojira/arisa/modules/CrashModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/CrashModuleTest.kt
@@ -1,6 +1,7 @@
 package io.github.mojira.arisa.modules
 
 import arrow.core.right
+import com.urielsalis.mccrashlib.CrashReader
 import io.github.mojira.arisa.domain.CommentOptions
 import io.github.mojira.arisa.infrastructure.config.CrashDupeConfig
 import io.github.mojira.arisa.utils.mockAttachment
@@ -11,7 +12,6 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
-import me.urielsalis.mccrashlib.CrashReader
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 


### PR DESCRIPTION
## Purpose
Now that mc-crash-lib is in maven central, use that version :D
## Approach

## Future work

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [wiki](https://github.com/mojira/arisa-kt/wiki)
- [ ] Tested in MCTEST-xxx
