### PR TITLE
Remove .sys attachments from bug reports

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -101,6 +101,7 @@ arisa:
         - '.dylib'
         - '.rtf'
         - '.pptx'
+        - '.sys'
       comment: attach-new-attachment
 
     duplicateMessage:


### PR DESCRIPTION
## Purpose
These are windows configuration files which may be dangerous towards users if they download them. I don't think removing these will be frequent but I've just removed one from a bug report so I thought I'd make this PR: https://bugs.mojang.com/browse/MCL-18792

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
