### PR TITLE
Refactor ArisaMain

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -21,7 +21,6 @@ arisa:
       - Won't Fix
       - Works As Intended
     url: https://bugs.mojang.com/
-    checkIntervalSeconds: 10
 
   customFields:
     linked: customfield_11100
@@ -36,9 +35,6 @@ arisa:
     default: '10318'
     special:
       MCL: '10502'
-
-  helperMessages:
-    updateIntervalSeconds: 3600
 
   modules:
     attachment:

--- a/src/main/kotlin/io/github/mojira/arisa/ArisaMain.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ArisaMain.kt
@@ -1,165 +1,68 @@
 package io.github.mojira.arisa
 
-import arrow.syntax.function.partially1
 import ch.qos.logback.classic.AsyncAppender
 import ch.qos.logback.classic.LoggerContext
 import com.github.napstr.logback.DiscordAppender
 import com.uchuhimo.konf.Config
 import com.uchuhimo.konf.source.yaml
-import io.github.mojira.arisa.domain.Issue
-import io.github.mojira.arisa.infrastructure.HelperMessageService
-import io.github.mojira.arisa.infrastructure.ProjectCache
 import io.github.mojira.arisa.infrastructure.config.Arisa
-import io.github.mojira.arisa.infrastructure.jira.connectToJira
-import io.github.mojira.arisa.infrastructure.jira.toDomain
-import io.github.mojira.arisa.registry.TicketQueryTimeframe
-import io.github.mojira.arisa.registry.getModuleRegistries
 import net.rcarz.jiraclient.JiraClient
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.io.File
-import java.lang.Long.max
-import java.time.Duration
-import java.time.Instant
-import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeUnit
 
 val log: Logger = LoggerFactory.getLogger("Arisa")
 
-private const val TIME_MINUTES = 5L
-private const val MAX_QUERY_TIMEFRAME_IN_MINUTES = 10L
-
-const val MAX_RESULTS = 50
-
-private const val RELOG_INTERVAL_IN_SECONDS = 5 * 60L
-private const val WAIT_TIME_AFTER_CONNECTION_ERROR_IN_SECONDS = 40L
-
 lateinit var jiraClient: JiraClient
 
-@Suppress("LongMethod", "TooGenericExceptionCaught", "NestedBlockDepth")
+private val config = readConfig()
+private val connectionService = JiraConnectionService(config)
+private var executor = Executor(config)
+
+const val MIN_TIME_BETWEEN_EXECUTION_CYCLES_IN_SECONDS = 10L
+
 fun main() {
-    val config = readConfig()
-    setWebhookOfLogger(config)
+    setLoggerWebhooks()
 
-    jiraClient =
-        connectToJira(
-            config[Arisa.Credentials.username],
-            config[Arisa.Credentials.password],
-            config[Arisa.Issues.url]
-        )
-    log.info("Connected to jira")
-
-    // Get tickets for re-run and last run time
-    var lastRelog = Instant.now()
-    val lastRunFile = File("last-run")
-    val lastRun = readLastRun(lastRunFile)
-    var lastRunTime = readLastRunTime(lastRun)
-    var rerunTickets = lastRun.subList(1, lastRun.size).toSet()
-    val failedTickets = mutableSetOf<String>()
-
-    val checkIntervalSeconds = config[Arisa.Issues.checkIntervalSeconds]
-
-    // Read helper-messages
-    val helperMessagesFile = File("helper-messages.json")
-    val helperMessagesInterval = config[Arisa.HelperMessages.updateIntervalSeconds]
-    HelperMessageService.updateHelperMessages(helperMessagesFile)
-    var helperMessagesLastFetch = Instant.now()
-
-    // Create executor
-    val moduleRegistries = getModuleRegistries(config)
-    var executor = Executor(
-        config, moduleRegistries, getSearchIssues(jiraClient, config)
-    )
+    connectionService.connect()
 
     while (true) {
-        // Save time before run, so nothing happening during the run is missed
-        val currentTime = Instant.now()
-        val endOfMaxTimeframe = lastRunTime.plus(MAX_QUERY_TIMEFRAME_IN_MINUTES, ChronoUnit.MINUTES)
+        HelperMessageUpdateService.checkForUpdate()
 
-        // The time at which we execute the bot.
-        // If we exceed our maximum time frame, act as if we were executing at the end of the maximum time frame.
-        // This is to make sure that `last-run` is updated once in a while,
-        // even if the bot is catching up after a long downtime.
-        val runOpenEnded = currentTime.isBefore(endOfMaxTimeframe)
-        val currentRunTime = if (runOpenEnded) { currentTime } else { endOfMaxTimeframe }
-
-        val timeframe = TicketQueryTimeframe(lastRunTime, currentRunTime, runOpenEnded)
-
-        // Execute all enabled modules using the executor
-        val executionResults = executor.execute(timeframe, rerunTickets)
-
-        if (executionResults.successful) {
-            rerunTickets = emptySet()
-            failedTickets.addAll(executionResults.failedTickets)
-            val failed = failedTickets.joinToString("") { ",$it" } // even first entry should start with a comma
-
-            if (config[Arisa.Debug.updateLastRun]) {
-                lastRunFile.writeText("${currentRunTime.toEpochMilli()}$failed")
-            }
-            lastRunTime = currentRunTime
-            TimeUnit.SECONDS.sleep(checkIntervalSeconds)
-        } else {
-            if (Duration.between(lastRelog, Instant.now()).toMinutes() >= 1) {
-                // If last relog was more than a minute before and execution failed with an exception, relog
-                log.info("Trying to relog")
-                try {
-                    jiraClient =
-                        connectToJira(
-                            config[Arisa.Credentials.username],
-                            config[Arisa.Credentials.password],
-                            config[Arisa.Issues.url]
-                        )
-                    log.info("Relog was successful")
-                    lastRelog = Instant.now()
-                    executor = Executor(
-                        config, moduleRegistries, getSearchIssues(jiraClient, config)
-                    )
-                    TimeUnit.SECONDS.sleep(checkIntervalSeconds)
-                } catch (exception: Exception) {
-                    log.error("Relog failed", exception)
-                    // Wait before performing any further action
-                    TimeUnit.SECONDS.sleep(max(RELOG_INTERVAL_IN_SECONDS, checkIntervalSeconds))
-                }
-            } else {
-                // Not enough time for relog passed, just try waiting a bit
-                log.info("Not enough time for relog has passed")
-                TimeUnit.SECONDS.sleep(max(WAIT_TIME_AFTER_CONNECTION_ERROR_IN_SECONDS, checkIntervalSeconds))
-            }
-        }
-
-        // Update helper messages if necessary
-        if (currentTime.epochSecond - helperMessagesLastFetch.epochSecond >= helperMessagesInterval) {
-            HelperMessageService.updateHelperMessages(helperMessagesFile)
-            executor = Executor(
-                config, moduleRegistries, getSearchIssues(jiraClient, config)
-            )
-            helperMessagesLastFetch = currentTime
-        }
+        val secondsToSleep = runExecutionCycle(executor)
+        TimeUnit.SECONDS.sleep(secondsToSleep)
     }
 }
 
