### PR TITLE
Upgrade mc-crash-lib

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
 
     implementation("com.uchuhimo", "konf", "0.22.1")
     implementation("com.github.rcarz", "jira-client", "master-SNAPSHOT")
-    implementation("com.urielsalis", "mc-crash-lib", "2.0.1")
+    implementation("com.urielsalis", "mc-crash-lib", "2.0.2")
     implementation("com.github.napstr", "logback-discord-appender", "1.0.0")
     implementation("org.slf4j", "slf4j-api", "1.7.25")
     implementation("ch.qos.logback", "logback-classic", logBackVersion)


### PR DESCRIPTION
## Purpose
Upgrade mc-crash-lib to get the latest bug fixes and features, most notably deobfuscation for pre-release crash reports has been fixed.

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
