### PR TITLE
Remove a regex causing false positives

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/PrivacyModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/PrivacyModule.kt
@@ -19,8 +19,7 @@ class PrivacyModule(
         """.*(?<![^\s])(?=[^\s]*[A-Z])(?=[^\s]*[0-9])[A-Z0-9]{17}(?![^\s]).*""".toRegex(),
         // At the moment braintree transaction IDs seem to have 8 chars, but to be future-proof
         // match if there are more chars as well
-        """.*\bbraintree:[a-f0-9]{6,12}\b.*""".toRegex(),
-        """.*\b([A-Za-z0-9]{4}-){3}[A-Za-z0-9]{4}\b.*""".toRegex()
+        """.*\bbraintree:[a-f0-9]{6,12}\b.*""".toRegex()
     )
 
     private val emailRegex = "(?<!\\[~)\\b[a-zA-Z0-9.\\-_]+@[a-zA-Z.\\-_]+\\.[a-zA-Z.\\-]{2,15}\\b".toRegex()


### PR DESCRIPTION
## Purpose

The last regex in the privacy module can cause false positives in launcher logs.

Example (note the `5865-5e24-84d9-f4b7` part):
```
[Info: 2021-07-16 21:24:45.7786953: ClientStarter.cpp(1071)] Java argument:-Djava.library.path=C:\Users\<>\AppData\Roaming\.minecraft\bin\5865-5e24-84d9-f4b7
```

## Approach

This commit removes that regex.

## Future work

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
