### PR TITLE
Don't transfer launcher legacy version to duplicated report

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -411,6 +411,9 @@ arisa:
     transferVersions:
       resolutions:
         - Duplicate
+      notTransferredVersionIds:
+        # MCL version "1.6.93 (legacy)"; in most cases this is erroneously selected by the user
+        - '18613'
 
     transferLinks:
       resolutions:

--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -420,7 +420,8 @@ Transfers versions from duplicated tickets to their parents.
 
 ### Checks
 - The ticket was linked as a duplicate after last run.
-- The version was released after the oldest version on the parent.
+- The Jira version ID is not listed in `notTransferredVersionIds` specified in the [config](../config/config.yml)
+  (defaults to empty list, i.e. all versions are transferred).
 - The version doesn't exist in the parent yet.
 
 ## UpdateLinked

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
@@ -327,7 +327,12 @@ object Arisa : ConfigSpec() {
             )
         }
 
-        object TransferVersions : ModuleConfigSpec()
+        object TransferVersions : ModuleConfigSpec() {
+            val notTransferredVersionIds by optional<List<String>>(
+                description = "List of Jira version IDs which should not be transferred.",
+                default = emptyList()
+            )
+        }
 
         object TransferLinks : ModuleConfigSpec()
 

--- a/src/main/kotlin/io/github/mojira/arisa/modules/TransferVersionsModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/TransferVersionsModule.kt
@@ -3,7 +3,9 @@ package io.github.mojira.arisa.modules
 import io.github.mojira.arisa.domain.Issue
 import io.github.mojira.arisa.domain.LinkedIssue
 
-class TransferVersionsModule : AbstractTransferFieldModule() {
+class TransferVersionsModule(
+    private val notTransferredVersionIds: List<String> = emptyList()
+) : AbstractTransferFieldModule() {
     override fun filterParents(linkedIssue: LinkedIssue, issue: Issue): Boolean {
         return linkedIssue.isSameProject(issue) && linkedIssue.isUnresolved()
     }
@@ -15,6 +17,7 @@ class TransferVersionsModule : AbstractTransferFieldModule() {
 
             issue.affectedVersions
                 .map { it.id }
+                .filter { it !in notTransferredVersionIds }
                 .filter { it !in parentVersionIds }
                 .map { { parent.addAffectedVersionById(it) } }
         }

--- a/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
@@ -117,7 +117,12 @@ class InstantModuleRegistry(config: Config) : ModuleRegistry(config) {
             )
         )
 
-        register(Arisa.Modules.TransferVersions, TransferVersionsModule())
+        register(
+            Arisa.Modules.TransferVersions,
+            TransferVersionsModule(
+                config[Arisa.Modules.TransferVersions.notTransferredVersionIds]
+            )
+        )
 
         register(
             Arisa.Modules.TransferLinks,


### PR DESCRIPTION
## Purpose
In most cases launcher legacy version was selected erroneously by user, so it should not be transferred to the duplicated report.
This was originally raised by @dericksonmark.

## Approach
Support specifying a list of Jira version IDs for `TransferVersionsModule` which should not be transferred. The `config.yml` currently only contains the version ID of MCL version "1.6.93 (legacy)".

@dericksonmark proposed adding a `ARISA_IGNORE_VERSION <version>` tag which can be added to a report to prevent Arisa from transferring that version. However, that might be a bit cumbersome especially since a large amount (or nearly all) reports with "1.6.93 (legacy)" have selected it erroneously.

#### Checklist
- [x] Included tests
- [x] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
