### PR TITLE
Add module for adding message when user selects legacy launcher version

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -37,6 +37,11 @@ arisa:
       MCL: '10502'
 
   modules:
+    affectedVersionMessage:
+      versionIdMessageMap:
+        # MCL version "1.6.93 (legacy)"; in most cases this is erroneously selected by the user
+        '18613': legacy-launcher-version
+
     attachment:
       extensionBlacklist:
         - '.jar'

--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -6,6 +6,23 @@ When a module is invoked it checks whether any action is needed for an issue, it
 performs one specific task. The execution of a module can be customized through the
 [config file](../config/config.yml)
 
+## AffectedVersionMessage
+| Entry | Value                                                                                     |
+| ----- | ----------------------------------------------------------------------------------------- |
+| Name  | `AffectedVersionMessage`                                                                  |
+| Class | [Link](../src/main/kotlin/io/github/mojira/arisa/modules/AffectedVersionMessageModule.kt) |
+
+Adds a message comment when an issue has a specific version as affected version. However, unlike other modules this
+module does not perform any other action, it neither removes the version nor resolves the issue. This module is
+intended for versions which are often erroneously added by users.
+
+The map from Jira version ID to message key is specified as `versionIdMessageMap` in the [config](../config/config.yml)
+(defaults to empty map).
+
+### Checks
+- The issue has been created after the last run.
+- The issue has not been created by a staff member (helper, moderator or Mojang employee).
+
 ## Attachment
 | Entry | Value                                                                         |
 | ----- | ----------------------------------------------------------------------------- |

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
@@ -99,6 +99,14 @@ object Arisa : ConfigSpec() {
             )
         }
 
