### PR TITLE
Update logback-discord-appender dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     implementation("com.uchuhimo", "konf", "0.22.1")
     implementation("com.github.rcarz", "jira-client", "868a5ca897")
     implementation("com.urielsalis", "mc-crash-lib", "2.0.4")
-    implementation("com.github.napstr", "logback-discord-appender", "1.0.0")
+    implementation("com.github.napstr", "logback-discord-appender", "a20617d401")
     implementation("org.slf4j", "slf4j-api", "1.7.25")
     implementation("ch.qos.logback", "logback-classic", logBackVersion)
     implementation("ch.qos.logback", "logback-core", logBackVersion)


### PR DESCRIPTION
## Purpose
See https://github.com/napstr/logback-discord-appender/pull/3
Probably has no impact since Arisa does not exit if the config is correct, but in case the configuration is incorrect or an uncaught exception causes the main loop to stop it will now also cause the complete program to exit.