### PR TITLE
Use Gradle repository content filtering

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,8 +11,30 @@ version = "1.0-SNAPSHOT"
 
 repositories {
     mavenCentral()
-    maven("https://jitpack.io")
-    maven("https://libraries.minecraft.net")
+    // Dependencies which can only be found in JitPack repository
+    exclusiveContent {
+        forRepository {
+            maven {
+                url = uri("https://jitpack.io")
+            }
+        }
+        filter {
+            includeModule("com.github.rcarz", "jira-client")
+            includeModule("com.github.napstr", "logback-discord-appender")
+        }
+    }
+    // Dependencies which can only be found in Mojang Maven repository
+    exclusiveContent {
+        forRepository {
+            maven {
+                url = uri("https://libraries.minecraft.net")
+            }
+        }
+        filter {
+            // Brigadier is not deployed to Maven Central yet, see https://github.com/Mojang/brigadier/issues/23
+            includeModule("com.mojang", "brigadier")
+        }
+    }
 }
 
 buildscript {


### PR DESCRIPTION
## Purpose
This protects against dependencies being fetched from the wrong repository.

See https://docs.gradle.org/current/userguide/declaring_repositories.html#declaring_content_exclusively_found_in_one_repository

## Approach
Declares that jira-client and logback-discord-appender dependencies can only be found in JitPack repository, and that Brigadier can only be found in the Mojang Maven repository.

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