+        object AffectedVersionMessage : ModuleConfigSpec() {
+            val versionIdMessageMap by optional<Map<String, String>>(
+                description = "Map from Jira version ID to message key of the message to add when that version has " +
+                        "been selected as affected version.",
+                default = emptyMap()
+            )
+        }
+
         object Attachment : ModuleConfigSpec() {
             val extensionBlacklist by required<List<String>>(
                 description = "The extensions (including leading dots) that should be removed from issues. " +

--- a/src/main/kotlin/io/github/mojira/arisa/modules/AffectedVersionMessageModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/AffectedVersionMessageModule.kt
@@ -1,0 +1,38 @@
+package io.github.mojira.arisa.modules
+
+import arrow.core.Either
+import arrow.core.extensions.fx
+import io.github.mojira.arisa.domain.CommentOptions
+import io.github.mojira.arisa.domain.Issue
+import io.github.mojira.arisa.domain.Version
+import java.time.Instant
+
+/**
+ * Module for adding a message comment when an issue has a specific version. However, unlike other modules
+ * this module does not perform any other action, it neither removes the version nor resolves the issue.
+ * This module is intended for versions which are often erroneously added by users.
+ */
+class AffectedVersionMessageModule(
+    private val versionIdMessageMap: Map<String, String>
+) : Module {
+    override fun invoke(issue: Issue, lastRun: Instant): Either<ModuleError, ModuleResponse> = with(issue) {
+        Either.fx {
+            assertTrue(created.isAfter(lastRun)).bind()
+            // Ignore when created by staff
+            assertFalse(wasCreatedByStaff()).bind()
+
+            // Note: Don't check changelog; assume that versions added after issue was created were added correctly
+            // (though this check here still covers them in case Arisa has not run in between)
+            val message = affectedVersions.asSequence()
+                .map(Version::id)
+                .mapNotNull(versionIdMessageMap::get)
+                .firstOrNull()
+
+            assertNotNull(message).bind()
+            addComment(CommentOptions(message!!))
+        }
+    }
+
+    private fun Issue.wasCreatedByStaff() =
+        reporter?.getGroups?.invoke()?.any { it == "helper" || it == "global-moderators" || it == "staff" } ?: false
+}

--- a/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
@@ -5,6 +5,7 @@ import com.urielsalis.mccrashlib.CrashReader
 import io.github.mojira.arisa.ExecutionTimeframe
 import io.github.mojira.arisa.infrastructure.LanguageDetectionApi
 import io.github.mojira.arisa.infrastructure.config.Arisa
+import io.github.mojira.arisa.modules.AffectedVersionMessageModule
 import io.github.mojira.arisa.modules.AttachmentModule
 import io.github.mojira.arisa.modules.CHKModule
 import io.github.mojira.arisa.modules.CommandModule
@@ -42,6 +43,13 @@ class InstantModuleRegistry(config: Config) : ModuleRegistry(config) {
     }
 
     init {
+        register(
+            Arisa.Modules.AffectedVersionMessage,
+            AffectedVersionMessageModule(
+                config[Arisa.Modules.AffectedVersionMessage.versionIdMessageMap]
+            )
+        )
+
         register(
             Arisa.Modules.Attachment,
             AttachmentModule(

--- a/src/test/kotlin/io/github/mojira/arisa/modules/AffectedVersionMessageModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/AffectedVersionMessageModuleTest.kt
@@ -1,0 +1,102 @@
+package io.github.mojira.arisa.modules
+
+import io.github.mojira.arisa.domain.CommentOptions
+import io.github.mojira.arisa.utils.RIGHT_NOW
+import io.github.mojira.arisa.utils.mockIssue
+import io.github.mojira.arisa.utils.mockUser
+import io.github.mojira.arisa.utils.mockVersion
+import io.kotest.assertions.arrow.either.shouldBeLeft
+import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainAnyOf
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+private val YESTERDAY: Instant = RIGHT_NOW.minus(1, ChronoUnit.DAYS)
+private val VERSION_1 = mockVersion(
+    id = "1"
+)
+private val VERSION_2 = mockVersion(
+    id = "2"
+)
+
+class AffectedVersionMessageModuleTest : StringSpec({
+    "should return OperationNotNeededModuleResponse when version is not in map" {
+        val module = AffectedVersionMessageModule(emptyMap())
+        val issue = mockIssue(
+            affectedVersions = listOf(VERSION_1)
+        )
+
+        val result = module(issue, YESTERDAY)
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when report was created before last run" {
+        val module = AffectedVersionMessageModule(mapOf(
+            VERSION_1.id to "message-1"
+        ))
+        val issue = mockIssue(
+            created = YESTERDAY,
+            affectedVersions = listOf(VERSION_1)
+        )
+
+        val result = module(issue, RIGHT_NOW)
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should return OperationNotNeededModuleResponse when report was created by staff" {
+        val module = AffectedVersionMessageModule(mapOf(
+            VERSION_1.id to "message-1"
+        ))
+        val issue = mockIssue(
+            reporter = mockUser(
+                getGroups = { listOf("staff") }
+            ),
+            affectedVersions = listOf(VERSION_1)
+        )
+
+        val result = module(issue, YESTERDAY)
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should add message when issue has affected version with message" {
+        val module = AffectedVersionMessageModule(mapOf(
+            VERSION_1.id to "message-1"
+        ))
+        val addedMessages = mutableListOf<CommentOptions>()
+
+        val issue = mockIssue(
+            affectedVersions = listOf(VERSION_1),
+            addComment = addedMessages::add
+        )
+
+        val result = module(issue, YESTERDAY)
+        result.shouldBeRight(ModuleResponse)
+        addedMessages shouldContainExactly listOf(CommentOptions("message-1"))
+    }
+
+    "should add only one message" {
+        val module = AffectedVersionMessageModule(mapOf(
+            VERSION_1.id to "message-1",
+            VERSION_2.id to "message-2"
+        ))
+        val addedMessages = mutableListOf<CommentOptions>()
+
+        val issue = mockIssue(
+            affectedVersions = listOf(VERSION_1, VERSION_2),
+            addComment = addedMessages::add
+        )
+
+        val result = module(issue, YESTERDAY)
+        result.shouldBeRight(ModuleResponse)
+
+        // Should only contain 1 message (but does not matter which one)
+        addedMessages shouldHaveSize 1
+        addedMessages shouldContainAnyOf listOf(
+            CommentOptions("message-1"),
+            CommentOptions("message-2")
+        )
+    }
+})

--- a/src/test/kotlin/io/github/mojira/arisa/modules/RemoveSpamModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/RemoveSpamModuleTest.kt
@@ -11,7 +11,7 @@ import io.kotest.matchers.booleans.shouldBeTrue
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
-val YESTERDAY: Instant = RIGHT_NOW.minus(1, ChronoUnit.DAYS)
+private val YESTERDAY: Instant = RIGHT_NOW.minus(1, ChronoUnit.DAYS)
 
 class RemoveSpamModuleTest : StringSpec({
     val module = RemoveSpamModule(listOf(


### PR DESCRIPTION
🚧 Depends on https://github.com/mojira/helper-messages/pull/166

## Purpose
In most cases the legacy launcher version is erroneously selected. The message tells the user to verify that they are actually using the legacy launcher.

## Approach
Adds `AffectedVersionMessageModule` which adds a message comment if a specific version is marked as affected.
The module is configured using a map from Jira version ID to message key.

The `config.yml` contains a mapping entry for "1.6.93 (legacy)" to the message added by https://github.com/mojira/helper-messages/pull/166

## Future work

#### Checklist
- [x] Included tests
- [x] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
