### PR TITLE
Re-add empty confirmation

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/Helpers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/Helpers.kt
@@ -132,6 +132,12 @@ fun String?.getOrDefault(default: String) =
     else
         this
 
+fun String?.getOrDefaultNull(default: String) =
+    if (this == null)
+        default
+    else
+        this
+
 fun MutableList<String>.splitElemsByCommas() {
     val newList = this.flatMap { s ->
         s.split(',').filter {

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModule.kt
@@ -13,9 +13,9 @@ class RevokeConfirmationModule : Module {
             val volunteerConfirmation = changeLog
                 .filter(::isConfirmationChange)
                 .lastOrNull(::changedByVolunteer)
-                ?.changedToString.getOrDefault("")
+                ?.changedToString.getOrDefault("Unconfirmed")
 
-            assertNotEquals(confirmationStatus.getOrDefault(""), volunteerConfirmation).bind()
+            assertNotEquals(confirmationStatus.getOrDefault("Unconfirmed"), volunteerConfirmation).bind()
             updateConfirmationStatus(volunteerConfirmation)
         }
     }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModule.kt
@@ -13,9 +13,9 @@ class RevokeConfirmationModule : Module {
             val volunteerConfirmation = changeLog
                 .filter(::isConfirmationChange)
                 .lastOrNull(::changedByVolunteer)
-                ?.changedToString.getOrDefault("Unconfirmed")
+                ?.changedToString.getOrDefaultNull("Unconfirmed")
 
-            assertNotEquals(confirmationStatus.getOrDefault("Unconfirmed"), volunteerConfirmation).bind()
+            assertNotEquals(confirmationStatus.getOrDefaultNull("Unconfirmed"), volunteerConfirmation).bind()
             updateConfirmationStatus(volunteerConfirmation)
         }
     }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModule.kt
@@ -15,7 +15,7 @@ class RevokeConfirmationModule : Module {
                 .lastOrNull(::changedByVolunteer)
                 ?.changedToString.getOrDefault("Unconfirmed")
 
-            assertNotEquals(confirmationStatus.getOrDefault("Unconfirmed"), volunteerConfirmation).bind()
+            assertNotEquals(confirmationStatus, volunteerConfirmation).bind()
             updateConfirmationStatus(volunteerConfirmation)
         }
     }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModule.kt
@@ -13,7 +13,7 @@ class RevokeConfirmationModule : Module {
             val volunteerConfirmation = changeLog
                 .filter(::isConfirmationChange)
                 .lastOrNull(::changedByVolunteer)
-                ?.changedToString.getOrDefault("Unconfirmed")
+                ?.changedToString
 
             assertNotEquals(confirmationStatus, volunteerConfirmation).bind()
             updateConfirmationStatus(volunteerConfirmation)

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModule.kt
@@ -13,9 +13,9 @@ class RevokeConfirmationModule : Module {
             val volunteerConfirmation = changeLog
                 .filter(::isConfirmationChange)
                 .lastOrNull(::changedByVolunteer)
-                ?.changedToString
+                ?.changedToString.getOrDefault("")
 
-            assertNotEquals(confirmationStatus, volunteerConfirmation).bind()
+            assertNotEquals(confirmationStatus.getOrDefault(""), volunteerConfirmation).bind()
             updateConfirmationStatus(volunteerConfirmation)
         }
     }

