### PR TITLE
Support custom messages for resolving issue with future version as Invalid

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -190,6 +190,9 @@ arisa:
     futureVersion:
       message: provide-affected-versions
       panel: panel-future-version
+      resolveAsInvalidMessages:
+        # 1.18 experimental snapshots
+        "20215": experimental-snapshot
 
     chk:
       projects:

--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -114,15 +114,20 @@ Resolves an empty report as `Incomplete`.
 | Name  | `FutureVersion`                                                                  |
 | Class | [Link](../src/main/kotlin/io/github/mojira/arisa/modules/FutureVersionModule.kt) |
 
-Removes future versions from the ticket, and resolves it as `Invalid` when the future version is the only version
-the ticket has.
+Removes future versions from the ticket, and resolves it as `Awaiting Response` when the future version is the only version
+the ticket has. If a custom message is specified for a future version by `resolveAsInvalidMessages` in the
+[config](../config/config.yml), the ticket is resolved as `Invalid` instead.
 
 ### Checks
 - Get all the versions of the ticket that are added after last run by non-`staff` users.
 - Any of those versions is a future version.
 - The project of this ticket has a released version.
-- Adds the latest released version to `Affected Versions` and removes all the future versions. If the future version
-  was the only version the ticket has, resolves the ticket as `Invalid`.
+- If the affected versions also contain a released version:
+  - Then: The future version is removed and only a message is added telling the user that future versions may not
+    be selected.
+  - Else: The future version is removed and the latest released version is added to `Affected Versions` and the ticket
+    is resolved. If a custom message for the future version is specified by `resolveAsInvalidMessages` in the
+    [config](../config/config.yml), the ticket is resolved as `Invalid`, otherwise it is resolved as `Awaiting Response`.
 
 ## HideImpostors
 | Entry | Value                                                                            |

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
@@ -46,7 +46,7 @@ object Arisa : ConfigSpec() {
         )
         val special by required<Map<String, String>>(
             description = "Some projects define their own security level. These projects need to be defined here with" +
-                    " their own ID.. Default is all projects use the default ID"
+                    " their own ID. Default is all projects use the default ID."
         )
     }
 
@@ -195,6 +195,13 @@ object Arisa : ConfigSpec() {
             )
             val panel by required<String>(
                 description = "The key of the message that is posted when there are more versions."
+            )
+            val resolveAsInvalidMessages by optional<Map<String, String>>(
+                description = "Map from future version Jira IDs to helper message keys. When an issue only has one " +
+                    "of the listed future versions as affected version the issue is resolved as Invalid (instead of " +
+                    "Awaiting Response) and the respective message is added as comment. By default no messages are " +
+                    "configured.",
+                default = emptyMap()
             )
         }
 

--- a/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
@@ -194,7 +194,8 @@ class InstantModuleRegistry(config: Config) : ModuleRegistry(config) {
             Arisa.Modules.FutureVersion,
             FutureVersionModule(
                 config[Arisa.Modules.FutureVersion.message],
-                config[Arisa.Modules.FutureVersion.panel]
+                config[Arisa.Modules.FutureVersion.panel],
+                config[Arisa.Modules.FutureVersion.resolveAsInvalidMessages]
             )
         )
 

--- a/src/test/kotlin/io/github/mojira/arisa/modules/FutureVersionModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/FutureVersionModuleTest.kt
@@ -1,6 +1,7 @@
 package io.github.mojira.arisa.modules
 
 import io.github.mojira.arisa.domain.CommentOptions
+import io.github.mojira.arisa.domain.Version
 import io.github.mojira.arisa.utils.RIGHT_NOW
 import io.github.mojira.arisa.utils.mockChangeLogItem
 import io.github.mojira.arisa.utils.mockIssue
@@ -12,6 +13,7 @@ import io.kotest.assertions.arrow.either.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 
 private val TWO_SECONDS_AGO = RIGHT_NOW.minusSeconds(2)
