### PR TITLE
Fix ThumbnailModule allowing ! and \n to be part of file names

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/ThumbnailModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ThumbnailModule.kt
@@ -61,15 +61,17 @@ class ThumbnailModule(
      * Only consider if:
      * - At start of line or has space or '!' in front
      * - At end of line or has space or '!' behind
-     * - Starting '!' is not followed by space
-     * - Ending '!' is not preceded by space
+     * - Starting '!' is not followed by space or exclamation mark
+     * - Ending '!' is not preceded by space or exclamation mark
      * - Does not include a '|', since then it already has display settings and trying to modify them
      *   might break the embedded image (or user already specified a reasonable size)
+     * - Does not include another exclamation mark somewhere inbetween
      *
      * Uses lazy quantifier ("+?") so text containing multiple exclamation marks only matches the
      * shortest substrings, e.g. "!a! !b!" matches "!a!" and "!b!"
      */
-    private val imageRegex = """(?<=(?:\s|!|^)!)(?!\s)[^|]+?(?<!\s)(?=!(?:\s|!|$))""".toRegex()
+//    private val imageRegex = """(?<=(?:\s|!|^)!)(?!\s)[^|]+?(?<!\s)(?=!(?:\s|!|$))""".toRegex()
+    private val imageRegex = """(?<=(?:\s|!|^)!)(?!\s)[^|\n!]+?(?<!\s)(?=!(?:\s|!|$))""".toRegex()
 
     private fun replaceEmbeddedImages(issue: Issue, text: String): String {
         var matchIndex = 0

--- a/src/test/kotlin/io/github/mojira/arisa/modules/ThumbnailModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/ThumbnailModuleTest.kt
@@ -373,7 +373,7 @@ class ThumbnailModuleTest : StringSpec({
         result.shouldBeRight(ModuleResponse)
         // Module is created with maxImagesCount=2, should only process at most two images
         hasUpdatedDescription shouldBe ("!$attachmentName|thumbnail! !$attachmentName|thumbnail! " +
-                "!$attachmentName! !$attachmentName! ")
+            "!$attachmentName! !$attachmentName! ")
     }
 
     "regex should match embedded images lazily" {
@@ -421,5 +421,34 @@ class ThumbnailModuleTest : StringSpec({
 
         result.shouldBeRight(ModuleResponse)
         hasUpdatedDescription shouldBe "!$attachmentName|thumbnail!!$attachmentName|thumbnail!"
+    }
+
+    "regex should not match newlines and exclamation marks as the file name" {
+        val issue = mockIssue(
+            // from MCPE-120943
+            description = "Hello !!!\n" +
+                "I’ve found the ultimate solution to the problem !!!!! \n" +
+                "Just login from settings and not the main menu ! " +
+                "Enter the code given to enter in aka.ms/remoteconnect and all done !!!!",
+            attachments = listOf(
+                mockAttachment(
+                    name = "!",
+                    openInputStream = PNG_LARGE_IMAGE_STREAM
+                ),
+                mockAttachment(
+                    name = "!\nI’ve found the ultimate solution to the problem !",
+                    openInputStream = PNG_LARGE_IMAGE_STREAM
+                ),
+                mockAttachment(
+                    name = "! \nJust login from settings and not the main menu ! " +
+                        "Enter the code given to enter in aka.ms/remoteconnect and all done !",
+                    openInputStream = PNG_LARGE_IMAGE_STREAM
+                )
+            )
+        )
+
+        val result = module(issue, A_SECOND_AGO)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 })

--- a/src/test/kotlin/io/github/mojira/arisa/modules/ThumbnailModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/ThumbnailModuleTest.kt
@@ -193,7 +193,7 @@ class ThumbnailModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse for malformed / ambiguous embedded image references" {
         val attachmentName = "test.png"
         val issue = mockIssue(
-            description = "!$attachmentName!$attachmentName! !|$attachmentName! !!$attachmentName!!",
+            description = "!$attachmentName!$attachmentName! !|$attachmentName!",
             attachments = listOf(
                 mockAttachment(
                     name = attachmentName,


### PR DESCRIPTION
## Purpose
Previously, the thumbnail module would allow `!` and `\n` to be part of file names. That's obviously not legal

## Approach
Try to understand the regex and put something there that solves the issue

I also removed one case from a test that's actually not illegal.

## Future work

#### Checklist
- [x] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
