### PR TITLE
Update mc-crash-lib to support Java 16 modules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
 
     implementation("com.uchuhimo", "konf", "0.22.1")
     implementation("com.github.rcarz", "jira-client", "868a5ca897")
-    implementation("com.urielsalis", "mc-crash-lib", "2.0.2")
+    implementation("com.urielsalis", "mc-crash-lib", "2.0.3")
     implementation("com.github.napstr", "logback-discord-appender", "1.0.0")
     implementation("org.slf4j", "slf4j-api", "1.7.25")
     implementation("ch.qos.logback", "logback-classic", logBackVersion)


### PR DESCRIPTION
## Purpose
Update mc-crash-lib to support Java 16 modules
## Approach
Adds new regex in mc-crash-lib
## Future work

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
