### PR TITLE
Add delay after successful relog

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/ArisaMain.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ArisaMain.kt
@@ -114,6 +114,7 @@ fun main() {
                     executor = Executor(
                         config, moduleRegistries, getSearchIssues(jiraClient, config)
                     )
+                    TimeUnit.SECONDS.sleep(checkIntervalSeconds)
                 } catch (exception: Exception) {
                     log.error("Relog failed", exception)
                     // Wait before performing any further action
@@ -121,6 +122,7 @@ fun main() {
                 }
             } else {
                 // Not enough time for relog passed, just try waiting a bit
+                log.info("Not enough time for relog has passed")
                 TimeUnit.SECONDS.sleep(max(WAIT_TIME_AFTER_CONNECTION_ERROR_IN_SECONDS, checkIntervalSeconds))
             }
         }


### PR DESCRIPTION
## Purpose
Oversight I made when writing #690

After a successful relog Arisa should probably also wait for the normal sleep interval.

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
