### PR TITLE
Change thumbnail regex to match multiple embedded images without space

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/ThumbnailModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ThumbnailModule.kt
@@ -59,8 +59,8 @@ class ThumbnailModule(
      * Match !<image-name>!
      * (The matched string only consists of the <image-name> part, e.g. "test.png")
      * Only consider if:
-     * - At start of line or has space in front
-     * - At end of line or has space behind
+     * - At start of line or has space or '!' in front
+     * - At end of line or has space or '!' behind
      * - Starting '!' is not followed by space
      * - Ending '!' is not preceded by space
      * - Does not include a '|', since then it already has display settings and trying to modify them
@@ -69,7 +69,7 @@ class ThumbnailModule(
      * Uses lazy quantifier ("+?") so text containing multiple exclamation marks only matches the
      * shortest substrings, e.g. "!a! !b!" matches "!a!" and "!b!"
      */
-    private val imageRegex = """(?<=(?:\s|^)!)(?!\s)[^|]+?(?<!\s)(?=!(?:\s|$))""".toRegex()
+    private val imageRegex = """(?<=(?:\s|!|^)!)(?!\s)[^|]+?(?<!\s)(?=!(?:\s|!|$))""".toRegex()
 
     private fun replaceEmbeddedImages(issue: Issue, text: String): String {
         var matchIndex = 0

--- a/src/test/kotlin/io/github/mojira/arisa/modules/ThumbnailModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/ThumbnailModuleTest.kt
@@ -399,4 +399,27 @@ class ThumbnailModuleTest : StringSpec({
         result.shouldBeRight(ModuleResponse)
         hasUpdatedDescription shouldBe "!$attachmentName|thumbnail! and more text!"
     }
+
+    "regex should match multiple images without space between" {
+        var hasUpdatedDescription: String? = null
+        val attachmentName = "test.png"
+        val issue = mockIssue(
+            description = "!$attachmentName!!$attachmentName!",
+            updateDescription = {
+                hasUpdatedDescription = it
+                Unit.right()
+            },
+            attachments = listOf(
+                mockAttachment(
+                    name = attachmentName,
+                    openInputStream = PNG_LARGE_IMAGE_STREAM
+                )
+            )
+        )
+
+        val result = module(issue, A_SECOND_AGO)
+
+        result.shouldBeRight(ModuleResponse)
+        hasUpdatedDescription shouldBe "!$attachmentName|thumbnail!!$attachmentName|thumbnail!"
+    }
 })


### PR DESCRIPTION
## Purpose
Now and then the description of reports contains multiple embedded images without space between them, e.g. `!test.png!!test.png!`. Currently the regex pattern used by the ThumbnailModule is not matching these.

## Approach
Adjust regex pattern to match these images.

Note: When shown as thumbnail Jira does not add any padding between the images so this might look confusing. However, changing the module to also add a line break might change the intended formatting and would also complicate the logic (since it would have to detect multiple embedded images directly next to each other).

#### Checklist
- [x] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
