### PR TITLE
Reject version for FixedCommand if same or older than any affected version

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -52,10 +52,16 @@ This command currently only exists because of a technical limitation. It will be
 Lowercases sentences in which the first letter of each word is capitalized.
 
 ## $ARISA_FIXED
-| Entry       | Value                    |
-| ----------- | ------------------------ |
-| Syntax      | `$ARISA_FIXED <version>` |
-| Permissions | Mod+                     |
+| Entry       | Value                            |
+| ----------- | -------------------------------- |
+| Syntax      | `$ARISA_FIXED <version> [force]` |
+| Permissions | Mod+                             |
+
+Resolves an issue as Fixed in the specified version. This command is useful when the version has already been
+archived, and the web interface does not allow choosing that version.
+
+When one of the affected versions of the issue was erroneously added and the fixed version is the same or an earlier
+version, the command fails. To skip this check, run with a trailing `force` literal, e.g. `$ARISA_FIXED 12w34a force`.
 
 ## $ARISA_LIST_USER_ACTIVITY
 | Entry       | Value                                  |

--- a/src/main/kotlin/io/github/mojira/arisa/domain/Issue.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/domain/Issue.kt
@@ -50,7 +50,7 @@ data class Issue(
     val addRestrictedComment: (options: CommentOptions) -> Unit,
     val addNotEnglishComment: (language: String) -> Unit,
     val addRawRestrictedComment: (body: String, restriction: String) -> Unit,
-    val markAsFixedWithSpecificVersion: (fixVersion: String) -> Unit,
+    val markAsFixedWithSpecificVersion: (fixVersionName: String) -> Unit,
     val changeReporter: (reporter: String) -> Unit,
     val addAttachment: (file: File, cleanupCallback: () -> Unit) -> Unit
 )

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
@@ -400,8 +400,8 @@ fun getGroups(jiraClient: JiraClient, username: String) = runBlocking {
     }
 }
 
