### PR TITLE
Fix #680 - Append deobf to the start instead of the end of attachment name

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/CrashModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/CrashModule.kt
@@ -58,7 +58,9 @@ class CrashModule(
             .filter { it.second != null }
             .filterNot {
                 issue.attachments.any { attachment ->
-                    attachment.name == getDeobfName(it.first) || attachment.name.startsWith("deobf_")
+                    attachment.name == getDeobfName(it.first) ||
+                        attachment.name.startsWith("deobf_") ||
+                        attachment.name.endsWith("deobfuscated.txt")
                 }
             }
         minecraftCrashesWithDeobf.forEach {

--- a/src/main/kotlin/io/github/mojira/arisa/modules/CrashModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/CrashModule.kt
@@ -58,9 +58,7 @@ class CrashModule(
             .filter { it.second != null }
             .filterNot {
                 issue.attachments.any { attachment ->
-                    attachment.name == getDeobfName(it.first) || attachment.name.endsWith(
-                        "deobfuscated.txt"
-                    )
+                    attachment.name == getDeobfName(it.first) || attachment.name.startsWith("deobf_")
                 }
             }
         minecraftCrashesWithDeobf.forEach {
@@ -78,7 +76,7 @@ class CrashModule(
         }
     }
 
-    private fun getDeobfName(name: String): String = "${name.substringBeforeLast(".")}-deobfuscated.txt"
+    private fun getDeobfName(name: String): String = "deobf_$name"
 
     /**
      * Checks whether an analyzed crash report matches any of the specified known crash issues.


### PR DESCRIPTION
## Purpose
Fix #680
## Approach
Append deobf at the start
## Future work

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
