### PR TITLE
Sanitize user controlled arguments in bot comments

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/HelperMessages.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/HelperMessages.kt
@@ -6,6 +6,7 @@ import arrow.core.right
 import arrow.core.rightIfNotNull
 import com.beust.klaxon.Klaxon
 import com.beust.klaxon.KlaxonException
+import io.github.mojira.arisa.infrastructure.jira.sanitizeCommentArg
 import io.github.mojira.arisa.modules.openHttpGetInputStream
 import org.slf4j.LoggerFactory
 import java.io.File
@@ -83,7 +84,7 @@ object HelperMessageService {
         return data.messages[key]?.find { isProjectMatch(project, it.project) }
             .rightIfNotNull { Error("Failed to find message for key $key under project $project") }
             .map { localizeValue(it.message, it.localizedMessages, lang) }
-            .map { resolvePlaceholder(it, filledText) }
+            .map { resolvePlaceholder(it, filledText?.let(::sanitizeCommentArg)) }
             .map { resolveVariables(it, project, lang) }
     }
 

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
@@ -408,3 +408,10 @@ fun markAsFixedWithSpecificVersion(context: Lazy<IssueUpdateContext>, fixVersion
 fun changeReporter(context: Lazy<IssueUpdateContext>, reporter: String) {
     context.value.update.field(Field.REPORTER, reporter)
 }
+
+// Allows some basic Jira formatting characters to be used by helper message arguments;
+// when used by malicious user they should at most cause text formatting errors
+private val sanitizationRegex = Regex("[^a-zA-Z0-9\\-+_#*?.,; ]")
+fun sanitizeCommentArg(arg: String): String {
+    return arg.replace(sanitizationRegex, "?")
+}

--- a/src/main/kotlin/io/github/mojira/arisa/modules/AttachmentModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/AttachmentModule.kt
@@ -6,6 +6,7 @@ import arrow.syntax.function.partially1
 import io.github.mojira.arisa.domain.Attachment
 import io.github.mojira.arisa.domain.CommentOptions
 import io.github.mojira.arisa.domain.Issue
+import io.github.mojira.arisa.infrastructure.jira.sanitizeCommentArg
 import java.time.Instant
 
 class AttachmentModule(
@@ -28,9 +29,11 @@ class AttachmentModule(
         }
     }
 
-    private fun List<Attachment>.getCommentInfo() = this
-        .map { "- [~${it.uploader!!.name}]: ${it.name}" }
-        .joinToString(separator = "\n")
+    private fun List<Attachment>.getCommentInfo() = this.joinToString(separator = "\n") {
+        val uploaderName = it.uploader!!.name?.let(::sanitizeCommentArg)
+        val attachmentName = sanitizeCommentArg(it.name)
+        "- [~$uploaderName]: $attachmentName"
+    }
 
     private fun endsWithBlacklistedExtensions(extensionBlackList: List<String>, name: String) =
         extensionBlackList.any { name.endsWith(it) }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/ListUserActivityCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/ListUserActivityCommand.kt
@@ -2,6 +2,7 @@ package io.github.mojira.arisa.modules.commands
 
 import arrow.core.Either
 import io.github.mojira.arisa.domain.Issue
+import io.github.mojira.arisa.infrastructure.jira.sanitizeCommentArg
 
 /**
  * How many tickets should be listed at max.
@@ -20,19 +21,22 @@ class ListUserActivityCommand(
             | OR issueFunction IN fileAttached("by '$escapedUserName'")"""
             .trimMargin().replace("[\n\r]", "")
 
+        val sanitizedUserName = sanitizeCommentArg(userName)
+
         val tickets = when (val either = searchIssues(jql, ACTIVITY_LIST_CAP)) {
-            is Either.Left -> throw CommandExceptions.CANNOT_QUERY_USER_ACTIVITY.create(userName)
+            is Either.Left -> throw CommandExceptions.CANNOT_QUERY_USER_ACTIVITY.create(sanitizedUserName)
             is Either.Right -> either.b
         }
 
         if (tickets.isNotEmpty()) {
             issue.addRawRestrictedComment(
-                "User \"$userName\" left comments on the following tickets:\n* ${tickets.joinToString("\n* ")}",
+                "User \"$sanitizedUserName\" left comments on the following tickets:" +
+                    "\n* ${tickets.joinToString("\n* ")}",
                 "staff"
             )
         } else {
             issue.addRawRestrictedComment(
-                """No unrestricted comments from user "$userName" were found.""",
+                """No unrestricted comments from user "$sanitizedUserName" were found.""",
                 "staff"
             )
         }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveContentCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveContentCommand.kt
@@ -2,6 +2,7 @@ package io.github.mojira.arisa.modules.commands
 
 import arrow.core.Either
 import io.github.mojira.arisa.infrastructure.escapeIssueFunction
+import io.github.mojira.arisa.infrastructure.jira.sanitizeCommentArg
 import io.github.mojira.arisa.log
 import net.rcarz.jiraclient.Attachment
 import net.rcarz.jiraclient.Comment
@@ -70,7 +71,7 @@ class RemoveContentCommand(
             .trimMargin().replace("[\n\r]", "")
 
         val ticketIds = when (val either = searchIssues(jql, REMOVABLE_ACTIVITY_CAP)) {
-            is Either.Left -> throw CommandExceptions.CANNOT_QUERY_USER_ACTIVITY.create(userName)
+            is Either.Left -> throw CommandExceptions.CANNOT_QUERY_USER_ACTIVITY.create(sanitizeCommentArg(userName))
             is Either.Right -> either.b
         }
 
@@ -79,7 +80,7 @@ class RemoveContentCommand(
 
             issue.addRawRestrictedComment(
                 "Removed ${result.removedComments} comments " +
-                        "and ${result.removedAttachments} attachments from user \"$userName\".",
+                    "and ${result.removedAttachments} attachments from user \"${sanitizeCommentArg(userName)}\".",
                 "staff"
             )
         }

--- a/src/test/kotlin/io/github/mojira/arisa/infrastructure/HelperMessagesTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/infrastructure/HelperMessagesTest.kt
@@ -198,6 +198,22 @@ class HelperMessagesTest : StringSpec({
         result.b shouldBe "With MC-4"
     }
 
+    "should sanitize filled text" {
+        val maliciousFilledText = "bad\n\r\n\u0000\"'\u202E"
+        val result = HelperMessageService.getSingleMessage("MC", "with-placeholder", maliciousFilledText)
+
+        result.shouldBeRight()
+        result.b shouldBe "With bad???????"
+    }
+
+    "should allow basic formatting for filled text" {
+        val filledText = "test *a* and _b_"
+        val result = HelperMessageService.getSingleMessage("MC", "with-placeholder", filledText)
+
+        result.shouldBeRight()
+        result.b shouldBe "With test *a* and _b_"
+    }
+
     "should use the original value when the lang doesn't exist" {
         val result = HelperMessageService.getSingleMessage("MC", "normal", lang = "cd")
 

--- a/src/test/kotlin/io/github/mojira/arisa/modules/CommandModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/CommandModuleTest.kt
@@ -58,7 +58,7 @@ class CommandModuleTest : StringSpec({
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
-    "should return OperationNotNeededModuleResponse when comment doesnt have correct group" {
+    "should return OperationNotNeededModuleResponse when comment doesn't have correct group" {
         val module = CommandModule("ARISA", "userName", ::getDispatcher)
         val comment = getComment(
             visibilityType = "notagroup"
@@ -72,7 +72,7 @@ class CommandModuleTest : StringSpec({
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
-    "should return OperationNotNeededModuleResponse when comment doesnt have correct value" {
+    "should return OperationNotNeededModuleResponse when comment doesn't have correct value" {
         val module = CommandModule("ARISA", "userName", ::getDispatcher)
         val comment = getComment(
             visibilityValue = "notagroup"
@@ -101,10 +101,27 @@ class CommandModuleTest : StringSpec({
         result.shouldBeLeft(OperationNotNeededModuleResponse)
     }
 
-    "should return OperationNotNeededModuleResponse when comment doesnt start with ARISA_" {
+    "should return OperationNotNeededModuleResponse when comment doesn't start with ARISA_" {
         val module = CommandModule("ARISA", "userName", ::getDispatcher)
         val comment = getComment(
             body = "ARISA"
+        )
+        val issue = mockIssue(
+            comments = listOf(comment)
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when comment has been written by bot" {
+        val botName = "botName"
+        val module = CommandModule("ARISA", botName, ::getDispatcher)
+        val comment = getComment(
+            author = mockUser(
+                name = botName
+            )
         )
         val issue = mockIssue(
             comments = listOf(comment)

--- a/src/test/kotlin/io/github/mojira/arisa/modules/commands/ListUserActivityCommandTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/commands/ListUserActivityCommandTest.kt
@@ -13,7 +13,7 @@ class ListUserActivityCommandTest : StringSpec({
     "should query user activity and post a comment with all tickets" {
         var calledSearch = false
         var comment: String? = null
-        var commentRestrictions: String? = null
+        var commentRestriction: String? = null
 
         val issueList = listOf("MC-1", "MC-12", "MC-1234", "MC-12345")
 
@@ -25,21 +25,53 @@ class ListUserActivityCommandTest : StringSpec({
         }
 
         val issue = mockIssue(
-            addRawRestrictedComment = { body, restrictions ->
+            addRawRestrictedComment = { body, restriction ->
                 comment = body
-                commentRestrictions = restrictions
+                commentRestriction = restriction
             }
         )
 
-        val result = command(issue, "userName")
+        val result = command(issue, "user\nName")
 
         result shouldBe 1
         calledSearch.shouldBeTrue()
         comment.shouldNotBeNull()
-        commentRestrictions.shouldBe("staff")
+        commentRestriction shouldBe "staff"
 
         issueList.forEach {
-            comment.shouldContain(it)
+            comment shouldContain it
         }
+        // Should contain sanitized user name
+        comment shouldContain "user?Name"
+    }
+
+    "should post comment when no tickets were found" {
+        var calledSearch = false
+        var comment: String? = null
+        var commentRestriction: String? = null
+
+        val command = ListUserActivityCommand { _, _ ->
+            Either.fx {
+                calledSearch = true
+                emptyList()
+            }
+        }
+
+        val issue = mockIssue(
+            addRawRestrictedComment = { body, restriction ->
+                comment = body
+                commentRestriction = restriction
+            }
+        )
+
+        val result = command(issue, "user\nName")
+
+        result shouldBe 1
+        calledSearch.shouldBeTrue()
+        comment.shouldNotBeNull()
+        commentRestriction shouldBe "staff"
+
+        // Should contain sanitized user name
+        comment shouldBe "No unrestricted comments from user \"user?Name\" were found."
     }
 })

--- a/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
@@ -127,7 +127,7 @@ fun mockIssue(
     addDupeMessage: (options: CommentOptions) -> Unit = { },
     addRestrictedComment: (options: CommentOptions) -> Unit = { },
     addNotEnglishComment: (language: String) -> Unit = { },
-    addRawRestrictedComment: (body: String, restrictions: String) -> Unit = { _, _ -> },
+    addRawRestrictedComment: (body: String, restriction: String) -> Unit = { _, _ -> },
     markAsFixedInASpecificVersion: (versionName: String) -> Unit = { },
     changeReporter: (reporter: String) -> Unit = { },
     addAttachment: (file: File, cleanupCallback: () -> Unit) -> Unit = { _, cleanupCallback -> cleanupCallback() }


### PR DESCRIPTION
## Purpose
Sanitize user controlled arguments which are included in bot comments to prevent command injection.

## Approach
- Specify a list of allowed characters, see `Functions.kt#sanitizeCommentArg`
- Make `CommandModule` ignore comments written by bot

## Future work
Together with #671 we should have a single function testing whether an issue has a 'tag' comment, e.g. `MEQS_KEEP_PLATFORM`.
This function should ignore comments written by the bot to prevent tag injection.

#### Checklist
- [x] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
