### PR TITLE
Use threshold for logging language API quota warning

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -377,7 +377,7 @@ arisa:
         - Unresolved
       excludedStatuses:
         - Postponed
-      apiQuotaWarningThreshold: 15.0
+      apiQuotaWarningThreshold: 10.0
       allowedLanguages:
         - en
         - nl

--- a/config/config.yml
+++ b/config/config.yml
@@ -373,6 +373,7 @@ arisa:
         - Unresolved
       excludedStatuses:
         - Postponed
+      apiQuotaWarningThreshold: 15.0
       allowedLanguages:
         - en
         - nl

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleRegistry.kt
@@ -2,15 +2,14 @@ package io.github.mojira.arisa
 
 import arrow.core.Either
 import arrow.core.left
-import arrow.syntax.function.partially1
 import com.uchuhimo.konf.Config
 import com.urielsalis.mccrashlib.CrashReader
 import io.github.mojira.arisa.domain.Issue
+import io.github.mojira.arisa.infrastructure.LanguageDetectionApi
 import io.github.mojira.arisa.infrastructure.config.Arisa
 import io.github.mojira.arisa.infrastructure.config.Arisa.Credentials
 import io.github.mojira.arisa.infrastructure.config.Arisa.Modules
 import io.github.mojira.arisa.infrastructure.config.Arisa.Modules.ModuleConfigSpec
-import io.github.mojira.arisa.infrastructure.getLanguage
 import io.github.mojira.arisa.modules.AttachmentModule
 import io.github.mojira.arisa.modules.CHKModule
 import io.github.mojira.arisa.modules.CommandModule
@@ -220,7 +219,10 @@ class ModuleRegistry(private val config: Config) {
             LanguageModule(
                 config[Modules.Language.allowedLanguages],
                 config[Modules.Language.lengthThreshold],
-                ::getLanguage.partially1(config[Credentials.dandelionToken])
+                LanguageDetectionApi(
+                    config[Credentials.dandelionToken],
+                    config[Modules.Language.apiQuotaWarningThreshold]
+                )::getLanguage
             )
         )
 

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
@@ -166,6 +166,11 @@ object Arisa : ConfigSpec() {
         }
 
         object Language : ModuleConfigSpec() {
+            val apiQuotaWarningThreshold by optional<Double?>(
+                description = "When the number of remaining API quota units becomes equal to or lower than this" +
+                        " value a warning will be logged.",
+                default = null
+            )
             val allowedLanguages by required<List<String>>(
                 description = "Codes of languages that can be used."
             )


### PR DESCRIPTION
## Purpose
As mentioned by @urielsalis internally the current quota logging for the language API is too spammy because it is logged for every request.

## Approach
Define a `apiQuotaWarningThreshold` config entry. When the quota units become equal to or lower than this value a warning will be logged once.
Therefore no further messages are logged while the quota remains that low, and only once it was reset and again became lower than the threshold a warning will be logged again.

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
