### PR TITLE
Redact access tokens in attachments

### DIFF
--- a/config/local.template.yml
+++ b/config/local.template.yml
@@ -7,6 +7,6 @@ arisa:
     # These configs are optional and can be omitted
     dandelionToken: <Dandelion token>
     discordLogWebhook: <Discord log webhook>
-    discordErrorWebhook: <Discord error webhook>
+    discordErrorLogWebhook: <Discord error webhook>
   debug:
     # You can add some debug options here, see `ArisaConfig.kt` for details

--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -229,10 +229,10 @@ Resolves tickets about pirated games as `Invalid`.
 - Any of the description, environment, and/or summary contains any of the `piracySignatures` defined in the [config](../config/config.yml).
 
 ## Privacy
-| Entry | Value                                                                      |
-| ----- | -------------------------------------------------------------------------- |
-| Name  | `Privacy`                                                                  |
-| Class | [Link](../src/main/kotlin/io/github/mojira/arisa/modules/PrivacyModule.kt) |
+| Entry | Value                                                                              |
+| ----- | ---------------------------------------------------------------------------------- |
+| Name  | `Privacy`                                                                          |
+| Class | [Link](../src/main/kotlin/io/github/mojira/arisa/modules/privacy/PrivacyModule.kt) |
 
 Makes tickets and comments, which contain sensitive data like Email addresses, private.
 Additionally in some cases it redacts sensitive data from attachments by deleting the original attachment,

--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -233,12 +233,15 @@ Resolves tickets about pirated games as `Invalid`.
 | Name  | `Privacy`                                                                  |
 | Class | [Link](../src/main/kotlin/io/github/mojira/arisa/modules/PrivacyModule.kt) |
 
-Hides privacy information like Email addresses in tickets or comments.
+Makes tickets and comments, which contain sensitive data like Email addresses, private.
+Additionally in some cases it redacts sensitive data from attachments by deleting the original attachment,
+reuploading it with redacted content and its name prefixed with `redacted_` and adding a comment informing the uploader.
 
 ### Checks
 - The ticket is not set to private.
 #### For Setting Tickets to Private
-- Any of the fields and/or text attachments added after last run contains session ID or Email.
+- Any of the fields and/or text attachments added after last run contains session ID or Email, and for attachments the
+  module was not able to redact sensitive data.
 - Or any of the attachments has a name specified by `sensitiveFileNames` in the [config](../config/config.yml)
   (defaults to empty list)
 #### For Restricting Comments to `staff`

--- a/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ModuleExecutor.kt
@@ -62,6 +62,6 @@ class ModuleExecutor(
         return allIssues
             .filter { it.project.key in projects }
             .filter { it.status.toLowerCase() !in excludedStatuses }
-            .filter { it.resolution?.toLowerCase() ?: "unresolved" in resolutions }
+            .filter { (it.resolution?.toLowerCase() ?: "unresolved") in resolutions }
     }
 }

--- a/src/main/kotlin/io/github/mojira/arisa/domain/Attachment.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/domain/Attachment.kt
@@ -12,4 +12,10 @@ data class Attachment(
     val openContentStream: () -> InputStream,
     val getContent: () -> ByteArray,
     val uploader: User?
-)
+) {
+    /** Returns whether the type of the content is text */
+    fun hasTextContent() = mimeType.startsWith("text/")
+
+    /** Decodes the content as UTF-8 String */
+    fun getTextContent() = String(getContent())
+}