@@ -26,7 +28,7 @@ private val ADD_FUTURE_VERSION = mockChangeLogItem(field = "Version", changedTo 
 
 class FutureVersionModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse when there is no change log" {
-        val module = FutureVersionModule("message", "panel")
+        val module = FutureVersionModule("message", "panel", emptyMap())
         val issue = mockIssue(
             created = FIVE_SECONDS_AGO,
             affectedVersions = listOf(FUTURE_VERSION),
@@ -41,7 +43,7 @@ class FutureVersionModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse when there are no version changes" {
-        val module = FutureVersionModule("messgit age", "panel")
+        val module = FutureVersionModule("messgit age", "panel", emptyMap())
         val issue = mockIssue(
             created = FIVE_SECONDS_AGO,
             affectedVersions = listOf(FUTURE_VERSION),
@@ -61,7 +63,7 @@ class FutureVersionModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse when the version change is before last run" {
-        val module = FutureVersionModule("message", "panel")
+        val module = FutureVersionModule("message", "panel", emptyMap())
         val issue = mockIssue(
             created = FIVE_SECONDS_AGO,
             affectedVersions = listOf(FUTURE_VERSION),
@@ -83,7 +85,7 @@ class FutureVersionModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse when the version change is an removal" {
-        val module = FutureVersionModule("message", "panel")
+        val module = FutureVersionModule("message", "panel", emptyMap())
         val issue = mockIssue(
             created = FIVE_SECONDS_AGO,
             affectedVersions = listOf(FUTURE_VERSION),
@@ -104,7 +106,7 @@ class FutureVersionModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse when the future version is added by a staff upon ticket creation" {
-        val module = FutureVersionModule("message", "panel")
+        val module = FutureVersionModule("message", "panel", emptyMap())
         val issue = mockIssue(
             reporter = mockUser(
                 getGroups = { listOf("staff") }
@@ -121,7 +123,7 @@ class FutureVersionModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse when the future version is added by a staff via editing" {
-        val module = FutureVersionModule("message", "panel")
+        val module = FutureVersionModule("message", "panel", emptyMap())
         val issue = mockIssue(
             created = FIVE_SECONDS_AGO,
             affectedVersions = listOf(FUTURE_VERSION),
@@ -143,7 +145,7 @@ class FutureVersionModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse when affected versions are empty" {
-        val module = FutureVersionModule("message", "panel")
+        val module = FutureVersionModule("message", "panel", emptyMap())
         val issue = mockIssue(
             project = mockProject(
                 versions = listOf(RELEASED_VERSION)
@@ -156,7 +158,7 @@ class FutureVersionModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse when project versions are empty" {
-        val module = FutureVersionModule("message", "panel")
+        val module = FutureVersionModule("message", "panel", emptyMap())
         val issue = mockIssue(
             affectedVersions = listOf(FUTURE_VERSION),
             changeLog = listOf(ADD_FUTURE_VERSION)
@@ -168,7 +170,7 @@ class FutureVersionModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse when project versions are null" {
-        val module = FutureVersionModule("message", "panel")
+        val module = FutureVersionModule("message", "panel", emptyMap())
         val issue = mockIssue(
             affectedVersions = listOf(FUTURE_VERSION),
             changeLog = listOf(ADD_FUTURE_VERSION)
@@ -180,7 +182,7 @@ class FutureVersionModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse when project versions do not contain released versions" {
-        val module = FutureVersionModule("message", "panel")
+        val module = FutureVersionModule("message", "panel", emptyMap())
         val issue = mockIssue(
             affectedVersions = listOf(FUTURE_VERSION),
             changeLog = listOf(ADD_FUTURE_VERSION),
@@ -195,7 +197,7 @@ class FutureVersionModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse if no future version is marked affected" {
-        val module = FutureVersionModule("message", "panel")
+        val module = FutureVersionModule("message", "panel", emptyMap())
         val issue = mockIssue(
             affectedVersions = listOf(RELEASED_VERSION),
             changeLog = listOf(ADD_FUTURE_VERSION),
@@ -210,7 +212,7 @@ class FutureVersionModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse if only an archived version is marked affected" {
-        val module = FutureVersionModule("message", "panel")
+        val module = FutureVersionModule("message", "panel", emptyMap())
         val issue = mockIssue(
             affectedVersions = listOf(ARCHIVED_VERSION),
             changeLog = listOf(ADD_ARCHIVED_VERSION),
@@ -242,13 +244,13 @@ class FutureVersionModuleTest : StringSpec({
             archived = false
         )
 
-        val module = FutureVersionModule("message", "panel")
+        val module = FutureVersionModule("message", "panel", emptyMap())
         val issue = mockIssue(
             affectedVersions = listOf(futureVersion),
             project = mockProject(
                 versions = listOf(releasedVersion, futureVersion)
             ),
-            resolveAsInvalid = { isResolved = true },
+            resolveAsAwaitingResponse = { isResolved = true },
             addComment = { addedComment = it },
             removeAffectedVersion = { isRemoved = it.id == "3" },
             addAffectedVersion = { if (it.id == "3") versionsAdded.add("future") else versionsAdded.add("released") }
@@ -281,7 +283,7 @@ class FutureVersionModuleTest : StringSpec({
             archived = false
         )
 
-        val module = FutureVersionModule("message", "panel")
+        val module = FutureVersionModule("message", "panel", emptyMap())
         val issue = mockIssue(
             reporter = mockUser(
                 getGroups = { listOf("user") }
@@ -290,7 +292,7 @@ class FutureVersionModuleTest : StringSpec({
             project = mockProject(
                 versions = listOf(releasedVersion, futureVersion)
             ),
-            resolveAsInvalid = { isResolved = true },
+            resolveAsAwaitingResponse = { isResolved = true },
             addComment = { addedComment = it },
             removeAffectedVersion = { isRemoved = it.id == "3" },
             addAffectedVersion = { if (it.id == "3") versionsAdded.add("future") else versionsAdded.add("released") }
@@ -323,7 +325,7 @@ class FutureVersionModuleTest : StringSpec({
             archived = false
         )
 
-        val module = FutureVersionModule("message", "panel")
+        val module = FutureVersionModule("message", "panel", emptyMap())
         val issue = mockIssue(
             created = FIVE_SECONDS_AGO,
             resolution = "Invalid",
@@ -332,7 +334,7 @@ class FutureVersionModuleTest : StringSpec({
             project = mockProject(
                 versions = listOf(releasedVersion, futureVersion)
             ),
-            resolveAsInvalid = { preResolved = false },
+            resolveAsAwaitingResponse = { preResolved = false },
             addComment = { addedComment = it },
             removeAffectedVersion = { isRemoved = it.id == "3" },
             addAffectedVersion = { if (it.id == "3") versionsAdded.add("future") else versionsAdded.add("released") }
@@ -365,7 +367,7 @@ class FutureVersionModuleTest : StringSpec({
             archived = false
         )
 
-        val module = FutureVersionModule("message", "panel")
+        val module = FutureVersionModule("message", "panel", emptyMap())
         val issue = mockIssue(
             created = FIVE_SECONDS_AGO,
             affectedVersions = listOf(futureVersion),
@@ -373,7 +375,7 @@ class FutureVersionModuleTest : StringSpec({
             project = mockProject(
                 versions = listOf(releasedVersion, futureVersion)
             ),
-            resolveAsInvalid = { isResolved = true },
+            resolveAsAwaitingResponse = { isResolved = true },
             addComment = { addedComment = it },
             removeAffectedVersion = { isRemoved = it.id == "3" },
             addAffectedVersion = { if (it.id == "3") versionsAdded.add("future") else versionsAdded.add("released") }
@@ -406,7 +408,7 @@ class FutureVersionModuleTest : StringSpec({
             archived = false
         )
 
-        val module = FutureVersionModule("message", "panel")
+        val module = FutureVersionModule("message", "panel", emptyMap())
         val issue = mockIssue(
             created = FIVE_SECONDS_AGO,
             affectedVersions = listOf(futureVersion, releasedVersion),
@@ -414,7 +416,7 @@ class FutureVersionModuleTest : StringSpec({
             project = mockProject(
                 versions = listOf(releasedVersion)
             ),
-            resolveAsInvalid = { isResolved = true },
+            resolveAsAwaitingResponse = { isResolved = true },
             addComment = { addedComment = it },
             removeAffectedVersion = { isRemoved = it.id == "3" },
             addAffectedVersion = { if (it.id == "3") versionsAdded.add("future") else versionsAdded.add("released") }
@@ -453,7 +455,7 @@ class FutureVersionModuleTest : StringSpec({
             archived = true
         )
 
-        val module = FutureVersionModule("message", "panel")
+        val module = FutureVersionModule("message", "panel", emptyMap())
         val issue = mockIssue(
             reporter = mockUser(
                 getGroups = { listOf("user") }
@@ -462,7 +464,7 @@ class FutureVersionModuleTest : StringSpec({
             project = mockProject(
                 versions = listOf(releasedVersion, archivedVersion, futureVersion)
             ),
-            resolveAsInvalid = { isResolved = true },
+            resolveAsAwaitingResponse = { isResolved = true },
             addComment = { addedComment = it },
             removeAffectedVersion = { isRemoved = it.id == "3" },
             addAffectedVersion = {
@@ -501,7 +503,7 @@ class FutureVersionModuleTest : StringSpec({
             archived = false
         )
 
-        val module = FutureVersionModule("message", "panel")
+        val module = FutureVersionModule("message", "panel", emptyMap())
         val issue = mockIssue(
             created = FIVE_SECONDS_AGO,
             affectedVersions = listOf(futureVersion),
@@ -515,7 +517,7 @@ class FutureVersionModuleTest : StringSpec({
             project = mockProject(
                 versions = listOf(releasedVersion, futureVersion)
             ),
-            resolveAsInvalid = { isResolved = true },
+            resolveAsAwaitingResponse = { isResolved = true },
             addComment = { addedComment = it },
             removeAffectedVersion = { isRemoved = it.id == "3" },
             addAffectedVersion = { if (it.id == "3") versionsAdded.add("future") else versionsAdded.add("released") }
@@ -536,22 +538,10 @@ class FutureVersionModuleTest : StringSpec({
         val versionsAdded = mutableListOf<String>()
         var addedComment = CommentOptions("")
 
-        val futureVersion = mockVersion(
-            id = "3",
-            released = false,
-            archived = false
-        )
-
-        val releasedVersion = mockVersion(
-            id = "2",
-            released = true,
-            archived = false
-        )
-
-        val module = FutureVersionModule("message", "panel")
+        val module = FutureVersionModule("message", "panel", emptyMap())
         val issue = mockIssue(
             created = FIVE_SECONDS_AGO,
-            affectedVersions = listOf(futureVersion),
+            affectedVersions = listOf(FUTURE_VERSION),
             changeLog = listOf(
                 mockChangeLogItem(
                     field = "Version",
@@ -560,9 +550,9 @@ class FutureVersionModuleTest : StringSpec({
                 )
             ),
             project = mockProject(
-                versions = listOf(releasedVersion, futureVersion)
+                versions = listOf(RELEASED_VERSION, FUTURE_VERSION)
             ),
-            resolveAsInvalid = { isResolved = true },
+            resolveAsAwaitingResponse = { isResolved = true },
             addComment = { addedComment = it },
             removeAffectedVersion = { isRemoved = it.id == "3" },
             addAffectedVersion = { if (it.id == "3") versionsAdded.add("future") else versionsAdded.add("released") }
@@ -575,5 +565,105 @@ class FutureVersionModuleTest : StringSpec({
         isResolved.shouldBeTrue()
         versionsAdded.shouldBe(mutableListOf("released"))
         addedComment shouldBe CommentOptions("message")
+    }
+
+    "should resolve as Invalid when only version with custom message exists" {
+        var isRemoved = false
+        var isResolvedAsAR = false
+        var isResolvedAsInvalid = false
+        val versionsAdded = mutableListOf<Version>()
+        var addedComment: CommentOptions? = null
+
+        val invalidMessage = "custom-message"
+        val resolveAsInvalidMessages = mapOf(FUTURE_VERSION.id to invalidMessage)
+
+        val module = FutureVersionModule("message", "panel", resolveAsInvalidMessages)
+        val issue = mockIssue(
+            reporter = mockUser(
+                getGroups = { listOf("user") }
+            ),
+            affectedVersions = listOf(FUTURE_VERSION),
+            project = mockProject(
+                versions = listOf(RELEASED_VERSION, FUTURE_VERSION)
+            ),
+            resolveAsAwaitingResponse = { isResolvedAsAR = true },
+            resolveAsInvalid = { isResolvedAsInvalid = true },
+            addComment = { addedComment = it },
+            removeAffectedVersion = { isRemoved = it.id == FUTURE_VERSION.id },
+            addAffectedVersion = { versionsAdded.add(it) }
+        )
+
+        val result = module(issue, TWO_SECONDS_AGO)
+
+        result.shouldBeRight(ModuleResponse)
+        isRemoved.shouldBeTrue()
+        isResolvedAsAR.shouldBeFalse()
+        isResolvedAsInvalid.shouldBeTrue()
+        versionsAdded.shouldContainExactly(RELEASED_VERSION)
+        addedComment shouldBe CommentOptions(invalidMessage)
+    }
+
+    // Covers the case where version has been released but Arisa config has not been updated yet
+    "should return OperationNotNeededModuleResponse when version with custom message has been released" {
+        val futureVersion = mockVersion(
+            id = FUTURE_VERSION.id,
+            // Future version has been released in the meantime
+            released = true,
+            archived = false
+        )
+
+        val invalidMessage = "custom-message"
+        val resolveAsInvalidMessages = mapOf(futureVersion.id to invalidMessage)
+
+        val module = FutureVersionModule("message", "panel", resolveAsInvalidMessages)
+        val issue = mockIssue(
+            reporter = mockUser(
+                getGroups = { listOf("user") }
+            ),
+            affectedVersions = listOf(futureVersion),
+            project = mockProject(
+                versions = listOf(RELEASED_VERSION, futureVersion)
+            )
+        )
+
+        val result = module(issue, TWO_SECONDS_AGO)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should not resolve as Invalid when future and released version are marked as affected" {
+        var isRemoved = false
+        var isResolvedAsAR = false
+        var isResolvedAsInvalid = false
+        var hasAddedVersion = false
+        var addedComment: CommentOptions? = null
+
+        val invalidMessage = "custom-message"
+        val resolveAsInvalidMessages = mapOf(FUTURE_VERSION.id to invalidMessage)
+
+        val module = FutureVersionModule("message", "panel", resolveAsInvalidMessages)
+        val issue = mockIssue(
+            reporter = mockUser(
+                getGroups = { listOf("user") }
+            ),
+            affectedVersions = listOf(RELEASED_VERSION, FUTURE_VERSION),
+            project = mockProject(
+                versions = listOf(RELEASED_VERSION, FUTURE_VERSION)
+            ),
+            resolveAsAwaitingResponse = { isResolvedAsAR = true },
+            resolveAsInvalid = { isResolvedAsInvalid = true },
+            addComment = { addedComment = it },
+            removeAffectedVersion = { isRemoved = it.id == FUTURE_VERSION.id },
+            addAffectedVersion = { hasAddedVersion = true }
+        )
+
+        val result = module(issue, TWO_SECONDS_AGO)
+
+        result.shouldBeRight(ModuleResponse)
+        isRemoved.shouldBeTrue()
+        isResolvedAsAR.shouldBeFalse()
+        isResolvedAsInvalid.shouldBeFalse()
+        hasAddedVersion.shouldBeFalse()
+        addedComment shouldBe CommentOptions("panel")
     }
 })


### PR DESCRIPTION
## Purpose
Follow-up for #725
Resolves https://github.com/mojira/helper-messages/issues/161

See also https://github.com/mojira/helper-messages/issues/161#issuecomment-881977354

Instead of resolving all reports with only a future version as Invalid, specify a mapping from version Jira ID to custom message key for resolving reports as Invalid. All other reports will still be resolved as Awaiting Response.
This should help dealing with the increase of 1.18 experimental snapshot reports, but at the same time allows keeping other reports which have other future versions only as Awaiting Response. Additionally the specific message might also help users to report experimental snapshot issues at the correct place.

## Approach
The config for the `FutureVersion` module has now a `resolveAsInvalidMessages` `Map<String, String>` for specifying the mapping from specific future version Jira IDs to respective message keys.
Currently the config contains an entry for the 1.18 future version to the `experimental-snapshot` helper message.

## Open question
Is the approach of assuming that future version 1.18 means the user plays the experimental snapshot correct, or could it confuse new users who just happened to select that version?
Should we maybe adjust `experimental-snapshot` or add a slightly modified variant which also tells the user that they can create a new report with the correct version?

## Future work
Remove mappings again from the config once a future version has been released.
However, it does not cause any issues when mappings are not removed immediately after a future version has been released, the module will simply ignore the mappings.

#### Checklist
- [x] Included tests
- [x] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
