### PR TITLE
Make bug reports with attached JFR files private, as they can contain access tokens

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -107,7 +107,6 @@ arisa:
         - '.rtf'
         - '.pptx'
         - '.sys'
-        - '.jfr'
       comment: attach-new-attachment
 
     duplicateMessage:
@@ -184,6 +183,7 @@ arisa:
         - launcher_accounts.json
         - launcher_msa_credentials.json
         - launcher_profiles.json
+        - .jfr
 
     removeTriagedMeqs:
       resolutions:

--- a/config/config.yml
+++ b/config/config.yml
@@ -107,6 +107,7 @@ arisa:
         - '.rtf'
         - '.pptx'
         - '.sys'
+        - '.jfr'
       comment: attach-new-attachment
 
     duplicateMessage:


### PR DESCRIPTION
## Purpose
Block JFR files as they contain access tokens
## Approach
Add it to the extension blacklist
## Future work

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
