### PR TITLE
Fix PrivacyModule not detecting braintree transaction IDs

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/PrivacyModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/PrivacyModule.kt
@@ -17,7 +17,9 @@ class PrivacyModule(
         """.*\(Session ID is token:.*""".toRegex(),
         """.*--accessToken ey.*""".toRegex(),
         """.*(?<![^\s])(?=[^\s]*[A-Z])(?=[^\s]*[0-9])[A-Z0-9]{17}(?![^\s]).*""".toRegex(),
-        """.*\bbraintree:[0-9]{6,7}\b.*""".toRegex(),
+        // At the moment braintree transaction IDs seem to have 8 chars, but to be future-proof
+        // match if there are more chars as well
+        """.*\bbraintree:[a-f0-9]{6,12}\b.*""".toRegex(),
         """.*\b([A-Za-z0-9]{4}-){3}[A-Za-z0-9]{4}\b.*""".toRegex()
     )
 

--- a/src/test/kotlin/io/github/mojira/arisa/modules/PrivacyModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/PrivacyModuleTest.kt
@@ -208,6 +208,20 @@ class PrivacyModuleTest : StringSpec({
         hasSetPrivate shouldBe true
     }
 
+    "should mark as private when the description contains braintree transaction ID" {
+        var hasSetPrivate = false
+
+        val issue = mockIssue(
+            description = "My transaction id: *braintree:1a2b3c4d*",
+            setPrivate = { hasSetPrivate = true }
+        )
+
+        val result = MODULE(issue, TWO_SECONDS_AGO)
+
+        result.shouldBeRight(ModuleResponse)
+        hasSetPrivate shouldBe true
+    }
+
     "should mark as private when the attachment contains Email" {
         var hasSetPrivate = false
 


### PR DESCRIPTION
## Purpose
braintree transaction IDs currently seem to consist of 8 digits or letters, `PrivacyModule`'s regex pattern currently does not detect this.

## Approach
Adjust regex pattern. This should not result in an increase of false positives since the pattern explicitly requires the prefix `braintree:`.

#### Checklist
- [x] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
