### PR TITLE
Fix `NullPointerException` for FixedCommand

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/domain/Comment.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/domain/Comment.kt
@@ -3,6 +3,7 @@ package io.github.mojira.arisa.domain
 import java.time.Instant
 
 data class Comment(
+    val id: String,
     val body: String?,
     val author: User,
     val getAuthorGroups: () -> List<String>?,

--- a/src/main/kotlin/io/github/mojira/arisa/domain/Version.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/domain/Version.kt
@@ -7,5 +7,9 @@ data class Version(
     val name: String,
     val released: Boolean,
     val archived: Boolean,
+    /**
+     * **Important**: Even if [released]=true the release date may be `null`, examples are:
+     * "Minecraft 19w03c", "Minecraft 19w13b"
+     */
     val releaseDate: Instant?
 )

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
@@ -178,6 +178,7 @@ fun JiraComment.toDomain(
 ): Comment {
     val context = issue.getUpdateContext(jiraClient)
     return Comment(
+        id,
         body,
         author.toDomain(jiraClient),
         { getGroups(jiraClient, author.name).fold({ null }, { it }) },

--- a/src/main/kotlin/io/github/mojira/arisa/modules/CommandModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/CommandModule.kt
@@ -107,7 +107,8 @@ class CommandModule(
         }
 
         val feedback = when (result) {
-            is Either.Left -> result.a.message
+            // Use exception message, or if not present (e.g. for NullPointerException) the string representation
+            is Either.Left -> result.a.message ?: result.a.toString()
             is Either.Right -> "Command was executed successfully, with ${result.b} affected element(s)"
         }
 

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/FixedCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/FixedCommand.kt
@@ -17,11 +17,11 @@ class FixedCommand {
             throw CommandExceptions.ALREADY_RESOLVED.create(issue.resolution)
         }
 
-        if (!force) {
+        if (!force && fixVersion.releaseDate != null) {
             // Fail if any affected version is same or newer than fix version
             // Since archived fix versions cannot be removed again this prevents accidentally adding an incorrect
             // fix version
-            issue.affectedVersions.firstOrNull { it.releaseDate!!.isSameOrAfter(fixVersion.releaseDate!!) }?.let {
+            issue.affectedVersions.firstOrNull { it.releaseDate?.isSameOrAfter(fixVersion.releaseDate) == true }?.let {
                 throw CommandExceptions.FIX_VERSION_SAME_OR_BEFORE_AFFECTED_VERSION.create(fixVersionName, it.name)
             }
         }

--- a/src/test/kotlin/io/github/mojira/arisa/modules/KeepPrivateModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/KeepPrivateModuleTest.kt
@@ -38,7 +38,11 @@ private val REMOVE_SECURITY_STAFF = mockChangeLogItem(
 class KeepPrivateModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse when keep private tag is null" {
         val module = KeepPrivateModule(null, "message")
-        val comment = mockComment("MEQS_KEEP_PRIVATE", visibilityType = "group", visibilityValue = "staff")
+        val comment = mockComment(
+            body = "MEQS_KEEP_PRIVATE",
+            visibilityType = "group",
+            visibilityValue = "staff"
+        )
         val issue = mockIssue(
             comments = listOf(comment),
             changeLog = listOf(REMOVE_SECURITY)

--- a/src/test/kotlin/io/github/mojira/arisa/modules/PrivateDuplicateModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/PrivateDuplicateModuleTest.kt
@@ -22,7 +22,11 @@ private val duplicatesLinkComment = mockLink(
     issue = mockLinkedIssue(
         getFullIssue = { mockIssue(
             securityLevel = "private",
-            comments = listOf(mockComment("MEQS_KEEP_PRIVATE", visibilityType = "group", visibilityValue = "staff"))
+            comments = listOf(mockComment(
+                body = "MEQS_KEEP_PRIVATE",
+                visibilityType = "group",
+                visibilityValue = "staff"
+            ))
         ).right() }
     )
 )

--- a/src/test/kotlin/io/github/mojira/arisa/modules/ReplaceTextModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/ReplaceTextModuleTest.kt
@@ -382,7 +382,8 @@ class ReplaceTextModuleTest : StringSpec({
                     update = {
                         hasUpdatedComment0 = it
                         Unit.right()
-                    }),
+                    }
+                ),
                 mockComment(
                     body = "Check https://bugs.mojang.com/browse/MC-106013 too",
                     updated = RIGHT_NOW.plusSeconds(1),

--- a/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
@@ -60,6 +60,7 @@ fun mockChangeLogItem(
 )
 
 fun mockComment(
+    id: String = "0",
     body: String = "",
     author: User = mockUser(),
     getAuthorGroups: () -> List<String> = { emptyList() },
@@ -70,6 +71,7 @@ fun mockComment(
     restrict: (String) -> Unit = { },
     update: (String) -> Unit = { }
 ) = Comment(
+    id,
     body,
     author,
     getAuthorGroups,


### PR DESCRIPTION
## Purpose
- Fix a `NullPointerException` for `FixedCommand` which occurred when the `releaseDate` of a version is `null`.
There are a few versions which, despite being released, have no release date.
- Improve command feedback for exceptions with `null` message (e.g. `NullPointerException`). Now if the message is `null` the string representation of the exception will be used as message.
- Add logging for command results. Apparently we did not have any logging (?). Now for successful execution an info message is logged and for execution failure an error with the exception is logged.
This should hopefully not cause too much spam in the log because commands are not used that often (?). The log output also includes the used command and the user who executed it.

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [x] Tested in MCTEST-xxx