-private fun getSearchIssues(
-    jiraClient: JiraClient,
-    config: Config
-): (String, Int, () -> Unit) -> List<Issue> {
-    return ::searchIssues
-        .partially1(jiraClient)
-        .partially1(config)
+/**
+ * @return amount of seconds to sleep after this execution cycle
+ */
+private fun runExecutionCycle(executor: Executor): Long {
+    val timeframe = ExecutionTimeframe.getTimeframeFromLastRun()
+    val currentRunTime = timeframe.currentRunTime
+
+    // Execute all enabled modules using the executor
+    val executionResults = executor.execute(timeframe, LastRun.failedTickets)
+
+    return if (executionResults.successful) {
+        // Reset relog timer
+        connectionService.notifyOfSuccessfulConnection()
+
+        // Update last run and save it to file
+        LastRun.update(currentRunTime, executionResults.failedTickets)
+        if (config[Arisa.Debug.updateLastRun]) {
+            LastRun.writeToFile()
+        }
+
+        MIN_TIME_BETWEEN_EXECUTION_CYCLES_IN_SECONDS
+    } else {
+        connectionService.tryRelog().sleepTimeInSeconds
+    }
 }
 
-private fun readLastRunTime(lastRun: List<String>): Instant {
-    return if (lastRun[0].isNotEmpty())
-        Instant.ofEpochMilli(lastRun[0].toLong())
-    else Instant.now().minus(TIME_MINUTES, ChronoUnit.MINUTES)
-}
-
-private fun readLastRun(lastRunFile: File): List<String> {
-    return (if (lastRunFile.exists())
-        lastRunFile.readText().trim()
-    else "")
-        .split(",")
-}
-
+/**
+ * Reads the config from the config file(s) and other sources
+ */
 private fun readConfig(): Config {
     return Config { addSpec(Arisa) }
         .from.yaml.watchFile("config/config.yml")
@@ -168,46 +71,22 @@ private fun readConfig(): Config {
         .from.systemProperties()
 }
 
-private fun setWebhookOfLogger(config: Config) {
+/**
+ * Configures the logger, so that it sends log messages to the Discord webhooks
+ */
+private fun setLoggerWebhooks() {
     val context = LoggerFactory.getILoggerFactory() as LoggerContext
+
     val discordAsync = context.getLogger(Logger.ROOT_LOGGER_NAME).getAppender("ASYNC_DISCORD") as AsyncAppender?
     if (discordAsync != null) {
         val discordAppender = discordAsync.getAppender("DISCORD") as DiscordAppender
         discordAppender.webhookUri = config[Arisa.Credentials.discordLogWebhook]
     }
+
     val discordErrorAsync =
         context.getLogger(Logger.ROOT_LOGGER_NAME).getAppender("ASYNC_ERROR_DISCORD") as AsyncAppender?
     if (discordErrorAsync != null) {
         val discordErrorAppender = discordErrorAsync.getAppender("ERROR_DISCORD") as DiscordAppender
         discordErrorAppender.webhookUri = config[Arisa.Credentials.discordErrorLogWebhook]
     }
-}
-
-@Suppress("LongParameterList")
-private fun searchIssues(
-    jiraClient: JiraClient,
-    config: Config,
-    jql: String,
-    startAt: Int,
-    finishedCallback: () -> Unit
-): List<Issue> {
-    val searchResult = jiraClient.searchIssues(
-        jql,
-        "*all",
-        "changelog",
-        MAX_RESULTS,
-        startAt
-    ) ?: return emptyList()
-
-    if (startAt + searchResult.max >= searchResult.total) finishedCallback()
-
-    return searchResult
-        .issues
-        .map {
-            it.toDomain(
-                jiraClient,
-                ProjectCache.getProjectFromTicketId(it.key),
-                config
-            )
-        }
 }

--- a/src/main/kotlin/io/github/mojira/arisa/ArisaMain.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ArisaMain.kt
@@ -15,12 +15,12 @@ val log: Logger = LoggerFactory.getLogger("Arisa")
  */
 lateinit var jiraClient: JiraClient
 
-val configService = ConfigService()
-val webhookService = WebhookService(configService.config)
-val connectionService = JiraConnectionService(configService.config)
-val executionService = ExecutionService(configService.config, connectionService)
-
 fun main() {
+    val configService = ConfigService()
+    val webhookService = WebhookService(configService.config)
+    val connectionService = JiraConnectionService(configService.config)
+    val executionService = ExecutionService(configService.config, connectionService)
+
     webhookService.setLoggerWebhooks()
 
     connectionService.connect()

--- a/src/main/kotlin/io/github/mojira/arisa/ArisaMain.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ArisaMain.kt
@@ -1,11 +1,5 @@
 package io.github.mojira.arisa
 
-import ch.qos.logback.classic.AsyncAppender
-import ch.qos.logback.classic.LoggerContext
-import com.github.napstr.logback.DiscordAppender
-import com.uchuhimo.konf.Config
-import com.uchuhimo.konf.source.yaml
-import io.github.mojira.arisa.infrastructure.config.Arisa
 import net.rcarz.jiraclient.JiraClient
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -13,80 +7,26 @@ import java.util.concurrent.TimeUnit
 
 val log: Logger = LoggerFactory.getLogger("Arisa")
 
+/**
+ * Global instance for the Jira client.
+ * (not nice but it works)
+ *
+ * Gets initialized by [JiraConnectionService.connect]
+ */
 lateinit var jiraClient: JiraClient
 
-private val config = readConfig()
-private val connectionService = JiraConnectionService(config)
-private var executor = Executor(config)
-
-const val MIN_TIME_BETWEEN_EXECUTION_CYCLES_IN_SECONDS = 10L
+val configService = ConfigService()
+val webhookService = WebhookService(configService.config)
+val connectionService = JiraConnectionService(configService.config)
+val executionService = ExecutionService(configService.config, connectionService)
 
 fun main() {
-    setLoggerWebhooks()
+    webhookService.setLoggerWebhooks()
 
     connectionService.connect()
 
     while (true) {
-        HelperMessageUpdateService.checkForUpdate()
-
-        val secondsToSleep = runExecutionCycle(executor)
+        val secondsToSleep = executionService.runExecutionCycle()
         TimeUnit.SECONDS.sleep(secondsToSleep)
-    }
-}
-
-/**
- * @return amount of seconds to sleep after this execution cycle
- */
-private fun runExecutionCycle(executor: Executor): Long {
-    val timeframe = ExecutionTimeframe.getTimeframeFromLastRun()
-    val currentRunTime = timeframe.currentRunTime
-
-    // Execute all enabled modules using the executor
-    val executionResults = executor.execute(timeframe, LastRun.failedTickets)
-
-    return if (executionResults.successful) {
-        // Reset relog timer
-        connectionService.notifyOfSuccessfulConnection()
-
-        // Update last run and save it to file
-        LastRun.update(currentRunTime, executionResults.failedTickets)
-        if (config[Arisa.Debug.updateLastRun]) {
-            LastRun.writeToFile()
-        }
-
-        MIN_TIME_BETWEEN_EXECUTION_CYCLES_IN_SECONDS
-    } else {
-        connectionService.tryRelog().sleepTimeInSeconds
-    }
-}
-
-/**
- * Reads the config from the config file(s) and other sources
- */
-private fun readConfig(): Config {
-    return Config { addSpec(Arisa) }
-        .from.yaml.watchFile("config/config.yml")
-        .from.yaml.watchFile("config/local.yml")
-        .from.env()
-        .from.systemProperties()
-}
-
-/**
- * Configures the logger, so that it sends log messages to the Discord webhooks
- */
-private fun setLoggerWebhooks() {
-    val context = LoggerFactory.getILoggerFactory() as LoggerContext
-
-    val discordAsync = context.getLogger(Logger.ROOT_LOGGER_NAME).getAppender("ASYNC_DISCORD") as AsyncAppender?
-    if (discordAsync != null) {
-        val discordAppender = discordAsync.getAppender("DISCORD") as DiscordAppender
-        discordAppender.webhookUri = config[Arisa.Credentials.discordLogWebhook]
-    }
-
-    val discordErrorAsync =
-        context.getLogger(Logger.ROOT_LOGGER_NAME).getAppender("ASYNC_ERROR_DISCORD") as AsyncAppender?
-    if (discordErrorAsync != null) {
-        val discordErrorAppender = discordErrorAsync.getAppender("ERROR_DISCORD") as DiscordAppender
-        discordErrorAppender.webhookUri = config[Arisa.Credentials.discordErrorLogWebhook]
     }
 }

--- a/src/main/kotlin/io/github/mojira/arisa/ConfigService.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ConfigService.kt
@@ -1,0 +1,13 @@
+package io.github.mojira.arisa
+
+import com.uchuhimo.konf.Config
+import com.uchuhimo.konf.source.yaml
+import io.github.mojira.arisa.infrastructure.config.Arisa
+
+class ConfigService {
+    val config: Config = Config { addSpec(Arisa) }
+        .from.yaml.watchFile("config/config.yml")
+        .from.yaml.watchFile("config/local.yml")
+        .from.env()
+        .from.systemProperties()
+}

--- a/src/main/kotlin/io/github/mojira/arisa/ExecutionService.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ExecutionService.kt
@@ -8,7 +8,7 @@ class ExecutionService(
 ) {
     private val helperMessageUpdateService = HelperMessageUpdateService()
     private val executor = Executor(config)
-    private val lastRun = LastRun(config)
+    private val lastRun = LastRun.getLastRun(config)
 
     /**
      * @return amount of seconds to sleep after this execution cycle

--- a/src/main/kotlin/io/github/mojira/arisa/ExecutionService.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ExecutionService.kt
@@ -1,0 +1,36 @@
+package io.github.mojira.arisa
+
+import com.uchuhimo.konf.Config
+
+class ExecutionService(
+    config: Config,
+    private val connectionService: JiraConnectionService
+) {
+    private val executor = Executor(config)
+    private val lastRun = LastRun(config)
+
+    /**
+     * @return amount of seconds to sleep after this execution cycle
+     */
+    fun runExecutionCycle(): Long {
+        HelperMessageUpdateService.checkForUpdate()
+
+        val timeframe = ExecutionTimeframe.getTimeframeFromLastRun(lastRun)
+        val currentRunTime = timeframe.currentRunTime
+
+        // Execute all enabled modules using the executor
+        val executionResults = executor.execute(timeframe, lastRun.failedTickets)
+
+        return if (executionResults.successful) {
+            // Reset relog timer
+            connectionService.notifyOfSuccessfulConnection()
+
+            // Update last run and save it to file
+            lastRun.update(currentRunTime, executionResults.failedTickets)
+
+            JiraConnectionService.MIN_TIME_BETWEEN_EXECUTION_CYCLES_IN_SECONDS
+        } else {
+            connectionService.tryRelog().sleepTimeInSeconds
+        }
+    }
+}

--- a/src/main/kotlin/io/github/mojira/arisa/ExecutionService.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ExecutionService.kt
@@ -6,6 +6,7 @@ class ExecutionService(
     config: Config,
     private val connectionService: JiraConnectionService
 ) {
+    private val helperMessageUpdateService = HelperMessageUpdateService()
     private val executor = Executor(config)
     private val lastRun = LastRun(config)
 
@@ -13,7 +14,7 @@ class ExecutionService(
      * @return amount of seconds to sleep after this execution cycle
      */
     fun runExecutionCycle(): Long {
-        HelperMessageUpdateService.checkForUpdate()
+        helperMessageUpdateService.checkForUpdate()
 
         val timeframe = ExecutionTimeframe.getTimeframeFromLastRun(lastRun)
         val currentRunTime = timeframe.currentRunTime

--- a/src/main/kotlin/io/github/mojira/arisa/ExecutionTimeframe.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ExecutionTimeframe.kt
@@ -1,0 +1,60 @@
+package io.github.mojira.arisa
+
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+
+class ExecutionTimeframe(
+    val lastRunTime: Instant,
+    val currentRunTime: Instant,
+    private val openEnded: Boolean
+) {
+    companion object {
+        private const val MAX_TIMEFRAME_DURATION_IN_MINUTES = 10L
+
+        /**
+         * @return An [ExecutionTimeframe] beginning at [LastRun], either until right now,
+         * or until [MAX_TIMEFRAME_DURATION_IN_MINUTES] after [LastRun].
+         */
+        fun getTimeframeFromLastRun(): ExecutionTimeframe {
+            // Save time before run, so nothing happening during the run is missed
+            val currentTime = Instant.now()
+            val endOfMaxTimeframe = LastRun.time.plus(MAX_TIMEFRAME_DURATION_IN_MINUTES, ChronoUnit.MINUTES)
+
+            // The time at which we execute the bot.
+            // If we exceed our maximum time frame, act as if we were executing at the end of the maximum time frame.
+            // This is to make sure that `last-run` is updated once in a while,
+            // even if the bot is catching up after a long downtime.
+            val runOpenEnded = currentTime.isBefore(endOfMaxTimeframe)
+            val currentRunTime = if (runOpenEnded) {
+                currentTime
+            } else {
+                endOfMaxTimeframe
+            }
+
+            return ExecutionTimeframe(LastRun.time, currentRunTime, runOpenEnded)
+        }
+    }
+
+    fun duration(): Duration = Duration.between(lastRunTime, currentRunTime).abs()
+
+    /**
+     * Adds a cap to a JQL query if this time frame is not open.
+     *
+     * @return If open ended: empty string. Otherwise: ` AND updated <= [currentRunTime]`
+     */
+    fun capIfNotOpenEnded(): String =
+        if (openEnded) "" else " AND updated <= ${ currentRunTime.toEpochMilli() }"
+
+    override fun toString(): String {
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+
+        val start = formatter.format(LocalDateTime.ofInstant(lastRunTime, ZoneOffset.UTC))
+        val end = if (openEnded) "NOW" else formatter.format(LocalDateTime.ofInstant(currentRunTime, ZoneOffset.UTC))
+
+        return "[$start - $end]"
+    }
+}

--- a/src/main/kotlin/io/github/mojira/arisa/ExecutionTimeframe.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ExecutionTimeframe.kt
@@ -13,7 +13,7 @@ class ExecutionTimeframe(
     private val openEnded: Boolean
 ) {
     companion object {
-        private const val MAX_TIMEFRAME_DURATION_IN_MINUTES = 10L
+        const val MAX_TIMEFRAME_DURATION_IN_MINUTES = 10L
 
         /**
          * @return An [ExecutionTimeframe] beginning at [LastRun], either until right now,
@@ -21,7 +21,7 @@ class ExecutionTimeframe(
          */
         fun getTimeframeFromLastRun(lastRun: LastRun): ExecutionTimeframe {
             // Save time before run, so nothing happening during the run is missed
-            val currentTime = Instant.now()
+            val currentTime = Instant.now().truncatedTo(ChronoUnit.MILLIS)
             val endOfMaxTimeframe = lastRun.time.plus(MAX_TIMEFRAME_DURATION_IN_MINUTES, ChronoUnit.MINUTES)
 
             // The time at which we execute the bot.

--- a/src/main/kotlin/io/github/mojira/arisa/ExecutionTimeframe.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ExecutionTimeframe.kt
@@ -19,10 +19,10 @@ class ExecutionTimeframe(
          * @return An [ExecutionTimeframe] beginning at [LastRun], either until right now,
          * or until [MAX_TIMEFRAME_DURATION_IN_MINUTES] after [LastRun].
          */
-        fun getTimeframeFromLastRun(): ExecutionTimeframe {
+        fun getTimeframeFromLastRun(lastRun: LastRun): ExecutionTimeframe {
             // Save time before run, so nothing happening during the run is missed
             val currentTime = Instant.now()
-            val endOfMaxTimeframe = LastRun.time.plus(MAX_TIMEFRAME_DURATION_IN_MINUTES, ChronoUnit.MINUTES)
+            val endOfMaxTimeframe = lastRun.time.plus(MAX_TIMEFRAME_DURATION_IN_MINUTES, ChronoUnit.MINUTES)
 
             // The time at which we execute the bot.
             // If we exceed our maximum time frame, act as if we were executing at the end of the maximum time frame.
@@ -35,7 +35,7 @@ class ExecutionTimeframe(
                 endOfMaxTimeframe
             }
 
-            return ExecutionTimeframe(LastRun.time, currentRunTime, runOpenEnded)
+            return ExecutionTimeframe(lastRun.time, currentRunTime, runOpenEnded)
         }
     }
 

--- a/src/main/kotlin/io/github/mojira/arisa/Executor.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/Executor.kt
@@ -1,25 +1,33 @@
 package io.github.mojira.arisa
 
+import arrow.syntax.function.partially1
 import com.uchuhimo.konf.Config
 import io.github.mojira.arisa.domain.Issue
 import io.github.mojira.arisa.infrastructure.CommentCache
+import io.github.mojira.arisa.infrastructure.ProjectCache
 import io.github.mojira.arisa.infrastructure.config.Arisa
+import io.github.mojira.arisa.infrastructure.jira.toDomain
 import io.github.mojira.arisa.registry.ModuleRegistry
-import io.github.mojira.arisa.registry.TicketQueryTimeframe
+import io.github.mojira.arisa.registry.getModuleRegistries
 
 class Executor(
     private val config: Config,
-    private val registries: List<ModuleRegistry>,
-    private val searchIssues: (String, Int, () -> Unit) -> List<Issue>
+    private val registries: List<ModuleRegistry> = getModuleRegistries(config),
+    private val searchIssues: (String, Int, () -> Unit) -> List<Issue> =
+        ::getSearchResultsFromJira.partially1(config).partially1(MAX_RESULTS)
 ) {
+    companion object {
+        private const val MAX_RESULTS = 100
+    }
+
     data class ExecutionResults(
         val successful: Boolean,
-        val failedTickets: Collection<String>
+        val failedTickets: Set<String>
     )
 
     @Suppress("TooGenericExceptionCaught")
     fun execute(
-        timeframe: TicketQueryTimeframe,
+        timeframe: ExecutionTimeframe,
         rerunTickets: Set<String>
     ): ExecutionResults {
         val failedTickets = mutableSetOf<String>()
@@ -44,20 +52,20 @@ class Executor(
         registry: ModuleRegistry,
         rerunTickets: Collection<String>,
         addFailedTicket: (String) -> Unit,
-        timeframe: TicketQueryTimeframe
+        timeframe: ExecutionTimeframe
     ) {
         val issues = getIssuesForRegistry(registry, rerunTickets, timeframe)
 
         registry.getEnabledModules().forEach { (moduleName, _, execute, moduleExecutor) ->
             log.debug("Executing module $moduleName")
-            moduleExecutor.executeModule(issues, addFailedTicket) { issue -> execute(issue, timeframe.lastRun) }
+            moduleExecutor.executeModule(issues, addFailedTicket) { issue -> execute(issue, timeframe.lastRunTime) }
         }
     }
 
     private fun getIssuesForRegistry(
         registry: ModuleRegistry,
         rerunTickets: Collection<String>,
-        timeframe: TicketQueryTimeframe
+        timeframe: ExecutionTimeframe
     ): List<Issue> {
         val issues = mutableListOf<Issue>()
 
@@ -94,4 +102,32 @@ class Executor(
         val enabledModules = registries.flatMap { registry -> registry.getEnabledModules().map { it.name } }
         log.debug("Enabled modules: $enabledModules")
     }
+}
+
+private fun getSearchResultsFromJira(
+    config: Config,
+    maxResults: Int,
+    jql: String,
+    startAt: Int,
+    finishedCallback: () -> Unit
+): List<Issue> {
+    val searchResult = jiraClient.searchIssues(
+        jql,
+        "*all",
+        "changelog",
+        maxResults,
+        startAt
+    ) ?: return emptyList()
+
+    if (startAt + searchResult.max >= searchResult.total) finishedCallback()
+
+    return searchResult
+        .issues
+        .map {
+            it.toDomain(
+                jiraClient,
+                ProjectCache.getProjectFromTicketId(it.key),
+                config
+            )
+        }
 }

--- a/src/main/kotlin/io/github/mojira/arisa/HelperMessageUpdateService.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/HelperMessageUpdateService.kt
@@ -9,7 +9,7 @@ object HelperMessageUpdateService {
     private const val UPDATE_INTERVAL_IN_SECONDS = 60 * 60L // 1 hour
 
     private val helperMessagesFile = File("helper-messages.json")
-    private var helperMessagesLastFetch = Instant.now()
+    private var helperMessagesLastFetch = Instant.now().minusSeconds(UPDATE_INTERVAL_IN_SECONDS + 1)
 
     fun checkForUpdate() {
         val currentTime = Instant.now()

--- a/src/main/kotlin/io/github/mojira/arisa/HelperMessageUpdateService.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/HelperMessageUpdateService.kt
@@ -5,8 +5,10 @@ import java.io.File
 import java.time.Duration
 import java.time.Instant
 
-object HelperMessageUpdateService {
-    private const val UPDATE_INTERVAL_IN_SECONDS = 60 * 60L // 1 hour
+class HelperMessageUpdateService {
+    companion object {
+        private const val UPDATE_INTERVAL_IN_SECONDS = 60 * 60L // 1 hour
+    }
 
     private val helperMessagesFile = File("helper-messages.json")
     private var helperMessagesLastFetch = Instant.now().minusSeconds(UPDATE_INTERVAL_IN_SECONDS + 1)

--- a/src/main/kotlin/io/github/mojira/arisa/HelperMessageUpdateService.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/HelperMessageUpdateService.kt
@@ -1,0 +1,27 @@
+package io.github.mojira.arisa
+
+import io.github.mojira.arisa.infrastructure.HelperMessageService
+import java.io.File
+import java.time.Duration
+import java.time.Instant
+
+object HelperMessageUpdateService {
+    private const val UPDATE_INTERVAL_IN_SECONDS = 60 * 60L // 1 hour
+
+    private val helperMessagesFile = File("helper-messages.json")
+    private var helperMessagesLastFetch = Instant.now()
+
+    fun checkForUpdate() {
+        val currentTime = Instant.now()
+
+        val secondsSinceLastUpdate =
+            Duration.between(helperMessagesLastFetch, currentTime).abs().toSeconds()
+
+        // Update helper messages if necessary
+        if (secondsSinceLastUpdate >= UPDATE_INTERVAL_IN_SECONDS) {
+            HelperMessageService.updateHelperMessages(helperMessagesFile)
+
+            helperMessagesLastFetch = currentTime
+        }
+    }
+}

--- a/src/main/kotlin/io/github/mojira/arisa/JiraConnectionService.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/JiraConnectionService.kt
@@ -1,0 +1,134 @@
+package io.github.mojira.arisa
+
+import com.uchuhimo.konf.Config
+import io.github.mojira.arisa.infrastructure.config.Arisa
+import io.github.mojira.arisa.infrastructure.jira.connectToJira
+import java.lang.Long.max
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+
+class JiraConnectionService(
+    private val config: Config
+) {
+    companion object {
+        /**
+         * How long ago the last successful connection needs to be for Arisa to try to relog
+         */
+        private const val MAX_SECONDS_SINCE_LAST_SUCCESSFUL_CONNECTION = 60L
+
+        /**
+         * How long Arisa should wait after it was unable to relog
+         */
+        private const val WAIT_TIME_AFTER_UNSUCCESSFUL_RELOG_IN_SECONDS = 5 * 60L // 5 minutes
+
+        /**
+         * How long Arisa should wait after a connection error before continuing without trying to relog
+         */
+        private const val WAIT_TIME_AFTER_CONNECTION_ERROR_IN_SECONDS = 40L
+    }
+
+    private var lastSuccessfulConnection = Instant.now().minusSeconds(MAX_SECONDS_SINCE_LAST_SUCCESSFUL_CONNECTION + 1)
+
+    /**
+     * Tries to establish a connection and log into Jira.
+     * @returns null if able to connect, the connection exception otherwise
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private fun establishConnection(): Exception? {
+        return try {
+            val client = connectToJira(
+                config[Arisa.Credentials.username],
+                config[Arisa.Credentials.password],
+                config[Arisa.Issues.url]
+            )
+
+            log.info("Successfully connected to jira")
+            lastSuccessfulConnection = Instant.now()
+            jiraClient = client
+
+            null
+        } catch (exception: Exception) {
+            exception
+        }
+    }
+
+    /**
+     * Try relogging if the last successful connection was at least [MAX_SECONDS_SINCE_LAST_SUCCESSFUL_CONNECTION] ago.
+     * @return
+     * - [RelogResult.SuccessfulRelog] if relog was successful
+     * - [RelogResult.UnsucessfulRelog] if unable to relog
+     * - [RelogResult.NoRelogAttempted] if no relog was attempted because the last relog happened recently
+     */
+    fun tryRelog(): RelogResult {
+        val secondsSinceLastSuccessfulConnection = Duration.between(lastSuccessfulConnection, Instant.now()).toSeconds()
+
+        return if (secondsSinceLastSuccessfulConnection > MAX_SECONDS_SINCE_LAST_SUCCESSFUL_CONNECTION) {
+            log.info("Trying to relog")
+
+            establishConnection() ?: return RelogResult.SuccessfulRelog()
+
+            val relogResult = RelogResult.UnsucessfulRelog()
+            log.error(
+                "Could not reconnect. Will attempt to relog again in ${ relogResult.sleepTimeInSeconds } seconds."
+            )
+
+            relogResult
+        } else {
+            RelogResult.NoRelogAttempted()
+        }
+    }
+
+    /**
+     * Tries to reconnect after the connection failed
+     * Only used in [connect] below when initially connecting to Jira.
+     */
+    private fun reconnect() {
+        var relogResult = tryRelog()
+        while (relogResult !is RelogResult.SuccessfulRelog) {
+            val secondsToSleep = relogResult.sleepTimeInSeconds
+            TimeUnit.SECONDS.sleep(secondsToSleep)
+            relogResult = tryRelog()
+        }
+    }
+
+    /**
+     * Connect to Jira for the first time
+     * Tries to reconnect until it has established a connection
+     */
+    fun connect() {
+        val exception = establishConnection() ?: return
+
+        log.error("Could not connect to Jira", exception)
+        reconnect()
+    }
+
+    /**
+     * Notifies the connection service that a successful connection took place.
+     * Resets the [lastSuccessfulConnection] timer.
+     */
+    fun notifyOfSuccessfulConnection() {
+        lastSuccessfulConnection = Instant.now()
+    }
+
+    /**
+     * Stores information about a relog attempt, and how long to wait after a specific relog outcome
+     */
+    interface RelogResult {
+        class SuccessfulRelog : RelogResult {
+            override val sleepTimeInSeconds = MIN_TIME_BETWEEN_EXECUTION_CYCLES_IN_SECONDS
+        }
+
+        class UnsucessfulRelog : RelogResult {
+            override val sleepTimeInSeconds =
+                max(WAIT_TIME_AFTER_UNSUCCESSFUL_RELOG_IN_SECONDS, MIN_TIME_BETWEEN_EXECUTION_CYCLES_IN_SECONDS)
+        }
+
+        class NoRelogAttempted : RelogResult {
+            override val sleepTimeInSeconds =
+                max(WAIT_TIME_AFTER_CONNECTION_ERROR_IN_SECONDS, MIN_TIME_BETWEEN_EXECUTION_CYCLES_IN_SECONDS)
+        }
+
+        val sleepTimeInSeconds: Long
+    }
+}

--- a/src/main/kotlin/io/github/mojira/arisa/LastRun.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/LastRun.kt
@@ -1,0 +1,42 @@
+package io.github.mojira.arisa
+
+import java.io.File
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+/**
+ * Stores information about the previous run (start time, and tickets that failed during the run)
+ */
+object LastRun {
+    var time: Instant
+    var failedTickets: Set<String>
+
+    private val lastRunFile = File("last-run")
+
+    private const val DEFAULT_START_TIME_MINUTES_BEFORE_NOW = 5L
+
+    fun writeToFile() {
+        val failedString = failedTickets.joinToString("") { ",$it" } // even first entry should start with a comma
+
+        lastRunFile.writeText("${time.toEpochMilli()}$failedString")
+    }
+
+    fun update(newTime: Instant, newFailedTickets: Set<String>) {
+        time = newTime
+        failedTickets = newFailedTickets
+    }
+
+    init {
+        val fileContents = if (lastRunFile.exists()) { lastRunFile.readText() } else ""
+
+        val lastRunFileComponents = fileContents.trim().split(',')
+
+        time = if (lastRunFileComponents[0].isNotEmpty()) {
+            Instant.ofEpochMilli(lastRunFileComponents[0].toLong())
+        } else {
+            Instant.now().minus(DEFAULT_START_TIME_MINUTES_BEFORE_NOW, ChronoUnit.MINUTES)
+        }
+
+        failedTickets = lastRunFileComponents.subList(1, lastRunFileComponents.size).toSet()
+    }
+}

--- a/src/main/kotlin/io/github/mojira/arisa/LastRun.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/LastRun.kt
@@ -1,5 +1,7 @@
 package io.github.mojira.arisa
 
+import com.uchuhimo.konf.Config
+import io.github.mojira.arisa.infrastructure.config.Arisa
 import java.io.File
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -7,23 +9,34 @@ import java.time.temporal.ChronoUnit
 /**
  * Stores information about the previous run (start time, and tickets that failed during the run)
  */
-object LastRun {
+class LastRun(
+    private val config: Config
+) {
+    companion object {
+        private const val DEFAULT_START_TIME_MINUTES_BEFORE_NOW = 5L
+    }
+
     var time: Instant
     var failedTickets: Set<String>
 
     private val lastRunFile = File("last-run")
 
-    private const val DEFAULT_START_TIME_MINUTES_BEFORE_NOW = 5L
-
-    fun writeToFile() {
+    private fun writeToFile() {
         val failedString = failedTickets.joinToString("") { ",$it" } // even first entry should start with a comma
 
         lastRunFile.writeText("${time.toEpochMilli()}$failedString")
     }
 
+    /**
+     * Updates last run and writes it to the `last-run` file
+     */
     fun update(newTime: Instant, newFailedTickets: Set<String>) {
         time = newTime
         failedTickets = newFailedTickets
+
+        if (config[Arisa.Debug.updateLastRun]) {
+            writeToFile()
+        }
     }
 
     init {

--- a/src/main/kotlin/io/github/mojira/arisa/WebhookService.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/WebhookService.kt
@@ -1,0 +1,33 @@
+package io.github.mojira.arisa
+
+import ch.qos.logback.classic.AsyncAppender
+import ch.qos.logback.classic.LoggerContext
+import com.github.napstr.logback.DiscordAppender
+import com.uchuhimo.konf.Config
+import io.github.mojira.arisa.infrastructure.config.Arisa
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class WebhookService(
+    private val config: Config
+) {
+    /**
+     * Configures the logger, so that it sends log messages to the Discord webhooks
+     */
+    fun setLoggerWebhooks() {
+        val context = LoggerFactory.getILoggerFactory() as LoggerContext
+
+        val discordAsync = context.getLogger(Logger.ROOT_LOGGER_NAME).getAppender("ASYNC_DISCORD") as AsyncAppender?
+        if (discordAsync != null) {
+            val discordAppender = discordAsync.getAppender("DISCORD") as DiscordAppender
+            discordAppender.webhookUri = config[Arisa.Credentials.discordLogWebhook]
+        }
+
+        val discordErrorAsync =
+            context.getLogger(Logger.ROOT_LOGGER_NAME).getAppender("ASYNC_ERROR_DISCORD") as AsyncAppender?
+        if (discordErrorAsync != null) {
+            val discordErrorAppender = discordErrorAsync.getAppender("ERROR_DISCORD") as DiscordAppender
+            discordErrorAppender.webhookUri = config[Arisa.Credentials.discordErrorLogWebhook]
+        }
+    }
+}

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
@@ -28,7 +28,6 @@ object Arisa : ConfigSpec() {
             description = "The resolutions to operate on. Used for default whitelist of modules"
         )
         val url by required<String>(description = "The base url for the jira instance")
-        val checkIntervalSeconds by required<Long>(description = "The interval in which all issues are checked")
     }
 
     object CustomFields : ConfigSpec() {
@@ -48,12 +47,6 @@ object Arisa : ConfigSpec() {
         val special by required<Map<String, String>>(
             description = "Some projects define their own security level. These projects need to be defined here with" +
                     " their own ID.. Default is all projects use the default ID"
-        )
-    }
-
-    object HelperMessages : ConfigSpec() {
-        val updateIntervalSeconds by required<Long>(
-            description = "The interval in which the messages.json file is updated"
         )
     }
 

--- a/src/main/kotlin/io/github/mojira/arisa/registry/DelayedModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/registry/DelayedModuleRegistry.kt
@@ -1,6 +1,7 @@
 package io.github.mojira.arisa.registry
 
 import com.uchuhimo.konf.Config
+import io.github.mojira.arisa.ExecutionTimeframe
 import io.github.mojira.arisa.infrastructure.config.Arisa
 import io.github.mojira.arisa.modules.DuplicateMessageModule
 import java.time.temporal.ChronoUnit
@@ -9,10 +10,10 @@ import java.time.temporal.ChronoUnit
  * This class is the registry for modules that get executed `commentDelayMinutes` after the ticket has been updated.
  */
 class DelayedModuleRegistry(config: Config) : ModuleRegistry(config) {
-    override fun getJql(timeframe: TicketQueryTimeframe): String {
-        val checkStart = timeframe.lastRun
+    override fun getJql(timeframe: ExecutionTimeframe): String {
+        val checkStart = timeframe.lastRunTime
             .minus(config[Arisa.Modules.DuplicateMessage.commentDelayMinutes], ChronoUnit.MINUTES)
-        val checkEnd = timeframe.currentRun
+        val checkEnd = timeframe.currentRunTime
             .minus(config[Arisa.Modules.DuplicateMessage.commentDelayMinutes], ChronoUnit.MINUTES)
 
         return "updated > ${checkStart.toEpochMilli()} AND updated <= ${checkEnd.toEpochMilli()}"

--- a/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
@@ -2,6 +2,7 @@ package io.github.mojira.arisa.registry
 
 import com.uchuhimo.konf.Config
 import com.urielsalis.mccrashlib.CrashReader
+import io.github.mojira.arisa.ExecutionTimeframe
 import io.github.mojira.arisa.infrastructure.LanguageDetectionApi
 import io.github.mojira.arisa.infrastructure.config.Arisa
 import io.github.mojira.arisa.modules.AttachmentModule
@@ -36,8 +37,8 @@ import io.github.mojira.arisa.modules.TransferVersionsModule
  * This class is the registry for modules that get executed immediately after a ticket has been updated.
  */
 class InstantModuleRegistry(config: Config) : ModuleRegistry(config) {
-    override fun getJql(timeframe: TicketQueryTimeframe): String {
-        return "updated > ${ timeframe.lastRun.toEpochMilli() }${ timeframe.capIfNotOpenEnded() }"
+    override fun getJql(timeframe: ExecutionTimeframe): String {
+        return "updated > ${ timeframe.lastRunTime.toEpochMilli() }${ timeframe.capIfNotOpenEnded() }"
     }
 
     init {

--- a/src/main/kotlin/io/github/mojira/arisa/registry/LinkedModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/registry/LinkedModuleRegistry.kt
@@ -1,6 +1,7 @@
 package io.github.mojira.arisa.registry
 
 import com.uchuhimo.konf.Config
+import io.github.mojira.arisa.ExecutionTimeframe
 import io.github.mojira.arisa.infrastructure.config.Arisa
 import io.github.mojira.arisa.modules.UpdateLinkedModule
 import java.time.temporal.ChronoUnit
@@ -11,10 +12,10 @@ import java.time.temporal.ChronoUnit
  * This is done in order to avoid spam.
  */
 class LinkedModuleRegistry(config: Config) : ModuleRegistry(config) {
-    override fun getJql(timeframe: TicketQueryTimeframe): String {
-        val freshlyUpdatedJql = "updated > ${ timeframe.lastRun.toEpochMilli() }${ timeframe.capIfNotOpenEnded() }"
+    override fun getJql(timeframe: ExecutionTimeframe): String {
+        val freshlyUpdatedJql = "updated > ${ timeframe.lastRunTime.toEpochMilli() }${ timeframe.capIfNotOpenEnded() }"
 
-        val intervalEnd = timeframe.currentRun.minus(
+        val intervalEnd = timeframe.currentRunTime.minus(
             config[Arisa.Modules.UpdateLinked.updateIntervalHours], ChronoUnit.HOURS
         )
         val intervalStart = intervalEnd.minus(timeframe.duration())

--- a/src/main/kotlin/io/github/mojira/arisa/registry/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/registry/ModuleRegistry.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import arrow.core.left
 import com.uchuhimo.konf.Config
 import io.github.mojira.arisa.ModuleExecutor
+import io.github.mojira.arisa.ExecutionTimeframe
 import io.github.mojira.arisa.domain.Issue
 import io.github.mojira.arisa.infrastructure.config.Arisa
 import io.github.mojira.arisa.infrastructure.config.Arisa.Modules.ModuleConfigSpec
@@ -11,11 +12,7 @@ import io.github.mojira.arisa.modules.FailedModuleResponse
 import io.github.mojira.arisa.modules.Module
 import io.github.mojira.arisa.modules.ModuleError
 import io.github.mojira.arisa.modules.ModuleResponse
-import java.time.Duration
 import java.time.Instant
-import java.time.LocalDateTime
-import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
 
 // All defined module registries
 val getModuleRegistries = { config: Config ->
@@ -24,31 +21,6 @@ val getModuleRegistries = { config: Config ->
         DelayedModuleRegistry(config),
         LinkedModuleRegistry(config)
     )
-}
-
-class TicketQueryTimeframe(
-    val lastRun: Instant,
-    val currentRun: Instant,
-    private val openEnded: Boolean
-) {
-    fun duration(): Duration = Duration.between(lastRun, currentRun).abs()
-
-    /**
-     * Adds a cap to a JQL query if this time frame is not open.
-     *
-     * @return If open ended: empty string. Otherwise: ` AND updated <= [currentRun]`
-     */
-    fun capIfNotOpenEnded(): String =
-        if (openEnded) "" else " AND updated <= ${ currentRun.toEpochMilli() }"
-
-    override fun toString(): String {
-        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
-
-        val start = formatter.format(LocalDateTime.ofInstant(lastRun, ZoneOffset.UTC))
-        val end = if (openEnded) "NOW" else formatter.format(LocalDateTime.ofInstant(currentRun, ZoneOffset.UTC))
-
-        return "[$start - $end]"
-    }
 }
 
 abstract class ModuleRegistry(protected val config: Config) {
@@ -61,7 +33,7 @@ abstract class ModuleRegistry(protected val config: Config) {
 
     private val modules = mutableListOf<Entry>()
 
-    protected abstract fun getJql(timeframe: TicketQueryTimeframe): String
+    protected abstract fun getJql(timeframe: ExecutionTimeframe): String
 
     fun getAllModules(): List<Entry> = modules
 
@@ -92,7 +64,7 @@ abstract class ModuleRegistry(protected val config: Config) {
         moduleName to tryExecuteModule { module(issue, lastRun) }
     }
 
-    private fun getJqlWithDebug(timeframe: TicketQueryTimeframe): String {
+    private fun getJqlWithDebug(timeframe: ExecutionTimeframe): String {
         val registryJql = getJql(timeframe)
 
         val debugWhitelist = config[Arisa.Debug.ticketWhitelist]
@@ -101,7 +73,7 @@ abstract class ModuleRegistry(protected val config: Config) {
         else "key IN (${debugWhitelist.joinToString()}) AND ($registryJql)"
     }
 
-    fun getFullJql(timeframe: TicketQueryTimeframe, failedTickets: Collection<String>): String {
+    fun getFullJql(timeframe: ExecutionTimeframe, failedTickets: Collection<String>): String {
         val failedTicketsJql = if (failedTickets.isEmpty()) "" else "key in (${ failedTickets.joinToString() }) OR "
         val registryJql = "(${ getJqlWithDebug(timeframe) })"
 

--- a/src/test/kotlin/io/github/mojira/arisa/ExecutionTimeframeTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/ExecutionTimeframeTest.kt
@@ -1,0 +1,53 @@
+package io.github.mojira.arisa
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.time.Duration
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class ExecutionTimeframeTest : StringSpec({
+    "getTimeframeFromLastRun should return the correct timeframe if last run was recently" {
+        val lastRunTime = Instant.now()
+            .minus(1, ChronoUnit.MINUTES)
+            .truncatedTo(ChronoUnit.MILLIS)
+
+        val lastRun = LastRun(
+            { lastRunTime.toEpochMilli().toString() },
+            { }
+        )
+
+        val timeframe = ExecutionTimeframe.getTimeframeFromLastRun(lastRun)
+
+        val timeframeEnd = Instant.now().truncatedTo(ChronoUnit.MILLIS)
+
+        timeframe.lastRunTime shouldBe lastRunTime
+        timeframe.currentRunTime.isAfter(timeframeEnd) shouldBe false
+        timeframe.capIfNotOpenEnded() shouldBe ""
+        timeframe.duration() shouldBe Duration.between(lastRunTime, timeframeEnd).abs()
+    }
+
+    "getTimeframeFromLastRun should return the correct timeframe if last run was a while ago" {
+        val offsetInMinutes = 20L
+
+        val lastRunTime = Instant.now()
+            .minus(offsetInMinutes, ChronoUnit.MINUTES)
+            .truncatedTo(ChronoUnit.MILLIS)
+
+        val timeframeEnd = lastRunTime
+            .plus(ExecutionTimeframe.MAX_TIMEFRAME_DURATION_IN_MINUTES, ChronoUnit.MINUTES)
+            .truncatedTo(ChronoUnit.MILLIS)
+
+        val lastRun = LastRun(
+            { lastRunTime.toEpochMilli().toString() },
+            { }
+        )
+
+        val timeframe = ExecutionTimeframe.getTimeframeFromLastRun(lastRun)
+
+        timeframe.lastRunTime shouldBe lastRunTime
+        timeframe.currentRunTime.isAfter(timeframeEnd) shouldBe false
+        timeframe.capIfNotOpenEnded() shouldBe " AND updated <= ${ timeframeEnd.toEpochMilli() }"
+        timeframe.duration() shouldBe Duration.between(lastRunTime, timeframeEnd).abs()
+    }
+})

--- a/src/test/kotlin/io/github/mojira/arisa/ExecutorTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/ExecutorTest.kt
@@ -8,7 +8,6 @@ import io.github.mojira.arisa.infrastructure.config.Arisa
 import io.github.mojira.arisa.modules.FailedModuleResponse
 import io.github.mojira.arisa.modules.OperationNotNeededModuleResponse
 import io.github.mojira.arisa.registry.ModuleRegistry
-import io.github.mojira.arisa.registry.TicketQueryTimeframe
 import io.github.mojira.arisa.utils.mockIssue
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -24,7 +23,7 @@ private val failedModuleRegistryMock = mockk<ModuleRegistry>()
 private val moduleExecutorMock = mockk<ModuleExecutor>()
 private val failedModuleExecutorMock = mockk<ModuleExecutor>()
 
-private val dummyTimeframe = TicketQueryTimeframe(Instant.now(), Instant.now(), true)
+private val dummyTimeframe = ExecutionTimeframe(Instant.now(), Instant.now(), true)
 
 class ExecutorTest : StringSpec({
     every { moduleRegistryMock.getEnabledModules() } returns listOf(

--- a/src/test/kotlin/io/github/mojira/arisa/LastRunTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/LastRunTest.kt
@@ -1,0 +1,75 @@
+package io.github.mojira.arisa
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class LastRunTest : StringSpec({
+    "should use default time before now if input file is empty" {
+        val lastRun = LastRun(
+            { "" },
+            { }
+        )
+
+        val time = Instant.now().minus(LastRun.DEFAULT_START_TIME_MINUTES_BEFORE_NOW, ChronoUnit.MINUTES)
+
+        lastRun.time.isAfter(time) shouldBe false
+        lastRun.failedTickets.shouldBeEmpty()
+    }
+
+    "should read time from input file" {
+        val time = Instant.ofEpochMilli(123456789)
+
+        val lastRun = LastRun(
+            { time.toEpochMilli().toString() },
+            { }
+        )
+
+        lastRun.time shouldBe time
+        lastRun.failedTickets.shouldBeEmpty()
+    }
+
+    "should read failed tickets from input file" {
+        val time = Instant.now().truncatedTo(ChronoUnit.MILLIS)
+        val tickets = listOf("MC-1234", "MCL-5678", "MCPE-9012")
+
+        val lastRun = LastRun(
+            { "${ time.toEpochMilli() },${ tickets.joinToString(",") }" },
+            { }
+        )
+
+        lastRun.time shouldBe time
+        lastRun.failedTickets shouldContainExactly tickets
+    }
+
+    "should update time and failed tickets" {
+        val time = Instant.now()
+        val tickets = listOf("MC-1234", "MCL-5678", "MCPE-9012")
+
+        var writtenToFile = false
+        var fileContents = "${ time.toEpochMilli() },${ tickets.joinToString(",") }"
+
+        val lastRun = LastRun(
+            { fileContents },
+            { contents ->
+                writtenToFile = true
+                fileContents = contents
+            }
+        )
+
+        val newTime = Instant.now()
+        val newTickets = setOf("MC-4", "MCPE-9012")
+        val newFileContents = "${ newTime.toEpochMilli() },${ newTickets.joinToString(",") }"
+
+        lastRun.update(newTime, newTickets)
+
+        lastRun.time shouldBe newTime
+        lastRun.failedTickets shouldContainExactly newTickets
+
+        writtenToFile shouldBe true
+        fileContents shouldBe newFileContents
+    }
+})


### PR DESCRIPTION
## Purpose
`ArisaMain` got messier and messier, so it's time for some spring cleaning, innit?

## Approach
This turned out to be a bigger task than I expected.

This PR refactors `ArisaMain` by splitting it up into smaller pieces. Most notably:
* `JiraConnectionService` is responsible for connecting to Jira, and reconnecting if something goes wrong
* `HelperMessageUpdateService` is simply responsible to update the helper messages if they haven't been updated in a while. Simple.
* `LastRun` is responsible for keeping track of the previous run, saving it to the file, and reading it from the file when the bot starts initially.
* `ExecutionTimeframe` existed previously inside of `ModuleRegistry`, now it's its own class and handles everything in regard to the time frame in which the bot searches for updated tickets.
* `ArisaMain` is only responsible for glueing everything together.

I removed all of the timeouts / intervals from the config and into the kotlin classes themselves. I don't think it's necessary to have them in the config, and it's just easier to overview what something is set to by having it directly where it's used.

I've also fixed a small bug (?) where, if the bot would encounter a connection error, it would immediately go to sleep for 5 minutes, and then try to reconnect. This might not be optimal if there's only a very short outage. Instead, the bot now saves when the last successful connection happened, and only tries to relog if that connection is older than a minute.

Speaking of that, I didn't change any of the intervals from previously, only renamed them. I think they make sense how they were/are, but we can change them pretty easily if we want to.

As a summary, when Arisa encounters an exception it will do the following:
1. If the last successful connection (previously: last relog) was less than a minute ago: Wait 40 seconds
2. Try relogging
3. If that wasn't successful, wait 5 minutes and repeat from step 2
4. Continue as normal

Note, I've also removed the printing of the exception when a relog fails, in order to prevent spam. I'd say it suffices if we know that JIRA is not reachable, and at least one exception is always printed.

## Future work
MOAR REFACTORING

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [x] Tested in MCTEST-xxx