-fun markAsFixedWithSpecificVersion(context: Lazy<IssueUpdateContext>, fixVersion: String) {
-    context.value.resolve.field(Field.FIX_VERSIONS, listOf(mapOf("name" to fixVersion)))
+fun markAsFixedWithSpecificVersion(context: Lazy<IssueUpdateContext>, fixVersionName: String) {
+    context.value.resolve.field(Field.FIX_VERSIONS, listOf(mapOf("name" to fixVersionName)))
     context.value.transitionName = "Resolve Issue"
 }
 

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/CommandDispatcher.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/CommandDispatcher.kt
@@ -14,6 +14,8 @@ import io.github.mojira.arisa.infrastructure.jira.getIssuesFromJql
 import io.github.mojira.arisa.jiraClient
 import io.github.mojira.arisa.modules.commands.arguments.LinkList
 import io.github.mojira.arisa.modules.commands.arguments.LinkListArgumentType
+import io.github.mojira.arisa.modules.commands.arguments.StringWithFlag
+import io.github.mojira.arisa.modules.commands.arguments.greedyStringWithFlag
 
 @Suppress("LongMethod")
 fun getCommandDispatcher(
@@ -121,11 +123,13 @@ fun getCommandDispatcher(
             literal<CommandSource>("${prefix}_FIXED")
                 .requires(::sentByModerator)
                 .then(
-                    argument<CommandSource, String>("version", greedyString())
+                    argument<CommandSource, StringWithFlag>("version", greedyStringWithFlag("force"))
                         .executes {
+                            val (version, force) = it.getStringWithFlag("version")
                             fixedCommand(
                                 it.source.issue,
-                                it.getString("version")
+                                version,
+                                force
                             )
                         }
                 )
@@ -232,3 +236,4 @@ private fun sentByModerator(source: CommandSource) =
 private fun CommandContext<*>.getInt(name: String) = getArgument(name, Int::class.java)
 private fun CommandContext<*>.getLinkList(name: String) = getArgument(name, LinkList::class.java)
 private fun CommandContext<*>.getString(name: String) = getArgument(name, String::class.java)
+private fun CommandContext<*>.getStringWithFlag(name: String) = getArgument(name, StringWithFlag::class.java)

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/CommandExceptions.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/CommandExceptions.kt
@@ -1,6 +1,7 @@
 package io.github.mojira.arisa.modules.commands
 
 import com.mojang.brigadier.LiteralMessage
+import com.mojang.brigadier.exceptions.Dynamic2CommandExceptionType
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType
 
@@ -21,9 +22,10 @@ object CommandExceptions {
         LiteralMessage("Could not query activity of user \"$it\"")
     }
 
-    val FIX_VERSION_BEFORE_FIRST_AFFECTED_VERSION = DynamicCommandExceptionType {
-        LiteralMessage("Cannot add fix version $it because the first affected " +
-                "version of the issue was released after it")
+    val FIX_VERSION_SAME_OR_BEFORE_AFFECTED_VERSION = Dynamic2CommandExceptionType {
+            fixVersionName, affectedVersionName -> LiteralMessage("Cannot add fix version $fixVersionName " +
+                "because the affected version $affectedVersionName of the issue is the same or was released after " +
+                "it; run with `<version> force` to add the fix version anyways")
     }
 
     val INVALID_LINK_TYPE = SimpleCommandExceptionType(
@@ -33,6 +35,10 @@ object CommandExceptions {
     val INVALID_TICKET_KEY = SimpleCommandExceptionType(
         LiteralMessage("Found invalid ticket key")
     )
+
+    val GREEDY_STRING_ONLY_FLAG = DynamicCommandExceptionType {
+        LiteralMessage("Argument consists only of flag '$it' but does not contain a string")
+    }
 
     val LEFT_EITHER = DynamicCommandExceptionType {
         LiteralMessage("Something went wrong, but I'm too lazy to interpret the details for you (>ω<): $it")

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/FixedCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/FixedCommand.kt
@@ -1,26 +1,34 @@
 package io.github.mojira.arisa.modules.commands
 
 import io.github.mojira.arisa.domain.Issue
+import java.time.Instant
 
 class FixedCommand {
     @Suppress("ThrowsCount")
-    operator fun invoke(issue: Issue, version: String): Int {
-        if (issue.fixVersions.any { it.name == version }) {
-            throw CommandExceptions.ALREADY_FIXED_IN.create(version)
+    operator fun invoke(issue: Issue, fixVersionName: String, force: Boolean): Int {
+        if (issue.fixVersions.any { it.name == fixVersionName }) {
+            throw CommandExceptions.ALREADY_FIXED_IN.create(fixVersionName)
         }
-        if (issue.project.versions.none { it.name == version }) {
-            throw CommandExceptions.NO_SUCH_VERSION.create(version)
-        }
+
+        val fixVersion = issue.project.versions.firstOrNull { it.name == fixVersionName }
+            ?: throw CommandExceptions.NO_SUCH_VERSION.create(fixVersionName)
+
         if (issue.resolution !in listOf(null, "", "Unresolved")) {
             throw CommandExceptions.ALREADY_RESOLVED.create(issue.resolution)
         }
-        if (issue.affectedVersions.first().releaseDate!!.isAfter(
-                issue.project.versions.first { it.name == version }.releaseDate
-            )) {
-            throw CommandExceptions.FIX_VERSION_BEFORE_FIRST_AFFECTED_VERSION.create(version)
+
+        if (!force) {
+            // Fail if any affected version is same or newer than fix version
+            // Since archived fix versions cannot be removed again this prevents accidentally adding an incorrect
+            // fix version
+            issue.affectedVersions.firstOrNull { it.releaseDate!!.isSameOrAfter(fixVersion.releaseDate!!) }?.let {
+                throw CommandExceptions.FIX_VERSION_SAME_OR_BEFORE_AFFECTED_VERSION.create(fixVersionName, it.name)
+            }
         }
 
-        issue.markAsFixedWithSpecificVersion(version)
+        issue.markAsFixedWithSpecificVersion(fixVersionName)
         return 1
     }
 }
+
+private fun Instant.isSameOrAfter(other: Instant) = !this.isBefore(other)

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/arguments/GreedyStringWithTrailingFlagArgumentType.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/arguments/GreedyStringWithTrailingFlagArgumentType.kt
@@ -1,0 +1,41 @@
+package io.github.mojira.arisa.modules.commands.arguments
+
+import com.mojang.brigadier.StringReader
+import com.mojang.brigadier.arguments.ArgumentType
+import io.github.mojira.arisa.modules.commands.CommandExceptions
+
+/**
+ * Similar to [com.mojang.brigadier.arguments.StringArgumentType.greedyString], except that the string
+ * may end with an optional flag separated by a space.
+ */
+fun greedyStringWithFlag(flag: String): ArgumentType<StringWithFlag> = GreedyStringWithTrailingFlagArgumentType(flag)
+
+private class GreedyStringWithTrailingFlagArgumentType(private val flag: String) : ArgumentType<StringWithFlag> {
+    private val flagSuffix = " $flag"
+
+    override fun parse(reader: StringReader): StringWithFlag {
+        var text = reader.remaining
+
+        // Throw exception when input consists only of flag, to prevent accidental incorrect usage
+        if (text == flag) {
+            throw CommandExceptions.GREEDY_STRING_ONLY_FLAG.createWithContext(reader, flag)
+        }
+
+        // Consume complete input
+        reader.cursor = reader.totalLength
+
+        var isFlagSet = false
+        if (text.endsWith(flagSuffix)) {
+            text = text.removeSuffix(flagSuffix)
+            isFlagSet = true
+        }
+
+        return StringWithFlag(text, isFlagSet)
+    }
+}
+
+data class StringWithFlag(
+    val string: String,
+    /** `true` if the flag was explicitly provided in the command */
+    val isFlagSet: Boolean
+)

--- a/src/test/kotlin/io/github/mojira/arisa/modules/commands/arguments/GreedyStringWithTrailingFlagArgumentTypeTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/commands/arguments/GreedyStringWithTrailingFlagArgumentTypeTest.kt
@@ -1,0 +1,63 @@
+package io.github.mojira.arisa.modules.commands.arguments
+
+import com.mojang.brigadier.StringReader
+import com.mojang.brigadier.exceptions.CommandSyntaxException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class GreedyStringWithTrailingFlagArgumentTypeTest : StringSpec({
+    val flag = "my-flag"
+    val argumentType = greedyStringWithFlag(flag)
+
+    "should work without flag" {
+        val reader = StringReader("some text")
+        val result = argumentType.parse(reader)
+        result shouldBe StringWithFlag(
+            "some text",
+            false
+        )
+        reader.remainingLength shouldBe 0
+    }
+
+    "should work with flag" {
+        val reader = StringReader("some text $flag")
+        val result = argumentType.parse(reader)
+        result shouldBe StringWithFlag(
+            "some text",
+            true
+        )
+        reader.remainingLength shouldBe 0
+    }
+
+    "should not detect as flag without space" {
+        val reader = StringReader("some text$flag")
+        val result = argumentType.parse(reader)
+        result shouldBe StringWithFlag(
+            "some text$flag",
+            false
+        )
+        reader.remainingLength shouldBe 0
+    }
+
+    "should work with empty text and flag" {
+        val reader = StringReader(" $flag")
+        val result = argumentType.parse(reader)
+        result shouldBe StringWithFlag(
+            "",
+            true
+        )
+        reader.remainingLength shouldBe 0
+    }
+
+    "should fail when only flag is used" {
+        val reader = StringReader(flag)
+        val exception = shouldThrow<CommandSyntaxException> {
+            argumentType.parse(reader)
+        }
+        exception.message shouldBe "Argument consists only of flag 'my-flag' but does not contain a string at position 0: <--[HERE]"
+
+        // Cursor should not have been changed
+        reader.cursor shouldBe 0
+    }
+})

--- a/src/test/kotlin/io/github/mojira/arisa/modules/commands/arguments/LinkListArgumentTypeTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/commands/arguments/LinkListArgumentTypeTest.kt
@@ -16,6 +16,7 @@ class LinkListArgumentTypeTest : StringSpec({
             "relates",
             listOf("MC-100", "MC-200")
         )
+        reader.remainingLength shouldBe 0
     }
 
     "should support URLs" {
@@ -28,6 +29,7 @@ class LinkListArgumentTypeTest : StringSpec({
             "relates",
             listOf("MC-100", "MC-200")
         )
+        reader.remainingLength shouldBe 0
     }
 
     "should support types with spaces" {
@@ -37,6 +39,7 @@ class LinkListArgumentTypeTest : StringSpec({
             "relates to",
             listOf("MC-100", "MC-200")
         )
+        reader.remainingLength shouldBe 0
     }
 
     "should support types case-insensitively" {
@@ -46,6 +49,7 @@ class LinkListArgumentTypeTest : StringSpec({
             "relAtes To",
             listOf("MC-100", "MC-200")
         )
+        reader.remainingLength shouldBe 0
     }
 
     "should support commas" {
@@ -55,6 +59,7 @@ class LinkListArgumentTypeTest : StringSpec({
             "relates",
             listOf("MC-100", "MC-200", "MC-300", "MC-400")
         )
+        reader.remainingLength shouldBe 0
     }
 
     "should support ticket keys case-insensitively" {
@@ -64,6 +69,7 @@ class LinkListArgumentTypeTest : StringSpec({
             "relates",
             listOf("mc-100")
         )
+        reader.remainingLength shouldBe 0
     }
 
     "should throw exception when there isn't enough segments" {

--- a/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
@@ -128,7 +128,7 @@ fun mockIssue(
     addRestrictedComment: (options: CommentOptions) -> Unit = { },
     addNotEnglishComment: (language: String) -> Unit = { },
     addRawRestrictedComment: (body: String, restrictions: String) -> Unit = { _, _ -> },
-    markAsFixedInASpecificVersion: (version: String) -> Unit = { },
+    markAsFixedInASpecificVersion: (versionName: String) -> Unit = { },
     changeReporter: (reporter: String) -> Unit = { },
     addAttachment: (file: File, cleanupCallback: () -> Unit) -> Unit = { _, cleanupCallback -> cleanupCallback() }
 ) = Issue(


### PR DESCRIPTION
## Purpose
Improves `FixedCommand` argument validation by failing if _any_ of the affected versions is the same or newer than the fix version.
This reimplements the changes of #721.

However, when a trailing `force` literal is present this check is skipped, allowing to set a fix version even when erroneously added affected versions exist which cannot be removed anymore (because they are archived), e.g.:
```
$ARISA_FIXED 12w34a force
```

@Pokechu22, that should solve the issue you mentioned, right?

## Approach
Uses a custom Brigadier argument type which acts like a _greedy string_ but allows a trailing _flag_; for the `FixedCommand` that is `force`. This still allows easily using version names containing spaces without having to quote them.
In theory this could cause issues when a version name ends with " force", though that is rather unlikely.

#### Checklist
- [x] Included tests
- [x] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
