### PR TITLE
Make PrivacyModule detect sensitive launcher files

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -176,6 +176,10 @@ arisa:
       allowedEmailRegex:
         - '^(mailer-daemon|postmaster|nobody|noreply|no-reply|hostmaster|usenet|news|webmaster|www|abuse|noc|security|info|support|uucp|ftp|news|admin|root)@.*'
         - '.*@(mojang.com|microsoft.com|minecraft.net|zendesk.com)$'
+      sensitiveFileNames:
+        - launcher_accounts.json
+        - launcher_msa_credentials.json
+        - launcher_profiles.json
 
     removeTriagedMeqs:
       resolutions:

--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -222,6 +222,8 @@ Hides privacy information like Email addresses in tickets or comments.
 - The ticket is not set to private.
 #### For Setting Tickets to Private
 - Any of the fields and/or text attachments added after last run contains session ID or Email.
+- Or any of the attachments has a name specified by `sensitiveFileNames` in the [config](../config/config.yml)
+  (defaults to empty list)
 #### For Restricting Comments to `staff`
 - The comment was added after last run.
 - The comment is not restricted.

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -211,7 +211,8 @@ class ModuleRegistry(private val config: Config) {
             PrivacyModule(
                 config[Modules.Privacy.message],
                 config[Modules.Privacy.commentNote],
-                config[Modules.Privacy.allowedEmailRegex].map(String::toRegex)
+                config[Modules.Privacy.allowedEmailRegex].map(String::toRegex),
+                config[Modules.Privacy.sensitiveFileNames]
             )
         )
 

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
@@ -163,6 +163,10 @@ object Arisa : ConfigSpec() {
                 default = emptyList(),
                 description = "List of regex for allowed emails"
             )
+            val sensitiveFileNames by optional<List<String>>(
+                default = emptyList(),
+                description = "Names of attachment files containing sensitive information"
+            )
         }
 
         object Language : ModuleConfigSpec() {


### PR DESCRIPTION
## Purpose
Fix #673

## Approach
Add a `sensitiveFileNames` `List<String>` config value and specify the launcher file names in the config.

## Future work
See #663

#### Checklist
- [x] Included tests
- [x] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