--- a/src/test/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModuleTest.kt
@@ -197,9 +197,9 @@ class RevokeConfirmationModuleTest : StringSpec({
         var changedConfirmation = ""
 
         val module = RevokeConfirmationModule()
-        val changeLogItem = mockChangeLogItem(value = null) { listOf("users") }
+        val changeLogItem = mockChangeLogItem(value = "") { listOf("users") }
         val issue = mockIssue(
-            confirmationStatus = null,
+            confirmationStatus = "",
             changeLog = listOf(changeLogItem),
             updateConfirmationStatus = { changedConfirmation = it; Unit.right() }
         )

--- a/src/test/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModuleTest.kt
@@ -193,6 +193,23 @@ class RevokeConfirmationModuleTest : StringSpec({
         changedConfirmation.shouldBe("Unconfirmed")
     }
 
+    "should set to Unconfirmed when ticket when confirmation status is removed by a non-volunteer" {
+        var changedConfirmation = ""
+
+        val module = RevokeConfirmationModule()
+        val changeLogItem = mockChangeLogItem(value = null) { listOf("users") }
+        val issue = mockIssue(
+            confirmationStatus = null,
+            changeLog = listOf(changeLogItem),
+            updateConfirmationStatus = { changedConfirmation = it; Unit.right() }
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeRight(ModuleResponse)
+        changedConfirmation.shouldBe("Unconfirmed")
+    }
+
     "should set back to status set by volunteer, when regular user changes confirmation status" {
         var changedConfirmation = ""
 

--- a/src/test/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModuleTest.kt
@@ -110,7 +110,7 @@ class RevokeConfirmationModuleTest : StringSpec({
         val otherVolunteerChange = mockChangeLogItem(value = "") { listOf("helper") }
         val issue = mockIssue(
             confirmationStatus = "Unconfirmed",
-            changeLog = listOf(volunteerChange, otherVolunteerChange)
+            changeLog = listOf(volunteerChange, otherVolunteerChange),
             updateConfirmationStatus = { changedConfirmation = it; Unit.right() }
         )
 
@@ -118,19 +118,6 @@ class RevokeConfirmationModuleTest : StringSpec({
 
         result.shouldBeRight(ModuleResponse)
         changedConfirmation.shouldBe("")
-    }
-
-    "should return OperationNotNeededModuleResponse when confirmation status is null and was unset" {
-        val module = RevokeConfirmationModule()
-        val volunteerChange = io.github.mojira.arisa.modules.mockChangeLogItem { listOf("staff") }
-        val otherVolunteerChange = mockChangeLogItem(value = "") { listOf("helper") }
-        val issue = mockIssue(
-            changeLog = listOf(volunteerChange, otherVolunteerChange)
-        )
-
-        val result = module(issue, RIGHT_NOW)
-
-        result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
     "should return OperationNotNeededModuleResponse when confirmation status is empty and was unset" {

--- a/src/test/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModuleTest.kt
@@ -197,7 +197,7 @@ class RevokeConfirmationModuleTest : StringSpec({
         var changedConfirmation = ""
 
         val module = RevokeConfirmationModule()
-        val changeLogItem = mockChangeLogItem(value = "") { listOf("users") }
+        val changeLogItem = io.github.mojira.arisa.modules.mockChangeLogItem(value = "") { listOf("users") }
         val issue = mockIssue(
             confirmationStatus = "",
             changeLog = listOf(changeLogItem),

--- a/src/test/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/RevokeConfirmationModuleTest.kt
@@ -102,18 +102,22 @@ class RevokeConfirmationModuleTest : StringSpec({
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
-    "should return OperationNotNeededModuleResponse when ticket is Unconfirmed and Confirmation Status was unset" {
+    "should unset confirmation when ticket is Unconfirmed and Confirmation Status was unset by a volunteer" {
+        var changedConfirmation = "Unconfirmed"
+
         val module = RevokeConfirmationModule()
         val volunteerChange = io.github.mojira.arisa.modules.mockChangeLogItem { listOf("staff") }
         val otherVolunteerChange = mockChangeLogItem(value = "") { listOf("helper") }
         val issue = mockIssue(
             confirmationStatus = "Unconfirmed",
             changeLog = listOf(volunteerChange, otherVolunteerChange)
+            updateConfirmationStatus = { changedConfirmation = it; Unit.right() }
         )
 
         val result = module(issue, RIGHT_NOW)
 
-        result.shouldBeLeft(OperationNotNeededModuleResponse)
+        result.shouldBeRight(ModuleResponse)
+        changedConfirmation.shouldBe("")
     }
 
     "should return OperationNotNeededModuleResponse when confirmation status is null and was unset" {


### PR DESCRIPTION
## Purpose
When a non-volunteer removes the confirmation status, it is not readded by the revoke confirmation module.