### PR TITLE
Fix #678 - Remove OutOfMemory from duplicate module due to false positives

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -342,9 +342,6 @@ arisa:
           exceptionRegex: Maybe try a lowerresolution texturepack
           duplicates: MC-29565
         - type: minecraft
-          exceptionRegex: 'java\.lang\.OutOfMemoryError: Java heap space'
-          duplicates: MC-12949
-        - type: minecraft
           exceptionRegex: try a lowerresolution
           duplicates: MC-29565
         - type: java


### PR DESCRIPTION
## Purpose
Fix #678
## Approach
Remove it from the automatic duplicate module
## Future work

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