--- a/src/main/kotlin/io/github/mojira/arisa/domain/ChangeLogItem.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/domain/ChangeLogItem.kt
@@ -3,6 +3,10 @@ package io.github.mojira.arisa.domain
 import java.time.Instant
 
 data class ChangeLogItem(
+    /** ID of the enclosing change log entry */
+    val entryId: String,
+    /** 0-based index of this change log item within the enclosing change log entry */
+    val itemIndex: Int,
     val created: Instant,
     val field: String,
     val changedFrom: String?,

--- a/src/main/kotlin/io/github/mojira/arisa/domain/Issue.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/domain/Issue.kt
@@ -50,6 +50,7 @@ data class Issue(
     val addRestrictedComment: (options: CommentOptions) -> Unit,
     val addNotEnglishComment: (language: String) -> Unit,
     val addRawRestrictedComment: (body: String, restriction: String) -> Unit,
+    val addRawBotComment: (rawMessage: String) -> Unit,
     val markAsFixedWithSpecificVersion: (fixVersionName: String) -> Unit,
     val changeReporter: (reporter: String) -> Unit,
     val addAttachment: (file: File, cleanupCallback: () -> Unit) -> Unit

--- a/src/main/kotlin/io/github/mojira/arisa/domain/User.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/domain/User.kt
@@ -4,5 +4,6 @@ data class User(
     val name: String?,
     val displayName: String?,
     val getGroups: () -> List<String>?,
-    val isNewUser: () -> Boolean
+    val isNewUser: () -> Boolean,
+    val isBotUser: () -> Boolean
 )

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/AttachmentUtils.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/AttachmentUtils.kt
@@ -10,8 +10,7 @@ import java.time.Instant
 
 class AttachmentUtils(
     private val crashReportExtensions: List<String>,
-    private val crashReader: CrashReader,
-    private val botUserName: String
+    private val crashReader: CrashReader
 ) {
     private val mappingsDir by lazy {
         val file = File("mc-mappings")
@@ -34,7 +33,7 @@ class AttachmentUtils(
         // Get crashes from issue attachments
         val textDocuments = attachments
             // Ignore attachments from Arisa (e.g. deobfuscated crash reports)
-            .filterNot { it.uploader?.name == botUserName }
+            .filterNot { it.uploader?.isBotUser?.invoke() == true }
 
             // Only check attachments with allowed extensions
             .filter { isCrashAttachment(it.name) }
@@ -58,10 +57,7 @@ class AttachmentUtils(
         crashReportExtensions.any { it == fileName.substring(fileName.lastIndexOf(".") + 1) }
 
     private fun fetchAttachment(attachment: Attachment): TextDocument {
-        val getText = {
-            val data = attachment.getContent()
-            String(data)
-        }
+        val getText = attachment::getTextContent
 
         return TextDocument(getText, attachment.created, attachment.name)
     }

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/HelperMessages.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/HelperMessages.kt
@@ -1,6 +1,7 @@
 package io.github.mojira.arisa.infrastructure
 
 import arrow.core.Either
+import arrow.core.getOrElse
 import arrow.core.left
 import arrow.core.right
 import arrow.core.rightIfNotNull
@@ -119,11 +120,18 @@ object HelperMessageService {
         }
     }
 
+    private const val BOT_SIGNATURE_KEY = "i-am-a-bot"
     fun getMessageWithBotSignature(project: String, key: String, filledText: String? = null, lang: String = "en") =
-        getMessage(project, listOf(key, "i-am-a-bot"), listOf(filledText), lang)
+        getMessage(project, listOf(key, BOT_SIGNATURE_KEY), listOf(filledText), lang)
 
     fun getMessageWithDupeBotSignature(project: String, key: String, filledText: String? = null, lang: String = "en") =
         getMessage(project, listOf(key, "i-am-a-bot-dupe"), listOf(filledText), lang)
+
+    fun getRawMessageWithBotSignature(rawMessage: String): String {
+        // Note: Project does not matter, message is (currently) the same for all projects
+        val botSignature = getSingleMessage("MC", BOT_SIGNATURE_KEY).getOrElse { "" }
+        return "$rawMessage\n$botSignature"
+    }
 
     fun setHelperMessages(json: String) = data.fromJSON(json)
         ?: throw IOException("Couldn't deserialize helper messages from setHelperMessages()")

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
@@ -52,7 +52,7 @@ fun JiraAttachment.toDomain(jiraClient: JiraClient, issue: JiraIssue, config: Co
 )
 
 fun getCreationDate(issue: JiraIssue, id: String, default: Instant) = issue.changeLog.entries
-    .filter { it.items.any { it.field == "Attachment" && it.to == id } }
+    .filter { changeLogEntry -> changeLogEntry.items.any { it.field == "Attachment" && it.to == id } }
     .maxByOrNull { it.created }
     ?.created
     ?.toInstant() ?: default
@@ -221,11 +221,12 @@ fun JiraComment.toDomain(
 fun JiraUser.toDomain(jiraClient: JiraClient, config: Config) = User(
     name, displayName,
     ::getUserGroups.partially1(jiraClient).partially1(name),
-    ::isNewUser.partially1(jiraClient).partially1(name),
+    ::isNewUser.partially1(jiraClient).partially1(name)
+) {
     // Check case insensitively because it apparently does not matter when logging in, so `username` might have
     // incorrect capitalization
-    { name.equals(config[Arisa.Credentials.username], ignoreCase = true) }
-)
+    name.equals(config[Arisa.Credentials.username], ignoreCase = true)
+}
 
 private fun getUserGroups(jiraClient: JiraClient, username: String) = getGroups(
     jiraClient,

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
@@ -204,7 +204,9 @@ fun JiraUser.toDomain(jiraClient: JiraClient, config: Config) = User(
     name, displayName,
     ::getUserGroups.partially1(jiraClient).partially1(name),
     ::isNewUser.partially1(jiraClient).partially1(name),
-    { name == config[Arisa.Credentials.username] }
+    // Check case insensitively because it apparently does not matter when logging in, so `username` might have
+    // incorrect capitalization
+    { name.equals(config[Arisa.Credentials.username], ignoreCase = true) }
 )
 
 private fun getUserGroups(jiraClient: JiraClient, username: String) = getGroups(

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
@@ -257,7 +257,14 @@ fun JiraIssueLink.toDomain(
     ::deleteLink.partially1(issue.getUpdateContext(jiraClient)).partially1(this)
 )
 
-fun JiraChangeLogItem.toDomain(jiraClient: JiraClient, entry: JiraChangeLogEntry, config: Config) = ChangeLogItem(
+fun JiraChangeLogItem.toDomain(
+    jiraClient: JiraClient,
+    entry: JiraChangeLogEntry,
+    itemIndex: Int,
+    config: Config
+) = ChangeLogItem(
+    entry.id,
+    itemIndex,
     entry.created.toInstant(),
     field,
     from,
@@ -290,8 +297,8 @@ private fun JiraIssue.mapFixVersions() =
 
 private fun JiraIssue.getChangeLogEntries(jiraClient: JiraClient, config: Config) =
     changeLog.entries.flatMap { e ->
-        e.items.map { i ->
-            i.toDomain(jiraClient, e, config)
+        e.items.mapIndexed { index, item ->
+            item.toDomain(jiraClient, e, index, config)
         }
     }
 

--- a/src/main/kotlin/io/github/mojira/arisa/modules/AttachmentModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/AttachmentModule.kt
@@ -7,7 +7,10 @@ import io.github.mojira.arisa.domain.Attachment
 import io.github.mojira.arisa.domain.CommentOptions
 import io.github.mojira.arisa.domain.Issue
 import io.github.mojira.arisa.infrastructure.jira.sanitizeCommentArg
+import org.slf4j.LoggerFactory
 import java.time.Instant
+
+private val log = LoggerFactory.getLogger("AttachmentModule")
 
 class AttachmentModule(
     private val extensionBlackList: List<String>,
@@ -17,13 +20,16 @@ class AttachmentModule(
     override fun invoke(issue: Issue, lastRun: Instant): Either<ModuleError, ModuleResponse> = with(issue) {
         Either.fx {
             val endsWithBlacklistedExtensionAdapter = ::endsWithBlacklistedExtensions.partially1(extensionBlackList)
-            val functions = attachments
+            val attachmentsToDelete = attachments
                 .filter { endsWithBlacklistedExtensionAdapter(it.name) }
-            assertNotEmpty(functions).bind()
-            val commentInfo = functions.getCommentInfo()
-            functions
-                .map { it.remove }
-                .forEach { it.invoke() }
+            assertNotEmpty(attachmentsToDelete).bind()
+            val commentInfo = attachmentsToDelete.getCommentInfo()
+
+            val attachmentsString = attachmentsToDelete.joinToString(separator = ", ", transform = Attachment::id)
+            log.info("Deleting attachments of issue $key because they have forbidden extensions: $attachmentsString")
+            attachmentsToDelete
+                .forEach { it.remove() }
+
             addComment(CommentOptions(attachmentRemovedMessage))
             addRawRestrictedComment("Removed attachments:\n$commentInfo", "helper")
         }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/AttachmentRedactor.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/AttachmentRedactor.kt
@@ -1,0 +1,48 @@
+package io.github.mojira.arisa.modules
+
+import io.github.mojira.arisa.domain.Attachment
+
+private const val REDACTED_REPLACEMENT = "###REDACTED###"
+
+/**
+ * Important: Redactor implementations should be as specific as possible. They irrecoverably remove information
+ * from attachments which can only be recovered when the uploader provides the attachment again (in case they
+ * still have the original). Redactors should therefore only remove sensitive data when it is definitely not
+ * needed, such as access tokens in JVM crash reports. A redactor should for example not blindly remove (what it
+ * assumes to be) e-mail addresses from attachments without actually knowing what kind of attachment it is processing.
+ */
+interface AttachmentRedactor {
+    /**
+     * Redacts sensitive data from the attachment content.
+     *
+     * @return
+     *      information about the redacted attachment, or `null`
+     *      if nothing was redacted
+     */
+    fun redact(attachment: Attachment): RedactedAttachment?
+}
+
+/** Redacts access tokens passed as command line argument, as found in JVM crash reports. */
+object AccessTokenRedactor : AttachmentRedactor {
+    // Use lookbehind to only redact the token itself
+    private val pattern = Regex("""(?<=(^|\s)--accessToken )[a-zA-Z0-9.+/=\-_]+(?=(\s|$))""")
+
+    override fun redact(attachment: Attachment): RedactedAttachment? {
+        if (attachment.hasTextContent()) {
+            val original = attachment.getTextContent()
+            val redacted = original.replace(pattern, REDACTED_REPLACEMENT)
+            if (redacted != original) {
+                return RedactedAttachment(attachment, redacted)
+            }
+        }
+
+        return null
+    }
+}
+
+data class RedactedAttachment(
+    /** The original attachment containing sensitive data */
+    val attachment: Attachment,
+    /** Attachment content with sensitive data redacted */
+    val redactedContent: String
+)

--- a/src/main/kotlin/io/github/mojira/arisa/modules/CrashModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/CrashModule.kt
@@ -7,7 +7,6 @@ import arrow.core.left
 import arrow.core.right
 import arrow.syntax.function.partially2
 import com.urielsalis.mccrashlib.Crash
-import com.urielsalis.mccrashlib.CrashReader
 import com.urielsalis.mccrashlib.deobfuscator.getSafeChildPath
 import io.github.mojira.arisa.domain.CommentOptions
 import io.github.mojira.arisa.domain.Issue
@@ -17,17 +16,15 @@ import java.nio.file.Files
 import java.time.Instant
 
 class CrashModule(
-    private val crashReportExtensions: List<String>,
+    private val attachmentUtils: AttachmentUtils,
     private val crashDupeConfigs: List<CrashDupeConfig>,
-    private val crashReader: CrashReader,
     private val dupeMessage: String,
-    private val moddedMessage: String,
-    private val botUserName: String
+    private val moddedMessage: String
 ) : Module {
     override fun invoke(issue: Issue, lastRun: Instant): Either<ModuleError, ModuleResponse> = with(issue) {
         Either.fx {
             // Extract crashes from attachments
-            val crashes = AttachmentUtils(crashReportExtensions, crashReader, botUserName)
+            val crashes = attachmentUtils
                 .extractCrashesFromAttachments(issue)
 
             // Only check crashes added since the last run

--- a/src/main/kotlin/io/github/mojira/arisa/modules/Helpers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/Helpers.kt
@@ -126,10 +126,7 @@ fun String?.getOrDefault(default: String) =
         this
 
 fun String?.getOrDefaultNull(default: String) =
-    if (this == null)
-        default
-    else
-        this
+    this ?: default
 
 fun MutableList<String>.splitElemsByCommas() {
     val newList = this.flatMap { s ->

--- a/src/main/kotlin/io/github/mojira/arisa/modules/KeepPlatformModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/KeepPlatformModule.kt
@@ -64,11 +64,7 @@ class KeepPlatformModule(
             val userChange = firstOrNull {
                 it.created.isAfter(markedTime)
             }
-            if (userChange != null) {
-                userChange.changedFromString.getOrDefault("None")
-            } else {
-                null
-            }
+            userChange?.changedFromString?.getOrDefault("None")
         }
     }
 }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/PrivacyModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/PrivacyModule.kt
@@ -2,15 +2,21 @@ package io.github.mojira.arisa.modules
 
 import arrow.core.Either
 import arrow.core.extensions.fx
-import io.github.mojira.arisa.domain.Attachment
+import com.urielsalis.mccrashlib.deobfuscator.getSafeChildPath
 import io.github.mojira.arisa.domain.CommentOptions
 import io.github.mojira.arisa.domain.Issue
+import io.github.mojira.arisa.infrastructure.jira.sanitizeCommentArg
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
 import java.time.Instant
+
+private val log = LoggerFactory.getLogger("PrivacyModule")
 
 class PrivacyModule(
     private val message: String,
     private val commentNote: String,
     private val allowedEmailsRegex: List<Regex>,
+    private val attachmentRedactor: AttachmentRedactor,
     private val sensitiveFileNames: List<String>
 ) : Module {
     private val patterns: List<Regex> = listOf(
@@ -28,60 +34,32 @@ class PrivacyModule(
         Either.fx {
             assertNull(securityLevel).bind()
 
-            var string = ""
+            val (attachmentContainsSensitiveData, attachmentsToRedact) = checkAttachments(lastRun)
+            val issueContainsSensitiveData = attachmentContainsSensitiveData || containsIssueSensitiveData(lastRun)
 
-            if (created.isAfter(lastRun)) {
-                string += "$summary $environment $description "
-            }
-
-            attachments
-                .asSequence()
-                .filter { it.created.isAfter(lastRun) }
-                .filter { it.mimeType.startsWith("text/") }
-                .forEach { string += "${String(it.getContent())} " }
-
-            changeLog
-                .filter { it.created.isAfter(lastRun) }
-                .filter { it.field != "Attachment" }
-                .filter { it.changedFromString == null }
-                .forEach { string += "${it.changedToString} " }
-
-            val doesStringMatchPatterns = string.matches(patterns)
-            val doesEmailMatches = matchesEmail(string)
-
-            val doesAttachmentNameMatch = attachments
-                .asSequence()
-                .map(Attachment::name)
-                .any(sensitiveFileNames::contains)
-
-            val restrictCommentFunctions = comments
-                .asSequence()
-                .filter { it.created.isAfter(lastRun) }
-                .filter { it.visibilityType == null }
-                .filter { it.body?.matches(patterns) ?: false || matchesEmail(it.body ?: "") }
-                .filterNot {
-                    it.getAuthorGroups()?.any { group ->
-                        listOf("helper", "global-moderators", "staff").contains(group)
-                    } ?: false
-                }
-                .map { { it.restrict("${it.body}$commentNote") } }
-                .toList()
+            val restrictCommentActions = getRestrictCommentActions(lastRun)
 
             assertEither(
-                assertTrue(doesStringMatchPatterns),
-                assertTrue(doesEmailMatches),
-                assertTrue(doesAttachmentNameMatch),
-                assertNotEmpty(restrictCommentFunctions)
+                assertNotEmpty(attachmentsToRedact),
+                assertTrue(issueContainsSensitiveData),
+                assertNotEmpty(restrictCommentActions)
             ).bind()
 
-            if (doesStringMatchPatterns || doesEmailMatches || doesAttachmentNameMatch) {
+            // Always try to redact attachments, even if issue would be made private anyways
+            // So in case issue was made private erroneously it can easily be made public
+            val redactedAll = redactAttachments(issue, attachmentsToRedact)
+
+            if (!redactedAll || issueContainsSensitiveData) {
                 setPrivate()
                 addComment(CommentOptions(message))
             }
 
-            restrictCommentFunctions.forEach { it.invoke() }
+            restrictCommentActions.forEach { it.invoke() }
         }
     }
+
+    private fun containsSensitiveData(string: String) =
+        matchesEmail(string) || patterns.any { it.containsMatchIn(string) }
 
     private fun matchesEmail(string: String): Boolean {
         return emailRegex
@@ -90,5 +68,120 @@ class PrivacyModule(
             .any()
     }
 
-    private fun String.matches(patterns: List<Regex>) = patterns.any { it.containsMatchIn(this) }
+    private data class AttachmentsCheckResult(
+        /** Whether any of the attachments contains sensitive data which cannot be redacted */
+        val attachmentContainsSensitiveData: Boolean,
+        val attachmentsToRedact: List<RedactedAttachment>
+    )
+
+    private fun Issue.checkAttachments(lastRun: Instant): AttachmentsCheckResult {
+        var attachmentContainsSensitiveData: Boolean
+        val newAttachments = attachments.filter { it.created.isAfter(lastRun) }
+
+        attachmentContainsSensitiveData = newAttachments.any {
+            sensitiveFileNames.contains(it.name)
+        }
+
+        val attachmentsToRedact = newAttachments
+            .filter { it.hasTextContent() }
+            .mapNotNull {
+                // Don't redact bot attachments to guard against infinite loop
+                // But still check bot attachments for sensitive data, e.g. when deobfuscated crash report
+                // contains sensitive data
+                val redacted = if (it.uploader?.isBotUser?.invoke() == true) null else attachmentRedactor.redact(it)
+                if (redacted == null) {
+                    // No redaction necessary / possible; check if attachment contains sensitive data
+                    if (!attachmentContainsSensitiveData) {
+                        attachmentContainsSensitiveData = containsSensitiveData(it.getTextContent())
+                    }
+                    return@mapNotNull null
+                } else {
+                    // Check if attachment content still contains sensitive data after redacting
+                    if (containsSensitiveData(redacted.redactedContent)) {
+                        attachmentContainsSensitiveData = true
+                        return@mapNotNull null
+                    }
+                    return@mapNotNull redacted
+                }
+            }
+
+        return AttachmentsCheckResult(attachmentContainsSensitiveData, attachmentsToRedact)
+    }
+
+    private fun Issue.containsIssueSensitiveData(lastRun: Instant): Boolean {
+        if (created.isAfter(lastRun) && containsSensitiveData("$summary $environment $description")) {
+            return true
+        }
+
+        return changeLog
+            .asSequence()
+            .filter { it.created.isAfter(lastRun) }
+            .filter { it.field != "Attachment" }
+            .filter { it.changedFromString == null }
+            .mapNotNull { it.changedToString }
+            .any(::containsSensitiveData)
+    }
+
+    private fun Issue.getRestrictCommentActions(lastRun: Instant) = comments
+        .asSequence()
+        .filter { it.created.isAfter(lastRun) }
+        .filter { it.visibilityType == null }
+        .filter { it.body?.let(::containsSensitiveData) ?: false }
+        .filterNot {
+            it.getAuthorGroups()?.any { group ->
+                listOf("helper", "global-moderators", "staff").contains(group)
+            } ?: false
+        }
+        .map { { it.restrict("${it.body}$commentNote") } }
+        .toList()
+
+    private fun redactAttachments(issue: Issue, attachments: Collection<RedactedAttachment>): Boolean {
+        var redactedAll = true
+        attachments
+            // Group by uploader in case they uploaded multiple attachments at once
+            .groupBy { it.attachment.uploader?.name!! }
+            .forEach { (uploader, userAttachments) ->
+                val fileNames = mutableSetOf<String>()
+                userAttachments.forEach {
+                    val attachment = it.attachment
+                    val tempDir = Files.createTempDirectory("arisa-redaction-upload").toFile()
+                    val fileName = "redacted_${attachment.name}"
+                    val filePath = getSafeChildPath(tempDir, fileName)
+
+                    if (filePath == null || !fileNames.add(fileName)) {
+                        redactedAll = false
+                        // Note: Don't log file name to avoid log injection
+                        log.warn("Attachment with ID ${attachment.id} of issue ${issue.key} has malformed or " +
+                            "duplicate file name")
+                        tempDir.delete()
+                    } else {
+                        filePath.writeText(it.redactedContent)
+                        issue.addAttachment(filePath) {
+                            // Once uploaded, delete the temp directory containing the attachment
+                            tempDir.deleteRecursively()
+                        }
+                        // Remove the original attachment
+                        log.info("Deleting attachment with ID ${attachment.id} of issue ${issue.key} because it " +
+                            "contains sensitive data")
+                        attachment.remove()
+                    }
+                }
+
+                if (fileNames.isNotEmpty()) {
+                    val fileNamesString = fileNames.joinToString(separator = "") {
+                        // Use link for attachments
+                        "\n- [^${sanitizeCommentArg(it)}]"
+                    }
+                    val sanitizedUploaderName = sanitizeCommentArg(uploader)
+                    // Does not use helper message because message will only be used by bot and helper messages
+                    // currently only support one placeholder
+                    issue.addRawBotComment(
+                        "@[~$sanitizedUploaderName], sensitive data has been removed from your " +
+                            "attachment(s) and they have been re-uploaded as:$fileNamesString"
+                    )
+                }
+            }
+
+        return redactedAll
+    }
 }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModule.kt
@@ -17,8 +17,8 @@ import java.time.temporal.ChronoUnit
 const val TWO_SECONDS_IN_MILLIS = 2000
 
 class ReopenAwaitingModule(
-    private val blacklistedRoles: List<String>,
-    private val blacklistedVisibilities: List<String>,
+    private val blacklistedRoles: Set<String>,
+    private val blacklistedVisibilities: Set<String>,
     private val softArPeriod: Long,
     private val keepARTag: String,
     private val onlyOPTag: String,

--- a/src/main/kotlin/io/github/mojira/arisa/modules/ReplaceTextModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ReplaceTextModule.kt
@@ -2,7 +2,6 @@ package io.github.mojira.arisa.modules
 
 import arrow.core.Either
 import arrow.core.extensions.fx
-import io.github.mojira.arisa.domain.Comment
 import io.github.mojira.arisa.domain.Issue
 import java.time.Instant
 
@@ -15,13 +14,6 @@ class ReplaceTextModule(
         "(http://i.imgur.com)".toRegex() to "https://i.imgur.com"
     )
 ) : Module {
-    data class Request(
-        val lastRun: Instant,
-        val description: String?,
-        val comments: List<Comment>,
-        val updateDescription: (description: String) -> Either<Throwable, Unit>
-    )
-
     override fun invoke(issue: Issue, lastRun: Instant): Either<ModuleError, ModuleResponse> = with(issue) {
         Either.fx {
             val needUpdateDescription = created.isAfter(lastRun) &&
@@ -52,7 +44,6 @@ class ReplaceTextModule(
     private fun needReplacement(text: String?) = replacements.any { (regex, _) -> text?.contains(regex) ?: false }
 
     private fun replace(text: String): String = replacements.fold(
-        text,
-        { str, (regex, replacement) -> str.replace(regex, replacement) }
-    )
+        text
+    ) { str, (regex, replacement) -> str.replace(regex, replacement) }
 }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/DeobfuscateCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/DeobfuscateCommand.kt
@@ -33,8 +33,7 @@ class DeobfuscateCommand(private val attachmentUtils: AttachmentUtils) {
             throw CommandExceptions.ATTACHMENT_ALREADY_EXISTS.create(deobfuscatedName)
         }
 
-        @Suppress("VariableNaming")
-        var minecraftVersionId_ = minecraftVersionId
+        var resolvedMinecraftVersionId = minecraftVersionId
         var isClientCrash = when (crashReportType) {
             CrashReportType.CLIENT -> true
             CrashReportType.SERVER -> false
@@ -42,13 +41,13 @@ class DeobfuscateCommand(private val attachmentUtils: AttachmentUtils) {
         }
 
         // If version or crash report type are not specified try to obtain them from crash report
-        if (minecraftVersionId_ == null || isClientCrash == null) {
+        if (resolvedMinecraftVersionId == null || isClientCrash == null) {
             val parsedCrashReport = attachmentUtils.processCrash(attachmentUtils.fetchAttachment(attachment))
                 ?.crash as? Crash.Minecraft
                 ?: throw MISSING_DEOBFUSCATION_ARGUMENTS.create()
 
-            if (minecraftVersionId_ == null) {
-                minecraftVersionId_ = parsedCrashReport.minecraftVersion
+            if (resolvedMinecraftVersionId == null) {
+                resolvedMinecraftVersionId = parsedCrashReport.minecraftVersion
                     ?: throw MISSING_DEOBFUSCATION_ARGUMENTS.create()
             }
             if (isClientCrash == null) {
@@ -59,7 +58,7 @@ class DeobfuscateCommand(private val attachmentUtils: AttachmentUtils) {
         val deobfuscated = try {
             attachmentUtils.deobfuscate(
                 String(attachment.getContent()),
-                minecraftVersionId_,
+                resolvedMinecraftVersionId,
                 isClientCrash
             )
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {

--- a/src/main/kotlin/io/github/mojira/arisa/modules/privacy/AttachmentRedactor.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/privacy/AttachmentRedactor.kt
@@ -1,4 +1,4 @@
-package io.github.mojira.arisa.modules
+package io.github.mojira.arisa.modules.privacy
 
 import io.github.mojira.arisa.domain.Attachment
 

--- a/src/main/kotlin/io/github/mojira/arisa/modules/privacy/TextRangeLocation.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/privacy/TextRangeLocation.kt
@@ -1,0 +1,84 @@
+package io.github.mojira.arisa.modules.privacy
+
+data class TextRangeLocation(
+    private val completeText: String,
+    /** Global start index, beginning at 0 */
+    private val startIndex: Int,
+    /** Global end index (inclusive), beginning at 0 */
+    private val endIndex: Int
+) {
+    companion object {
+        fun fromMatchResult(completeText: String, matchResult: MatchResult): TextRangeLocation {
+            val range = matchResult.range
+            return TextRangeLocation(completeText, range.first, range.last)
+        }
+    }
+
+    private fun getIndexBehindNextLineTerminator(string: String, startIndex: Int): Int? {
+        val nextLfIndex = string.indexOf('\n', startIndex)
+        val nextCrIndex = string.indexOf('\r', startIndex)
+
+        return (
+            if (nextLfIndex != -1 && (nextCrIndex == -1 || nextLfIndex < nextCrIndex)) {
+                // LF
+                nextLfIndex + 1
+            } else if (nextCrIndex != -1) {
+                if (nextLfIndex == nextCrIndex + 1) {
+                    // CR LF
+                    nextLfIndex + 1
+                } else {
+                    // CR
+                    nextCrIndex + 1
+                }
+            } else {
+                null
+            }
+        )
+    }
+
+    fun getLocationDescription(): String {
+        var currentLineStartIndex = 0
+        // Start line numbering at 1
+        var lineNumber = 1
+
+        var startLine: Int? = null
+        var relativeStartIndex = 0
+        var endLine: Int? = null
+        var relativeEndIndex = 0
+
+        @Suppress("LoopWithTooManyJumpStatements")
+        while (true) {
+            val previousLineStartIndex = currentLineStartIndex
+            currentLineStartIndex = getIndexBehindNextLineTerminator(completeText, previousLineStartIndex)
+                ?: break // reached end of last line
+
+            if (startIndex in previousLineStartIndex until currentLineStartIndex) {
+                startLine = lineNumber
+                relativeStartIndex = startIndex - previousLineStartIndex
+            }
+            if (endIndex in previousLineStartIndex until currentLineStartIndex) {
+                endLine = lineNumber
+                relativeEndIndex = endIndex - previousLineStartIndex
+            }
+
+            // Found both line numbers, can stop iteration
+            if (startLine != null && endLine != null) {
+                break
+            }
+
+            lineNumber++
+        }
+
+        // If startLine or endLine are still null they are in the last line
+        if (startLine == null) {
+            startLine = lineNumber
+            relativeStartIndex = startIndex - currentLineStartIndex
+        }
+        if (endLine == null) {
+            endLine = lineNumber
+            relativeEndIndex = endIndex - currentLineStartIndex
+        }
+
+        return "$startIndex - $endIndex ($startLine:$relativeStartIndex - $endLine:$relativeEndIndex)"
+    }
+}

--- a/src/main/kotlin/io/github/mojira/arisa/modules/privacy/TextRangeLocation.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/privacy/TextRangeLocation.kt
@@ -47,7 +47,7 @@ data class TextRangeLocation(
         var relativeEndIndex = 0
 
         @Suppress("LoopWithTooManyJumpStatements")
-        while (true) {
+        while (currentLineStartIndex < completeText.length) {
             val previousLineStartIndex = currentLineStartIndex
             currentLineStartIndex = getIndexBehindNextLineTerminator(completeText, previousLineStartIndex)
                 ?: break // reached end of last line

--- a/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
@@ -195,8 +195,8 @@ class InstantModuleRegistry(config: Config) : ModuleRegistry(config) {
         register(
             Arisa.Modules.ReopenAwaiting,
             ReopenAwaitingModule(
-                config[Arisa.Modules.ReopenAwaiting.blacklistedRoles],
-                config[Arisa.Modules.ReopenAwaiting.blacklistedVisibilities],
+                config[Arisa.Modules.ReopenAwaiting.blacklistedRoles].toSetNoDuplicates(),
+                config[Arisa.Modules.ReopenAwaiting.blacklistedVisibilities].toSetNoDuplicates(),
                 config[Arisa.Modules.ReopenAwaiting.softARDays],
                 config[Arisa.Modules.ReopenAwaiting.keepARTag],
                 config[Arisa.Modules.ReopenAwaiting.onlyOPTag],
@@ -251,5 +251,21 @@ class InstantModuleRegistry(config: Config) : ModuleRegistry(config) {
                 config[Arisa.Modules.RemoveBotComment.removalTag]
             )
         )
+    }
+
+    private fun <T> List<T>.toSetNoDuplicates(): Set<T> {
+        val result = toMutableSet()
+        if (result.size != size) {
+            val duplicates = mutableSetOf<T>()
+            for (element in this) {
+                // If removal fails it is a duplicate element because it has already been removed
+                if (!result.remove(element)) {
+                    duplicates.add(element)
+                }
+            }
+            throw IllegalArgumentException("Contains these duplicate elements: $duplicates")
+        }
+
+        return result
     }
 }

--- a/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
@@ -6,7 +6,7 @@ import io.github.mojira.arisa.ExecutionTimeframe
 import io.github.mojira.arisa.infrastructure.AttachmentUtils
 import io.github.mojira.arisa.infrastructure.LanguageDetectionApi
 import io.github.mojira.arisa.infrastructure.config.Arisa
-import io.github.mojira.arisa.modules.AccessTokenRedactor
+import io.github.mojira.arisa.modules.privacy.AccessTokenRedactor
 import io.github.mojira.arisa.modules.AffectedVersionMessageModule
 import io.github.mojira.arisa.modules.AttachmentModule
 import io.github.mojira.arisa.modules.CHKModule
@@ -21,7 +21,7 @@ import io.github.mojira.arisa.modules.KeepPrivateModule
 import io.github.mojira.arisa.modules.LanguageModule
 import io.github.mojira.arisa.modules.MultiplePlatformsModule
 import io.github.mojira.arisa.modules.PiracyModule
-import io.github.mojira.arisa.modules.PrivacyModule
+import io.github.mojira.arisa.modules.privacy.PrivacyModule
 import io.github.mojira.arisa.modules.PrivateDuplicateModule
 import io.github.mojira.arisa.modules.RemoveIdenticalLinkModule
 import io.github.mojira.arisa.modules.RemoveNonStaffTagsModule

--- a/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
@@ -3,8 +3,10 @@ package io.github.mojira.arisa.registry
 import com.uchuhimo.konf.Config
 import com.urielsalis.mccrashlib.CrashReader
 import io.github.mojira.arisa.ExecutionTimeframe
+import io.github.mojira.arisa.infrastructure.AttachmentUtils
 import io.github.mojira.arisa.infrastructure.LanguageDetectionApi
 import io.github.mojira.arisa.infrastructure.config.Arisa
+import io.github.mojira.arisa.modules.AccessTokenRedactor
 import io.github.mojira.arisa.modules.AffectedVersionMessageModule
 import io.github.mojira.arisa.modules.AttachmentModule
 import io.github.mojira.arisa.modules.CHKModule
@@ -87,15 +89,14 @@ class InstantModuleRegistry(config: Config) : ModuleRegistry(config) {
             )
         )
 
+        val attachmentUtils = AttachmentUtils(config[Arisa.Modules.Crash.crashExtensions], CrashReader())
         register(
             Arisa.Modules.Crash,
             CrashModule(
-                config[Arisa.Modules.Crash.crashExtensions],
+                attachmentUtils,
                 config[Arisa.Modules.Crash.duplicates],
-                CrashReader(),
                 config[Arisa.Modules.Crash.duplicateMessage],
-                config[Arisa.Modules.Crash.moddedMessage],
-                config[Arisa.Credentials.username]
+                config[Arisa.Modules.Crash.moddedMessage]
             )
         )
 
@@ -151,6 +152,7 @@ class InstantModuleRegistry(config: Config) : ModuleRegistry(config) {
                 config[Arisa.Modules.Privacy.message],
                 config[Arisa.Modules.Privacy.commentNote],
                 config[Arisa.Modules.Privacy.allowedEmailRegex].map(String::toRegex),
+                AccessTokenRedactor,
                 config[Arisa.Modules.Privacy.sensitiveFileNames]
             )
         )

--- a/src/test/kotlin/io/github/mojira/arisa/infrastructure/HelperMessagesTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/infrastructure/HelperMessagesTest.kt
@@ -246,4 +246,10 @@ class HelperMessagesTest : StringSpec({
 
         result shouldBe "Normal message\n~{color:#888}-- I am a bot.{color}~"
     }
+
+    "should append the bot signature to raw message correctly" {
+        val result = HelperMessageService.getRawMessageWithBotSignature("some message")
+
+        result shouldBe "some message\n~{color:#888}-- I am a bot.{color}~"
+    }
 })

--- a/src/test/kotlin/io/github/mojira/arisa/modules/AccessTokenRedactorTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/AccessTokenRedactorTest.kt
@@ -1,0 +1,33 @@
+package io.github.mojira.arisa.modules
+
+import io.github.mojira.arisa.utils.mockAttachment
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+
+class AccessTokenRedactorTest : StringSpec({
+    "AccessTokenRedactor should return null if nothing to redact" {
+        val attachment = mockAttachment(
+            mimeType = "text/plain",
+            getContent = { "some text".toByteArray() }
+        )
+        val redactedAttachment = AccessTokenRedactor.redact(attachment)
+        redactedAttachment.shouldBeNull()
+    }
+
+    "AccessTokenRedactor should redact access token" {
+        val attachment = mockAttachment(
+            mimeType = "text/plain",
+            getContent = {
+                // Example JWT token from https://jwt.io/
+                ("some text --accessToken eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6" +
+                    "IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c more text"
+                ).toByteArray()
+            }
+        )
+        val redactedAttachment = AccessTokenRedactor.redact(attachment)
+        redactedAttachment!!.attachment shouldBeSameInstanceAs attachment
+        redactedAttachment.redactedContent shouldBe "some text --accessToken ###REDACTED### more text"
+    }
+})

--- a/src/test/kotlin/io/github/mojira/arisa/modules/CrashModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/CrashModuleTest.kt
@@ -273,8 +273,6 @@ private val A_MINUTE_AGO = NOW.minusSeconds(60)
 private const val UNCONFIRMED = "Unconfirmed"
 private val NO_PRIORITY = null
 
-private const val BOT_USER_NAME = "testBot"
-
 class CrashModuleTest : StringSpec({
     val crashReader = CrashReader()
     val attachmentUtils = AttachmentUtils(listOf("txt"), crashReader)

--- a/src/test/kotlin/io/github/mojira/arisa/modules/CrashModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/CrashModuleTest.kt
@@ -3,6 +3,7 @@ package io.github.mojira.arisa.modules
 import arrow.core.right
 import com.urielsalis.mccrashlib.CrashReader
 import io.github.mojira.arisa.domain.CommentOptions
+import io.github.mojira.arisa.infrastructure.AttachmentUtils
 import io.github.mojira.arisa.infrastructure.config.CrashDupeConfig
 import io.github.mojira.arisa.utils.mockAttachment
 import io.github.mojira.arisa.utils.mockIssue
@@ -246,18 +247,15 @@ private const val UNCONFIRMED = "Unconfirmed"
 private val NO_PRIORITY = null
 
 private val crashReader = CrashReader()
-
-private const val BOT_USER_NAME = "testBot"
+private val attachmentUtils = AttachmentUtils(listOf("txt"), crashReader)
 
 class CrashModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse when issue does not contain any valid crash report" {
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             listOf(CrashDupeConfig("minecraft", "Pixel format not accelerated", "MC-297")),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
         val issue = mockIssue(
             attachments = emptyList(),
@@ -278,12 +276,10 @@ class CrashModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when issue body does not contain any recent crash" {
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             listOf(CrashDupeConfig("minecraft", "Pixel format not accelerated", "MC-297")),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
 
         val issue = mockIssue(
@@ -305,12 +301,10 @@ class CrashModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when crash configurations are empty and report is not modded" {
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             emptyList(),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
         val issue = mockIssue(
             attachments = emptyList(),
@@ -331,12 +325,10 @@ class CrashModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when crash configuration has an invalid type and crash is not modded" {
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             listOf(CrashDupeConfig("hytale", "The game has not yet been released", "HT-1")),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
 
         val issue = mockIssue(
@@ -358,12 +350,10 @@ class CrashModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when reported crash is not configured and not modded" {
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             listOf(CrashDupeConfig("minecraft", "Unexpected loophole in Redstone implementation", "MC-108")),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
 
         val issue = mockIssue(
@@ -385,12 +375,10 @@ class CrashModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when issue does not contain any recent crash as attachment" {
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             listOf(CrashDupeConfig("minecraft", "Pixel format not accelerated", "MC-297")),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
 
         val attachment = getAttachment(
@@ -416,12 +404,10 @@ class CrashModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when attached crash is not configured and not modded" {
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             listOf(CrashDupeConfig("minecraft", "Unexpected loophole in Redstone implementation", "MC-108")),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
 
         val attachment = getAttachment(
@@ -446,12 +432,10 @@ class CrashModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when attached crash does have a wrong mime type" {
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             listOf(CrashDupeConfig("minecraft", "Pixel format not accelerated", "MC-297")),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
 
         val attachment = getAttachment(
@@ -477,12 +461,10 @@ class CrashModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when attached crash is not modded (Unknown)" {
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             listOf(),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
 
         val attachment = getAttachment(
@@ -507,12 +489,10 @@ class CrashModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when there is both a modded crash and an unmodded one" {
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             listOf(CrashDupeConfig("minecraft", "Pixel format not accelerated", "MC-297")),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
 
         val moddedCrash = getAttachment(
@@ -541,12 +521,10 @@ class CrashModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when there is both a duped crash and one that should not get resolved" {
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             listOf(CrashDupeConfig("minecraft", "Pixel format not accelerated", "MC-297")),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
         val pixelFormatCrash = getAttachment(
             content = PIXEL_FORMAT_CRASH
@@ -579,12 +557,10 @@ class CrashModuleTest : StringSpec({
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             emptyList(),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
         val issue = mockIssue(
             attachments = emptyList(),
@@ -617,12 +593,10 @@ class CrashModuleTest : StringSpec({
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             emptyList(),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
         val issue = mockIssue(
             attachments = emptyList(),
@@ -655,12 +629,10 @@ class CrashModuleTest : StringSpec({
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             emptyList(),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
         val issue = mockIssue(
             attachments = emptyList(),
@@ -693,12 +665,10 @@ class CrashModuleTest : StringSpec({
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             emptyList(),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
 
         val attachment = getAttachment(
@@ -735,12 +705,10 @@ class CrashModuleTest : StringSpec({
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             listOf(CrashDupeConfig("minecraft", "Pixel format not accelerated", "MC-297")),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
         val issue = mockIssue(
             attachments = emptyList(),
@@ -773,12 +741,10 @@ class CrashModuleTest : StringSpec({
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             listOf(CrashDupeConfig("minecraft", "Pixel format not accelerated", "MC-297")),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
 
         val attachment = getAttachment(
@@ -815,12 +781,10 @@ class CrashModuleTest : StringSpec({
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             listOf(CrashDupeConfig("java", "ig75icd64\\.dll", "MC-32606")),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
         val issue = mockIssue(
             attachments = emptyList(),
@@ -852,12 +816,10 @@ class CrashModuleTest : StringSpec({
         var addedAttachment = false
 
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             listOf(CrashDupeConfig("java", "ig75icd64\\.dll", "MC-32606")),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
         val issue = mockIssue(
             attachments = listOf(getAttachment(OBFUSCATED_CRASH)),
@@ -888,12 +850,10 @@ class CrashModuleTest : StringSpec({
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             listOf(CrashDupeConfig("java", "ig[0-9]{1,2}icd[0-9]{2}\\.dll", "MC-32606")),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
         val issue = mockIssue(
             attachments = emptyList(),
@@ -926,12 +886,10 @@ class CrashModuleTest : StringSpec({
         var isLinked = false
 
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             listOf(CrashDupeConfig("minecraft", "Pixel format not accelerated", "MC-297")),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
         val issue = mockIssue(
             attachments = emptyList(),
@@ -968,12 +926,10 @@ class CrashModuleTest : StringSpec({
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             listOf(CrashDupeConfig("minecraft", "Pixel format not accelerated", "MC-297")),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
         val modded = getAttachment(
             name = "crash_modded.txt",
@@ -1015,12 +971,10 @@ class CrashModuleTest : StringSpec({
         var addedComment = CommentOptions("")
 
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             listOf(CrashDupeConfig("minecraft", "Pixel format not accelerated", "MC-297")),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
         val modded = getAttachment(
             name = "crash_modded.txt",
@@ -1062,15 +1016,13 @@ class CrashModuleTest : StringSpec({
         var isLinked = false
 
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             listOf(
                 CrashDupeConfig("minecraft", "Pixel format not accelerated", "MC-297"),
                 CrashDupeConfig("minecraft", "WGL: The driver does not appear to support OpenGL", "MC-128302")
             ),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
 
         val fromNow = getAttachment(
@@ -1118,15 +1070,13 @@ class CrashModuleTest : StringSpec({
         var isLinked = false
 
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             listOf(
                 CrashDupeConfig("minecraft", "Pixel format not accelerated", "MC-297"),
                 CrashDupeConfig("minecraft", "WGL: The driver does not appear to support OpenGL", "MC-128302")
             ),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
 
         val fromNow = getAttachment(
@@ -1172,12 +1122,10 @@ class CrashModuleTest : StringSpec({
         var resolvedAsInvalid = false
 
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             listOf(CrashDupeConfig("minecraft", "Pixel format not accelerated", "MC-297")),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
         val issue = mockIssue(
             attachments = emptyList(),
@@ -1203,12 +1151,10 @@ class CrashModuleTest : StringSpec({
         var resolvedAsInvalid = false
 
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             listOf(CrashDupeConfig("minecraft", "Pixel format not accelerated", "MC-297")),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
         val issue = mockIssue(
             attachments = emptyList(),
@@ -1235,17 +1181,15 @@ class CrashModuleTest : StringSpec({
         var addedAttachment = false
 
         val module = CrashModule(
-            listOf("txt"),
+            attachmentUtils,
             listOf(CrashDupeConfig("minecraft", "Pixel format not accelerated", "MC-297")),
-            crashReader,
             "duplicate-tech",
-            "modified-game",
-            BOT_USER_NAME
+            "modified-game"
         )
         val issue = mockIssue(
             attachments = listOf(
                 getAttachment(OBFUSCATED_CRASH, "obfuscated.txt", A_MINUTE_AGO),
-                getAttachment(OBFUSCATED_CRASH, "deobf_obfuscated.txt", A_SECOND_AGO, uploader = BOT_USER_NAME)
+                getAttachment(OBFUSCATED_CRASH, "deobf_obfuscated.txt", A_SECOND_AGO, isUploadedByBot = true)
             ),
             description = "hello please verify my crash thanks",
             created = A_MINUTE_AGO,
@@ -1275,11 +1219,15 @@ private fun getAttachment(
     name: String = "crash.txt",
     created: Instant = NOW,
     remove: () -> Unit = { },
-    uploader: String = "someRandomUser"
+    uploader: String = "someRandomUser",
+    isUploadedByBot: Boolean = false
 ) = mockAttachment(
     name = name,
     created = created,
     remove = remove,
     getContent = { content.toByteArray() },
-    uploader = mockUser(uploader)
+    uploader = mockUser(
+        name = uploader,
+        isBotUser = { isUploadedByBot }
+    )
 )

--- a/src/test/kotlin/io/github/mojira/arisa/modules/PrivacyModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/PrivacyModuleTest.kt
@@ -1,19 +1,37 @@
 package io.github.mojira.arisa.modules
 
+import io.github.mojira.arisa.domain.Attachment
+import io.github.mojira.arisa.domain.CommentOptions
 import io.github.mojira.arisa.utils.RIGHT_NOW
 import io.github.mojira.arisa.utils.mockAttachment
 import io.github.mojira.arisa.utils.mockChangeLogItem
 import io.github.mojira.arisa.utils.mockComment
 import io.github.mojira.arisa.utils.mockIssue
+import io.github.mojira.arisa.utils.mockUser
 import io.kotest.assertions.arrow.either.shouldBeLeft
 import io.kotest.assertions.arrow.either.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 
 private val ALLOWED_REGEX = listOf("allowed@.*".toRegex())
-private val MODULE = PrivacyModule("message", "\n----\nRestricted by PrivacyModule ??[~arisabot]??", ALLOWED_REGEX, emptyList())
+private val NOOP_REDACTOR = object : AttachmentRedactor {
+    override fun redact(attachment: Attachment): RedactedAttachment? {
+        return null
+    }
+}
+private val MODULE = PrivacyModule(
+    "message",
+    "\n----\nRestricted by PrivacyModule ??[~arisabot]??",
+    ALLOWED_REGEX,
+    NOOP_REDACTOR,
+    emptyList()
+)
 private val TWO_SECONDS_AGO = RIGHT_NOW.minusSeconds(2)
 private val TEN_SECONDS_AGO = RIGHT_NOW.minusSeconds(10)
+
+// Example JWT token from https://jwt.io/
+private const val EXAMPLE_JWT_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
 
 class PrivacyModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse when the ticket is marked as private" {
@@ -282,7 +300,7 @@ class PrivacyModuleTest : StringSpec({
         hasSetPrivate shouldBe true
     }
 
-    "should mark as private when the attachment contains access token" {
+    "should mark as private when the attachment contains access token and no redactor is used" {
         var hasSetPrivate = false
 
         val issue = mockIssue(
@@ -386,7 +404,7 @@ class PrivacyModuleTest : StringSpec({
 
     "should mark as private when attachment has sensitive name" {
         val sensitiveFileName = "sensitive.txt"
-        val module = PrivacyModule("message", "comment", ALLOWED_REGEX, listOf(sensitiveFileName))
+        val module = PrivacyModule("message", "comment", ALLOWED_REGEX, NOOP_REDACTOR, listOf(sensitiveFileName))
         var hasSetPrivate = false
 
         val issue = mockIssue(
@@ -406,7 +424,7 @@ class PrivacyModuleTest : StringSpec({
 
     "should not mark as private when attachment has non-sensitive name" {
         val sensitiveFileName = "sensitive.txt"
-        val module = PrivacyModule("message", "comment", ALLOWED_REGEX, listOf(sensitiveFileName))
+        val module = PrivacyModule("message", "comment", ALLOWED_REGEX, NOOP_REDACTOR, listOf(sensitiveFileName))
         var hasSetPrivate = false
 
         val issue = mockIssue(
@@ -422,5 +440,245 @@ class PrivacyModuleTest : StringSpec({
 
         result.shouldBeLeft(OperationNotNeededModuleResponse)
         hasSetPrivate shouldBe false
+    }
+
+    "should redact access tokens" {
+        val module = PrivacyModule("message", "comment", ALLOWED_REGEX, AccessTokenRedactor, emptyList())
+        val uploader = "some-\n-user"
+        val attachmentName = "my-\u202E-attachment.txt"
+
+        var hasSetPrivate = false
+        var hasDeletedAttachment = false
+        var newAttachmentName: String? = null
+        var newAttachmentContent: String? = null
+        var addedComment: String? = null
+
+        val issue = mockIssue(
+            attachments = listOf(
+                mockAttachment(
+                    name = attachmentName,
+                    uploader = mockUser(
+                        name = uploader
+                    ),
+                    getContent = { "... --accessToken $EXAMPLE_JWT_TOKEN ...".toByteArray() },
+                    remove = { hasDeletedAttachment = true }
+                )
+            ),
+            setPrivate = { hasSetPrivate = true },
+            addAttachment = { file, cleanupCallback ->
+                newAttachmentName = file.name
+                newAttachmentContent = file.readText()
+                cleanupCallback()
+            },
+            addRawBotComment = { addedComment = it }
+        )
+
+        val result = module(issue, TWO_SECONDS_AGO)
+        result.shouldBeRight(ModuleResponse)
+
+        // Attachment was redacted; issue should not have been made private
+        hasSetPrivate shouldBe false
+        hasDeletedAttachment shouldBe true
+        newAttachmentName shouldBe "redacted_$attachmentName"
+        newAttachmentContent shouldBe "... --accessToken ###REDACTED### ..."
+
+        // Should also have sanitized user name and attachment name
+        addedComment shouldBe "@[~some-?-user], sensitive data has been removed from your attachment(s) and they have " +
+            "been re-uploaded as:\n" +
+            "- [^redacted_my-?-attachment.txt]"
+    }
+
+    "should add multiple comments when redacting attachments of multiple users" {
+        val module = PrivacyModule("message", "comment", ALLOWED_REGEX, AccessTokenRedactor, emptyList())
+        val uploader1 = "some-user"
+        val uploader1User = mockUser(
+            name = uploader1
+        )
+        val attachmentName1_1 = "my-attachment.txt"
+        val attachmentName1_2 = "my-attachment2.txt"
+
+        val uploader2 = "some-other-user"
+        val attachmentName2 = "other-attachment.txt"
+
+        var hasSetPrivate = false
+        val deletedAttachmentNames = mutableListOf<String>()
+        val newAttachmentNames = mutableListOf<String>()
+        val addedComments = mutableListOf<String>()
+
+        val issue = mockIssue(
+            attachments = listOf(
+                mockAttachment(
+                    name = attachmentName1_1,
+                    uploader = uploader1User,
+                    getContent = { "... --accessToken $EXAMPLE_JWT_TOKEN ...".toByteArray() },
+                    remove = { deletedAttachmentNames.add(attachmentName1_1) }
+                ),
+                mockAttachment(
+                    name = attachmentName1_2,
+                    uploader = uploader1User,
+                    getContent = { "... --accessToken $EXAMPLE_JWT_TOKEN ...".toByteArray() },
+                    remove = { deletedAttachmentNames.add(attachmentName1_2) }
+                ),
+                mockAttachment(
+                    name = attachmentName2,
+                    uploader = mockUser(name = uploader2),
+                    getContent = { "... --accessToken $EXAMPLE_JWT_TOKEN ...".toByteArray() },
+                    remove = { deletedAttachmentNames.add(attachmentName2) }
+                )
+            ),
+            setPrivate = { hasSetPrivate = true },
+            addAttachment = { file, cleanupCallback ->
+                newAttachmentNames.add(file.name)
+                cleanupCallback()
+            },
+            addRawBotComment = { addedComments.add(it) }
+        )
+
+        val result = module(issue, TWO_SECONDS_AGO)
+        result.shouldBeRight(ModuleResponse)
+
+        // Attachment was redacted; issue should not have been made private
+        hasSetPrivate shouldBe false
+        val expectedDeletedAttachmentNames = listOf(attachmentName1_1, attachmentName1_2, attachmentName2)
+        deletedAttachmentNames shouldContainExactlyInAnyOrder expectedDeletedAttachmentNames
+        newAttachmentNames shouldContainExactlyInAnyOrder expectedDeletedAttachmentNames.map { "redacted_$it" }
+
+        addedComments shouldContainExactlyInAnyOrder listOf(
+            "@[~some-user], sensitive data has been removed from your attachment(s) and they " +
+                "have been re-uploaded as:\n" +
+                "- [^redacted_my-attachment.txt]\n" +
+                "- [^redacted_my-attachment2.txt]",
+            "@[~some-other-user], sensitive data has been removed from your attachment(s) " +
+                "and they have been re-uploaded as:\n" +
+                "- [^redacted_other-attachment.txt]"
+        )
+    }
+
+    "should not redact bot attachments" {
+        val module = PrivacyModule("message", "comment", ALLOWED_REGEX, AccessTokenRedactor, emptyList())
+        var hasSetPrivate = false
+        var hasDeletedAttachment = false
+
+        val issue = mockIssue(
+            attachments = listOf(
+                mockAttachment(
+                    uploader = mockUser(
+                        isBotUser = { true }
+                    ),
+                    getContent = { "... --accessToken $EXAMPLE_JWT_TOKEN ...".toByteArray() },
+                    remove = { hasDeletedAttachment = true }
+                )
+            ),
+            setPrivate = { hasSetPrivate = true }
+        )
+
+        val result = module(issue, TWO_SECONDS_AGO)
+        result.shouldBeRight(ModuleResponse)
+
+        hasSetPrivate shouldBe true
+        hasDeletedAttachment shouldBe false
+    }
+
+    "should not redact attachments with non-redactable content" {
+        val module = PrivacyModule("message", "comment", ALLOWED_REGEX, AccessTokenRedactor, emptyList())
+
+        var hasSetPrivate = false
+        var hasDeletedAttachment = false
+
+        val issue = mockIssue(
+            attachments = listOf(
+                mockAttachment(
+                    // Redactor does not handle this; but it represents sensitive data
+                    getContent = { "My transaction ID is braintree:1a2b3c4d".toByteArray() },
+                    remove = { hasDeletedAttachment = true }
+                )
+            ),
+            setPrivate = { hasSetPrivate = true }
+        )
+
+        val result = module(issue, TWO_SECONDS_AGO)
+        result.shouldBeRight(ModuleResponse)
+
+        hasSetPrivate shouldBe true
+        hasDeletedAttachment shouldBe false
+    }
+
+    "should redact attachments even if issue is made private" {
+        val madePrivateMessage = "message"
+        val module = PrivacyModule(madePrivateMessage, "comment", ALLOWED_REGEX, AccessTokenRedactor, emptyList())
+
+        var hasSetPrivate = false
+        var hasDeletedAttachment = false
+        var hasAddedNewAttachment = false
+        var privateComment: CommentOptions? = null
+        var hasAddedRedactionComment = false
+
+        val issue = mockIssue(
+            // Issue description cannot be redacted (would still be in history)
+            description = "My transaction ID is braintree:1a2b3c4d",
+            attachments = listOf(
+                mockAttachment(
+                    getContent = { "... --accessToken $EXAMPLE_JWT_TOKEN ...".toByteArray() },
+                    remove = { hasDeletedAttachment = true }
+                )
+            ),
+            setPrivate = { hasSetPrivate = true },
+            addAttachment = { _, cleanupCallback ->
+                hasAddedNewAttachment = true
+                cleanupCallback()
+            },
+            addComment = { privateComment = it },
+            addRawBotComment = { hasAddedRedactionComment = true }
+        )
+
+        val result = module(issue, TWO_SECONDS_AGO)
+        result.shouldBeRight(ModuleResponse)
+
+        hasSetPrivate shouldBe true
+        privateComment shouldBe CommentOptions(madePrivateMessage)
+        // Issue was made private, but attachment should have been redacted anyways
+        hasDeletedAttachment shouldBe true
+        hasAddedNewAttachment shouldBe true
+        hasAddedRedactionComment shouldBe true
+    }
+
+    "should make private if redacting does not remove all sensitive data" {
+        val madePrivateMessage = "message"
+        val module = PrivacyModule(madePrivateMessage, "comment", ALLOWED_REGEX, AccessTokenRedactor, emptyList())
+
+        var hasSetPrivate = false
+        var hasDeletedAttachment = false
+        var hasAddedNewAttachment = false
+        var privateComment: CommentOptions? = null
+        var hasAddedRedactionComment = false
+
+        val issue = mockIssue(
+            attachments = listOf(
+                mockAttachment(
+                    getContent = { (
+                        "... --accessToken $EXAMPLE_JWT_TOKEN ...\n" +
+                        // This cannot be redacted
+                        "My transaction ID is braintree:1a2b3c4d"
+                    ).toByteArray() },
+                    remove = { hasDeletedAttachment = true }
+                )
+            ),
+            setPrivate = { hasSetPrivate = true },
+            addAttachment = { _, cleanupCallback ->
+                hasAddedNewAttachment = true
+                cleanupCallback()
+            },
+            addComment = { privateComment = it },
+            addRawBotComment = { hasAddedRedactionComment = true }
+        )
+
+        val result = module(issue, TWO_SECONDS_AGO)
+        result.shouldBeRight(ModuleResponse)
+
+        hasSetPrivate shouldBe true
+        privateComment shouldBe CommentOptions(madePrivateMessage)
+        hasDeletedAttachment shouldBe false
+        hasAddedNewAttachment shouldBe false
+        hasAddedRedactionComment shouldBe false
     }
 })

--- a/src/test/kotlin/io/github/mojira/arisa/modules/PrivacyModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/PrivacyModuleTest.kt
@@ -494,7 +494,9 @@ class PrivacyModuleTest : StringSpec({
         val uploader1User = mockUser(
             name = uploader1
         )
+        @Suppress("LocalVariableName")
         val attachmentName1_1 = "my-attachment.txt"
+        @Suppress("LocalVariableName")
         val attachmentName1_2 = "my-attachment2.txt"
 
         val uploader2 = "some-other-user"

--- a/src/test/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModuleTest.kt
@@ -28,8 +28,8 @@ private val TEN_SECONDS_AGO = RIGHT_NOW.minusSeconds(10)
 private val TWO_YEARS_AGO = RIGHT_NOW.minus(730, ChronoUnit.DAYS)
 
 private val MODULE = ReopenAwaitingModule(
-    listOf("staff", "global-moderators"),
-    listOf("helper", "staff", "global-moderators"),
+    setOf("staff", "global-moderators"),
+    setOf("helper", "staff", "global-moderators"),
     365,
     "MEQS_KEEP_AR",
     "ARISA_REOPEN_OP",

--- a/src/test/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModuleTest.kt
@@ -12,6 +12,18 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 
 class RevokeConfirmationModuleTest : StringSpec({
+    fun mockChangeLogItem(
+        created: Instant = RIGHT_NOW,
+        field: String = "Confirmation Status",
+        value: String = "Confirmed",
+        getAuthorGroups: () -> List<String>? = { emptyList() }
+    ) = mockChangeLogItem(
+        created = created,
+        field = field,
+        changedToString = value,
+        getAuthorGroups = getAuthorGroups
+    )
+
     "should return OperationNotNeededModuleResponse when Ticket is unconfirmed and confirmation was never changed" {
         val module = RevokeConfirmationModule()
         val issue = mockIssue(
@@ -25,7 +37,7 @@ class RevokeConfirmationModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when Ticket is confirmed and was changed by staff" {
         val module = RevokeConfirmationModule()
-        val changeLogItem = io.github.mojira.arisa.modules.mockChangeLogItem { listOf("staff") }
+        val changeLogItem = mockChangeLogItem { listOf("staff") }
         val issue = mockIssue(
             confirmationStatus = "Confirmed",
             changeLog = listOf(changeLogItem)
@@ -38,7 +50,7 @@ class RevokeConfirmationModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when Ticket is confirmed and was changed by helper" {
         val module = RevokeConfirmationModule()
-        val changeLogItem = io.github.mojira.arisa.modules.mockChangeLogItem { listOf("helper") }
+        val changeLogItem = mockChangeLogItem { listOf("helper") }
         val issue = mockIssue(
             confirmationStatus = "Confirmed",
             changeLog = listOf(changeLogItem)
@@ -51,7 +63,7 @@ class RevokeConfirmationModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when Ticket is confirmed and was changed by global-moderator" {
         val module = RevokeConfirmationModule()
-        val changeLogItem = io.github.mojira.arisa.modules.mockChangeLogItem { listOf("global-moderators") }
+        val changeLogItem = mockChangeLogItem { listOf("global-moderators") }
         val issue = mockIssue(
             confirmationStatus = "Confirmed",
             changeLog = listOf(changeLogItem)
@@ -64,7 +76,7 @@ class RevokeConfirmationModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when Ticket was confirmed more than a day ago by a user who is no longer staff" {
         val module = RevokeConfirmationModule()
-        val changeLogItem = io.github.mojira.arisa.modules.mockChangeLogItem(Instant.now().minus(2, ChronoUnit.DAYS))
+        val changeLogItem = mockChangeLogItem(Instant.now().minus(2, ChronoUnit.DAYS))
         val issue = mockIssue(
             confirmationStatus = "Confirmed",
             changeLog = listOf(changeLogItem)
@@ -77,7 +89,7 @@ class RevokeConfirmationModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when Ticket is confirmed and groups are unknown" {
         val module = RevokeConfirmationModule()
-        val changeLogItem = io.github.mojira.arisa.modules.mockChangeLogItem { null }
+        val changeLogItem = mockChangeLogItem { null }
         val issue = mockIssue(
             confirmationStatus = "Confirmed",
             changeLog = listOf(changeLogItem)
@@ -90,7 +102,7 @@ class RevokeConfirmationModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when multiple volunteers changed the confirmation status" {
         val module = RevokeConfirmationModule()
-        val volunteerChange = io.github.mojira.arisa.modules.mockChangeLogItem { listOf("staff") }
+        val volunteerChange = mockChangeLogItem { listOf("staff") }
         val otherVolunteerChange = mockChangeLogItem(value = "Unconfirmed") { listOf("helper") }
         val issue = mockIssue(
             confirmationStatus = "Unconfirmed",
@@ -106,7 +118,7 @@ class RevokeConfirmationModuleTest : StringSpec({
         var changedConfirmation = "Unconfirmed"
 
         val module = RevokeConfirmationModule()
-        val volunteerChange = io.github.mojira.arisa.modules.mockChangeLogItem { listOf("staff") }
+        val volunteerChange = mockChangeLogItem { listOf("staff") }
         val otherVolunteerChange = mockChangeLogItem(value = "") { listOf("helper") }
         val issue = mockIssue(
             confirmationStatus = "Unconfirmed",
@@ -122,7 +134,7 @@ class RevokeConfirmationModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when confirmation status is empty and was unset" {
         val module = RevokeConfirmationModule()
-        val volunteerChange = io.github.mojira.arisa.modules.mockChangeLogItem { listOf("staff") }
+        val volunteerChange = mockChangeLogItem { listOf("staff") }
         val otherVolunteerChange = mockChangeLogItem(value = "") { listOf("helper") }
         val issue = mockIssue(
             confirmationStatus = "",
@@ -154,7 +166,7 @@ class RevokeConfirmationModuleTest : StringSpec({
 
         val module = RevokeConfirmationModule()
         val changeLogItem =
-            io.github.mojira.arisa.modules.mockChangeLogItem(field = "Totally Not Confirmation Status") { listOf("staff") }
+            mockChangeLogItem(field = "Totally Not Confirmation Status") { listOf("staff") }
         val issue = mockIssue(
             confirmationStatus = "Confirmed",
             changeLog = listOf(changeLogItem),
@@ -171,7 +183,7 @@ class RevokeConfirmationModuleTest : StringSpec({
         var changedConfirmation = ""
 
         val module = RevokeConfirmationModule()
-        val changeLogItem = io.github.mojira.arisa.modules.mockChangeLogItem()
+        val changeLogItem = mockChangeLogItem()
         val issue = mockIssue(
             confirmationStatus = "Confirmed",
             changeLog = listOf(changeLogItem),
@@ -205,7 +217,7 @@ class RevokeConfirmationModuleTest : StringSpec({
         var changedConfirmation = ""
 
         val module = RevokeConfirmationModule()
-        val volunteerChange = io.github.mojira.arisa.modules.mockChangeLogItem { listOf("staff") }
+        val volunteerChange = mockChangeLogItem { listOf("staff") }
         val userChange = mockChangeLogItem(value = "Unconfirmed") { listOf("users") }
         val issue = mockIssue(
             confirmationStatus = "Unconfirmed",
@@ -223,7 +235,7 @@ class RevokeConfirmationModuleTest : StringSpec({
         var changedConfirmation = ""
 
         val module = RevokeConfirmationModule()
-        val volunteerChange = io.github.mojira.arisa.modules.mockChangeLogItem(Instant.now().minus(2, ChronoUnit.DAYS))
+        val volunteerChange = mockChangeLogItem(Instant.now().minus(2, ChronoUnit.DAYS))
         val userChange = mockChangeLogItem(value = "Unconfirmed") { listOf("users") }
         val issue = mockIssue(
             confirmationStatus = "Unconfirmed",
@@ -237,15 +249,3 @@ class RevokeConfirmationModuleTest : StringSpec({
         changedConfirmation.shouldBe("Confirmed")
     }
 })
-
-private fun mockChangeLogItem(
-    created: Instant = RIGHT_NOW,
-    field: String = "Confirmation Status",
-    value: String = "Confirmed",
-    getAuthorGroups: () -> List<String>? = { emptyList() }
-) = mockChangeLogItem(
-    created = created,
-    field = field,
-    changedToString = value,
-    getAuthorGroups = getAuthorGroups
-)

--- a/src/test/kotlin/io/github/mojira/arisa/modules/commands/arguments/EnumArgumentTypeTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/commands/arguments/EnumArgumentTypeTest.kt
@@ -16,7 +16,9 @@ private enum class MyEnum {
     WORLD
 }
 
+@Suppress("unused")
 private enum class EnumWithNameClashes {
+    @Suppress("EnumEntryName")
     a,
     A
 }

--- a/src/test/kotlin/io/github/mojira/arisa/modules/privacy/AccessTokenRedactorTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/privacy/AccessTokenRedactorTest.kt
@@ -1,4 +1,4 @@
-package io.github.mojira.arisa.modules
+package io.github.mojira.arisa.modules.privacy
 
 import io.github.mojira.arisa.utils.mockAttachment
 import io.kotest.core.spec.style.StringSpec

--- a/src/test/kotlin/io/github/mojira/arisa/modules/privacy/PrivacyModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/privacy/PrivacyModuleTest.kt
@@ -1,7 +1,9 @@
-package io.github.mojira.arisa.modules
+package io.github.mojira.arisa.modules.privacy
 
 import io.github.mojira.arisa.domain.Attachment
 import io.github.mojira.arisa.domain.CommentOptions
+import io.github.mojira.arisa.modules.ModuleResponse
+import io.github.mojira.arisa.modules.OperationNotNeededModuleResponse
 import io.github.mojira.arisa.utils.RIGHT_NOW
 import io.github.mojira.arisa.utils.mockAttachment
 import io.github.mojira.arisa.utils.mockChangeLogItem

--- a/src/test/kotlin/io/github/mojira/arisa/modules/privacy/TextRangeLocationTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/privacy/TextRangeLocationTest.kt
@@ -1,0 +1,54 @@
+package io.github.mojira.arisa.modules.privacy
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class TextRangeLocationTest : FunSpec({
+    data class TestData(
+        val description: String,
+        val textRangeLocation: TextRangeLocation,
+        val expectedLocationString: String
+    )
+
+    listOf(
+        TestData(
+            "in first line",
+            TextRangeLocation("first\nsecond", 2, 3),
+            "2 - 3 (1:2 - 1:3)"
+        ),
+        TestData(
+            "in middle line",
+            TextRangeLocation("first\nsecond\nthird", 9, 10),
+            "9 - 10 (2:3 - 2:4)"
+        ),
+        TestData(
+            "in last line",
+            TextRangeLocation("first\nsecond", 9, 10),
+            "9 - 10 (2:3 - 2:4)"
+        ),
+        TestData(
+            "spanning multiple lines",
+            TextRangeLocation("first\nsecond", 2, 9),
+            "2 - 9 (1:2 - 2:3)"
+        ),
+        TestData(
+            "with CR",
+            TextRangeLocation("first\rsecond", 9, 10),
+            "9 - 10 (2:3 - 2:4)"
+        ),
+        TestData(
+            "with CR LF",
+            TextRangeLocation("first\r\nsecond", 9, 10),
+            "9 - 10 (2:2 - 2:3)"
+        ),
+        TestData(
+            "with mixed CR and LF",
+            TextRangeLocation("first\nsecond\rthird\r\nfourth", 23, 24),
+            "23 - 24 (4:3 - 4:4)"
+        )
+    ).forEach {
+        test(it.description) {
+            it.textRangeLocation.getLocationDescription() shouldBe it.expectedLocationString
+        }
+    }
+})

--- a/src/test/kotlin/io/github/mojira/arisa/modules/privacy/TextRangeLocationTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/privacy/TextRangeLocationTest.kt
@@ -12,6 +12,18 @@ class TextRangeLocationTest : FunSpec({
 
     listOf(
         TestData(
+            "in empty string",
+            // Range 0..-1 is returned for 0-length match at start, e.g. `Regex("^").find("test")?.range`
+            TextRangeLocation("", 0, -1),
+            "0 - -1 (1:0 - 1:-1)"
+        ),
+        TestData(
+            "at end of string",
+            // Range 4..3 is returned for 0-length match at end, e.g. `Regex("$").find("test")?.range`
+            TextRangeLocation("test", 4, 3),
+            "4 - 3 (1:4 - 1:3)"
+        ),
+        TestData(
             "in first line",
             TextRangeLocation("first\nsecond", 2, 3),
             "2 - 3 (1:2 - 1:3)"
@@ -45,6 +57,17 @@ class TextRangeLocationTest : FunSpec({
             "with mixed CR and LF",
             TextRangeLocation("first\nsecond\rthird\r\nfourth", 23, 24),
             "23 - 24 (4:3 - 4:4)"
+        ),
+        TestData(
+            "with trailing LF",
+            TextRangeLocation("test\n", 2, 3),
+            "2 - 3 (1:2 - 1:3)"
+        ),
+        TestData(
+            "behind trailing LF",
+            // Range 5..4 is returned for 0-length match at end, e.g. `Regex("\\z").find("test\n")?.range`
+            TextRangeLocation("test\n", 5, 4),
+            "5 - 4 (2:0 - 1:4)"
         )
     ).forEach {
         test(it.description) {

--- a/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
@@ -40,6 +40,8 @@ fun mockAttachment(
 )
 
 fun mockChangeLogItem(
+    entryId: String = "1",
+    itemIndex: Int = 0,
     created: Instant = RIGHT_NOW,
     field: String = "",
     changedFrom: String? = null,
@@ -49,6 +51,8 @@ fun mockChangeLogItem(
     author: User = mockUser(),
     getAuthorGroups: () -> List<String>? = { emptyList() }
 ) = ChangeLogItem(
+    entryId,
+    itemIndex,
     created,
     field,
     changedFrom,

--- a/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
@@ -130,6 +130,7 @@ fun mockIssue(
     addRestrictedComment: (options: CommentOptions) -> Unit = { },
     addNotEnglishComment: (language: String) -> Unit = { },
     addRawRestrictedComment: (body: String, restriction: String) -> Unit = { _, _ -> },
+    addRawBotComment: (rawBody: String) -> Unit = { },
     markAsFixedInASpecificVersion: (versionName: String) -> Unit = { },
     changeReporter: (reporter: String) -> Unit = { },
     addAttachment: (file: File, cleanupCallback: () -> Unit) -> Unit = { _, cleanupCallback -> cleanupCallback() }
@@ -180,6 +181,7 @@ fun mockIssue(
     addRestrictedComment,
     addNotEnglishComment,
     addRawRestrictedComment,
+    addRawBotComment,
     markAsFixedInASpecificVersion,
     changeReporter,
     addAttachment
@@ -223,12 +225,14 @@ fun mockUser(
     name: String = "user",
     displayName: String = "User",
     getGroups: () -> List<String>? = { null },
-    isNewUser: () -> Boolean = { false }
+    isNewUser: () -> Boolean = { false },
+    isBotUser: () -> Boolean = { false }
 ) = User(
     name,
     displayName,
     getGroups,
-    isNewUser
+    isNewUser,
+    isBotUser
 )
 
 fun mockVersion(


### PR DESCRIPTION
## Purpose
Fixes #704

Redact access tokens in attachments (e.g. JVM crash reports) by deleting the original attachment and uploading a redacted version to avoid having to make the issue private. Additionally add a comment to let the user know that their attachment has been redacted.

Open questions:
- [x] Should a (bot/hidden) helper message be used for the comment? If so it would require at least two placeholders: Uploader, new attachment names
Edit: Message is currently hardcoded since only one placeholder is supported at the moment, and message is only relevant for Arisa, but is not useful as helper message.

Open tasks:
- [x] Verify that it works with an actual JVM crash report
- [x] Update documentation
- [x] Test in MCTEST

## Approach
`PrivacyModule` has been adjusted to redact access token references in the form `--accessToken ...` like they appear in JVM crash reports. In theory this could be done in a separate module, though it is closely related to what `PrivacyModule` does and having a separate module do this would be tricky (see #527) and would require that the modules are executed in the correct order.

Redaction logic does not reuse `PrivacyModule` regex patterns because they are known to cause false positives and might also not cover everything, e.g. `braintree:` transaction ID is usually provided together with a order ID. We can reliably match the transaction ID (due to its unambiguous `braintree:` prefix), but matching the order ID is not possible. So in that case merely redacting the transaction ID would not suffice.
Therefore redaction only covers the access token for now.

As a safe guard the redacted attachment content is checked to see if it still contains sensitive data (since redaction does not cover everthing); if this is the case the attachment is not redacted and the issue is made private.

A publicly visible comment is added informing the user that their attachments have been redacted.

## Future work
An error during deletion of the existing attachment or upload of the redacted attachment might not be handled correctly; this can lead to the following unwanted situations:
- deletion of old attachment fails, report is made public even though it still contains sensitive attachment
- upload of new attachment fails, attachment is effectively lost

Maybe in the future we could change `IssueUpdateContext` to group actions done by a single module invocation, and abort execution for that module if one of its actions fails (similar to #720); that should solve the above situations. It would also require removing the logging from the `deleteAttachment` and `addAttachmentFile` helper functions and always throw an exception when the HTTP code indicates a failure, because we cannot be sure if we interpret the error HTTP code the way Jira meant it.

#### Checklist
- [x] Included tests
- [x] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [x] Tested in MCTEST-142
