### PR TITLE
Refactor PrivacyModule

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -176,14 +176,23 @@ arisa:
 
         ----
         Restricted by PrivacyModule ??[~arisabot]??
-      allowedEmailRegex:
-        - '^(mailer-daemon|postmaster|nobody|noreply|no-reply|hostmaster|usenet|news|webmaster|www|abuse|noc|security|info|support|uucp|ftp|news|admin|root)@.*'
-        - '.*@(mojang.com|microsoft.com|minecraft.net|zendesk.com)$'
-      sensitiveFileNames:
-        - launcher_accounts.json
-        - launcher_msa_credentials.json
-        - launcher_profiles.json
-        - .jfr
+      # Important: These email regex patterns must match the email address completely
+      allowedEmailRegexes:
+        - '(mailer-daemon|postmaster|nobody|noreply|no-reply|hostmaster|usenet|news|webmaster|www|abuse|noc|security|info|support|uucp|ftp|news|admin|root)@.*'
+        - '.*@(mojang\.com|microsoft\.com|minecraft\.net|zendesk\.com)'
+      sensitiveTextRegexes:
+        - '\(Session ID is token:'
+        - '--accessToken ey'
+        - '(?<![^\s])(?=[^\s]*[A-Z])(?=[^\s]*[0-9])[A-Z0-9]{17}(?![^\s])'
+        # At the moment braintree transaction IDs seem to have 8 chars, but to be future-proof
+        # match if there are more chars as well
+        - '\bbraintree:[a-f0-9]{6,12}\b'
+      sensitiveFileNameRegexes:
+        - 'launcher_accounts\.json'
+        - 'launcher_msa_credentials\.json'
+        - 'launcher_profiles\.json'
+        # Java Flight Recorder files contain session token in some Minecraft versions
+        - '.*\.jfr'
 
     removeTriagedMeqs:
       resolutions:

--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -239,13 +239,18 @@ Hides privacy information like Email addresses in tickets or comments.
 ### Checks
 - The ticket is not set to private.
 #### For Setting Tickets to Private
-- Any of the fields and/or text attachments added after last run contains session ID or Email.
-- Or any of the attachments has a name specified by `sensitiveFileNames` in the [config](../config/config.yml)
-  (defaults to empty list)
+- Any of the following matches one of the regex patterns specified by `sensitiveTextRegexes` in the
+  [config](../config/config.yml), or contains an email address which does not match one of the `allowedEmailRegexes`:
+  - summary, environment, description (if ticket was created after last run)
+  - text attachment (if it was created after last run)
+  - changelog entry string value (if it was created after last run)
+- Or any of the attachments created after the last run has a name which matches one of `sensitiveFileNameRegexes` in
+  the [config](../config/config.yml).
 #### For Restricting Comments to `staff`
 - The comment was added after last run.
 - The comment is not restricted.
-- The comment contains session ID or Email.
+- The comment matches one of the regex patterns specified by `sensitiveTextRegexes` in the
+  [config](../config/config.yml), or contains an email address which does not match one of the `allowedEmailRegexes`.
 
 ## PrivateDuplicate
 | Entry | Value                                                                               |

--- a/src/main/kotlin/io/github/mojira/arisa/ConfigService.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ConfigService.kt
@@ -1,13 +1,17 @@
 package io.github.mojira.arisa
 
 import com.uchuhimo.konf.Config
+import com.uchuhimo.konf.Feature
 import com.uchuhimo.konf.source.yaml
 import io.github.mojira.arisa.infrastructure.config.Arisa
 
 class ConfigService {
     val config: Config = Config { addSpec(Arisa) }
-        .from.yaml.watchFile("config/config.yml")
-        .from.yaml.watchFile("config/local.yml")
+        // Only enable strict config parsing for YAML files; environment variables and system properties
+        // likely contain entries completely unrelated to Arisa
+        .from.enabled(Feature.FAIL_ON_UNKNOWN_PATH).yaml.watchFile("config/config.yml")
+        .from.enabled(Feature.FAIL_ON_UNKNOWN_PATH).yaml.watchFile("config/local.yml")
         .from.env()
         .from.systemProperties()
+        .validateRequired()
 }

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
@@ -160,13 +160,21 @@ object Arisa : ConfigSpec() {
                 "",
                 description = "The text which will be appended at the comments that are restricted by this module."
             )
-            val allowedEmailRegex by optional<List<String>>(
+            val allowedEmailRegexes by optional<List<String>>(
                 default = emptyList(),
-                description = "List of regex for allowed emails"
+                description = "Regex patterns matching allowed email addresses, that is, email addresses which may" +
+                    " be public. The patterns must match the complete email address; partial matches won't have any" +
+                    " effect."
             )
-            val sensitiveFileNames by optional<List<String>>(
+            val sensitiveTextRegexes by optional<List<String>>(
                 default = emptyList(),
-                description = "Names of attachment files containing sensitive information"
+                description = "Regex patterns matching sensitive text. The patterns do not have to match the" +
+                    " complete text; partial matches will be detected as well."
+            )
+            val sensitiveFileNameRegexes by optional<List<String>>(
+                default = emptyList(),
+                description = "Regex patterns matching names of attachment files containing sensitive information." +
+                    " The patterns must match the complete file name; partial matches won't have any effect."
             )
         }
 

--- a/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
@@ -156,8 +156,9 @@ class InstantModuleRegistry(config: Config) : ModuleRegistry(config) {
             PrivacyModule(
                 config[Arisa.Modules.Privacy.message],
                 config[Arisa.Modules.Privacy.commentNote],
-                config[Arisa.Modules.Privacy.allowedEmailRegex].map(String::toRegex),
-                config[Arisa.Modules.Privacy.sensitiveFileNames]
+                config[Arisa.Modules.Privacy.allowedEmailRegexes].map(String::toRegex),
+                config[Arisa.Modules.Privacy.sensitiveTextRegexes].map(String::toRegex),
+                config[Arisa.Modules.Privacy.sensitiveFileNameRegexes].map(String::toRegex)
             )
         )
 

--- a/src/test/kotlin/io/github/mojira/arisa/infrastructure/IntegrationTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/infrastructure/IntegrationTest.kt
@@ -1,6 +1,7 @@
 package io.github.mojira.arisa.infrastructure
 
 import com.uchuhimo.konf.Config
+import com.uchuhimo.konf.Feature
 import com.uchuhimo.konf.source.yaml
 import io.github.mojira.arisa.infrastructure.config.Arisa
 import io.kotest.core.spec.style.StringSpec
@@ -10,14 +11,16 @@ import java.io.File
 class IntegrationTest : StringSpec({
     "should be able to read the main config file correctly" {
         val config = Config { addSpec(Arisa) }
-            .from.map.flat(
+            // Only enable strict config parsing for map and YAML files; environment variables and system properties
+            // likely contain entries completely unrelated to Arisa
+            .from.enabled(Feature.FAIL_ON_UNKNOWN_PATH).map.flat(
                 mapOf(
                     "arisa.credentials.username" to "test",
                     "arisa.credentials.password" to "test",
                     "arisa.credentials.dandelionToken" to "test"
                 )
             )
-            .from.yaml.watchFile("config/config.yml")
+            .from.enabled(Feature.FAIL_ON_UNKNOWN_PATH).yaml.watchFile("config/config.yml")
             .from.env()
             .from.systemProperties()
 

--- a/src/test/kotlin/io/github/mojira/arisa/modules/PrivacyModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/PrivacyModuleTest.kt
@@ -1,5 +1,6 @@
 package io.github.mojira.arisa.modules
 
+import io.github.mojira.arisa.domain.CommentOptions
 import io.github.mojira.arisa.utils.RIGHT_NOW
 import io.github.mojira.arisa.utils.mockAttachment
 import io.github.mojira.arisa.utils.mockChangeLogItem
@@ -7,420 +8,519 @@ import io.github.mojira.arisa.utils.mockComment
 import io.github.mojira.arisa.utils.mockIssue
 import io.kotest.assertions.arrow.either.shouldBeLeft
 import io.kotest.assertions.arrow.either.shouldBeRight
-import io.kotest.core.spec.style.StringSpec
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
-private val ALLOWED_REGEX = listOf("allowed@.*".toRegex())
-private val MODULE = PrivacyModule("message", "\n----\nRestricted by PrivacyModule ??[~arisabot]??", ALLOWED_REGEX, emptyList())
 private val TWO_SECONDS_AGO = RIGHT_NOW.minusSeconds(2)
 private val TEN_SECONDS_AGO = RIGHT_NOW.minusSeconds(10)
 
-class PrivacyModuleTest : StringSpec({
-    "should return OperationNotNeededModuleResponse when the ticket is marked as private" {
-        val issue = mockIssue(
-            securityLevel = "private"
+private const val MADE_PRIVATE_MESSAGE = "made-private"
+private const val COMMENT_NOTE = "\n----\nRestricted by PrivacyModule ??[~arisabot]??"
+
+private fun createModule(
+    message: String = MADE_PRIVATE_MESSAGE,
+    commentNote: String = COMMENT_NOTE,
+    allowedEmailRegexes: List<Regex> = emptyList(),
+    sensitiveTextRegexes: List<Regex> = emptyList(),
+    sensitiveFileNameRegexes: List<Regex> = emptyList()
+) = PrivacyModule(
+    message,
+    commentNote,
+    allowedEmailRegexes,
+    sensitiveTextRegexes,
+    sensitiveFileNameRegexes
+)
+
+class PrivacyModuleTest : FunSpec({
+    data class ContentTestData(
+        val module: PrivacyModule,
+        val sensitiveText: String,
+        val testType: String
+    )
+
+    // Shared tests for email address and sensitive text detection
+    listOf(
+        ContentTestData(
+            createModule(),
+            "some text and test@example.com and \n another line",
+            "email"
+        ),
+        ContentTestData(
+            createModule(sensitiveTextRegexes = listOf(Regex.fromLiteral("sensitive"))),
+            "some sensitive text and \n another line",
+            "sensitive text"
         )
+    ).forEach { testData ->
+        context(testData.testType) {
+            context("ticket") {
+                test("should return OperationNotNeededModuleResponse when the ticket is marked as private") {
+                    val issue = mockIssue(
+                        securityLevel = "private",
+                        summary = testData.sensitiveText,
+                        environment = testData.sensitiveText,
+                        description = testData.sensitiveText,
+                        attachments = listOf(
+                            mockAttachment(
+                                name = testData.sensitiveText,
+                                getContent = { testData.sensitiveText.toByteArray() }
+                            )
+                        )
+                    )
 
-        val result = MODULE(issue, TWO_SECONDS_AGO)
+                    val result = testData.module(issue, TWO_SECONDS_AGO)
 
-        result.shouldBeLeft(OperationNotNeededModuleResponse)
+                    result.shouldBeLeft(OperationNotNeededModuleResponse)
+                }
+
+                test("should return OperationNotNeededModuleResponse when the ticket is created before lastRun") {
+                    val issue = mockIssue(
+                        created = TEN_SECONDS_AGO,
+                        description = testData.sensitiveText
+                    )
+
+                    val result = testData.module(issue, TWO_SECONDS_AGO)
+
+                    result.shouldBeLeft(OperationNotNeededModuleResponse)
+                }
+
+                test("should return OperationNotNeededModuleResponse when the attachment is created before lastRun") {
+                    val issue = mockIssue(
+                        attachments = listOf(
+                            mockAttachment(
+                                created = TEN_SECONDS_AGO,
+                                getContent = { testData.sensitiveText.toByteArray() }
+                            )
+                        )
+                    )
+
+                    val result = testData.module(issue, TWO_SECONDS_AGO)
+
+                    result.shouldBeLeft(OperationNotNeededModuleResponse)
+                }
+
+                test("should return OperationNotNeededModuleResponse when the attachment is not a text file") {
+                    val issue = mockIssue(
+                        attachments = listOf(
+                            mockAttachment(
+                                mimeType = "image/png",
+                                getContent = { testData.sensitiveText.toByteArray() }
+                            )
+                        )
+                    )
+
+                    val result = testData.module(issue, TWO_SECONDS_AGO)
+
+                    result.shouldBeLeft(OperationNotNeededModuleResponse)
+                }
+
+                test("should return OperationNotNeededModuleResponse when the change log item is created before lastRun") {
+                    val issue = mockIssue(
+                        changeLog = listOf(
+                            mockChangeLogItem(
+                                created = TEN_SECONDS_AGO,
+                                changedFromString = null,
+                                changedToString = testData.sensitiveText
+                            )
+                        )
+                    )
+
+                    val result = testData.module(issue, TWO_SECONDS_AGO)
+
+                    result.shouldBeLeft(OperationNotNeededModuleResponse)
+                }
+
+                test("should return OperationNotNeededModuleResponse when the ticket does not contain sensitive data") {
+                    val issue = mockIssue(
+                        summary = "Test"
+                    )
+
+                    val result = testData.module(issue, TWO_SECONDS_AGO)
+
+                    result.shouldBeLeft(OperationNotNeededModuleResponse)
+                }
+
+                test("should mark as private when the attachment contains sensitive data") {
+                    var hasSetPrivate = false
+                    var addedComment: CommentOptions? = null
+
+                    val issue = mockIssue(
+                        attachments = listOf(
+                            mockAttachment(
+                                getContent = { testData.sensitiveText.toByteArray() }
+                            )
+                        ),
+                        setPrivate = { hasSetPrivate = true },
+                        addComment = { addedComment = it }
+                    )
+
+                    val result = testData.module(issue, TWO_SECONDS_AGO)
+
+                    result.shouldBeRight(ModuleResponse)
+                    hasSetPrivate shouldBe true
+                    addedComment shouldBe CommentOptions(MADE_PRIVATE_MESSAGE)
+                }
+
+                test("should mark as private when the summary contains sensitive data") {
+                    var hasSetPrivate = false
+                    var addedComment: CommentOptions? = null
+
+                    val issue = mockIssue(
+                        summary = testData.sensitiveText,
+                        setPrivate = { hasSetPrivate = true },
+                        addComment = { addedComment = it }
+                    )
+
+                    val result = testData.module(issue, TWO_SECONDS_AGO)
+
+                    result.shouldBeRight(ModuleResponse)
+                    hasSetPrivate shouldBe true
+                    addedComment shouldBe CommentOptions(MADE_PRIVATE_MESSAGE)
+                }
+
+                test("should mark as private when the environment contains sensitive data") {
+                    var hasSetPrivate = false
+                    var addedComment: CommentOptions? = null
+
+                    val issue = mockIssue(
+                        environment = testData.sensitiveText,
+                        setPrivate = { hasSetPrivate = true },
+                        addComment = { addedComment = it }
+                    )
+
+                    val result = testData.module(issue, TWO_SECONDS_AGO)
+
+                    result.shouldBeRight(ModuleResponse)
+                    hasSetPrivate shouldBe true
+                    addedComment shouldBe CommentOptions(MADE_PRIVATE_MESSAGE)
+                }
+
+                test("should mark as private when the description contains sensitive data") {
+                    var hasSetPrivate = false
+                    var addedComment: CommentOptions? = null
+
+                    val issue = mockIssue(
+                        description = testData.sensitiveText,
+                        setPrivate = { hasSetPrivate = true },
+                        addComment = { addedComment = it }
+                    )
+
+                    val result = testData.module(issue, TWO_SECONDS_AGO)
+
+                    result.shouldBeRight(ModuleResponse)
+                    hasSetPrivate shouldBe true
+                    addedComment shouldBe CommentOptions(MADE_PRIVATE_MESSAGE)
+                }
+
+                test("should mark as private when the change log item contains sensitive data") {
+                    var hasSetPrivate = false
+                    var addedComment: CommentOptions? = null
+
+                    val issue = mockIssue(
+                        changeLog = listOf(
+                            mockChangeLogItem(
+                                field = "environment",
+                                changedFromString = null,
+                                changedToString = testData.sensitiveText
+                            )
+                        ),
+                        setPrivate = { hasSetPrivate = true },
+                        addComment = { addedComment = it }
+                    )
+
+                    val result = testData.module(issue, TWO_SECONDS_AGO)
+
+                    result.shouldBeRight(ModuleResponse)
+                    hasSetPrivate shouldBe true
+                    addedComment shouldBe CommentOptions(MADE_PRIVATE_MESSAGE)
+                }
+            }
+
+            context("comment") {
+                test("should return OperationNotNeededModuleResponse when the ticket is marked as private") {
+                    val issue = mockIssue(
+                        securityLevel = "private",
+                        comments = listOf(
+                            mockComment(
+                                body = testData.sensitiveText
+                            )
+                        )
+                    )
+
+                    val result = testData.module(issue, TWO_SECONDS_AGO)
+
+                    result.shouldBeLeft(OperationNotNeededModuleResponse)
+                }
+
+                test("should return OperationNotNeededModuleResponse when the comment is created before lastRun") {
+                    val issue = mockIssue(
+                        comments = listOf(
+                            mockComment(
+                                body = testData.sensitiveText,
+                                created = TEN_SECONDS_AGO
+                            )
+                        )
+                    )
+
+                    val result = testData.module(issue, TWO_SECONDS_AGO)
+
+                    result.shouldBeLeft(OperationNotNeededModuleResponse)
+                }
+
+                test("should return OperationNotNeededModuleResponse when the comment is not public") {
+                    val issue = mockIssue(
+                        comments = listOf(
+                            mockComment(
+                                body = testData.sensitiveText,
+                                visibilityType = "group",
+                                visibilityValue = "helper"
+                            )
+                        )
+                    )
+
+                    val result = testData.module(issue, TWO_SECONDS_AGO)
+
+                    result.shouldBeLeft(OperationNotNeededModuleResponse)
+                }
+
+                test("should restrict to staff when the comment contains sensitive data") {
+                    var hasSetPrivate = false
+                    var hasRestrictedComment = false
+
+                    val issue = mockIssue(
+                        comments = listOf(
+                            mockComment(
+                                body = testData.sensitiveText,
+                                restrict = {
+                                    hasRestrictedComment = true
+                                    it shouldBe "${testData.sensitiveText}$COMMENT_NOTE"
+                                }
+                            )
+                        ),
+                        setPrivate = { hasSetPrivate = true }
+                    )
+
+                    val result = testData.module(issue, TWO_SECONDS_AGO)
+
+                    result.shouldBeRight(ModuleResponse)
+                    hasSetPrivate shouldBe false
+                    hasRestrictedComment shouldBe true
+                }
+            }
+        }
     }
 
-    "should return OperationNotNeededModuleResponse when the ticket is created before lastRun" {
-        val issue = mockIssue(
-            created = TEN_SECONDS_AGO,
-            description = "foo@example.com"
-        )
-
-        val result = MODULE(issue, TWO_SECONDS_AGO)
-
-        result.shouldBeLeft(OperationNotNeededModuleResponse)
-    }
-
-    "should return OperationNotNeededModuleResponse when the comment is created before lastRun" {
-        val issue = mockIssue(
-            comments = listOf(
-                mockComment(
-                    body = "foo@example.com",
-                    created = TEN_SECONDS_AGO
-                )
+    // Tests specific to email address detection, which cannot be shared with 'sensitive text' tests above
+    context("email (specific)") {
+        test("should return OperationNotNeededModuleResponse when the email address is contained in a user mention") {
+            val issue = mockIssue(
+                summary = "[~foo@example.com]"
             )
-        )
 
-        val result = MODULE(issue, TWO_SECONDS_AGO)
+            val result = createModule()(issue, TWO_SECONDS_AGO)
 
-        result.shouldBeLeft(OperationNotNeededModuleResponse)
-    }
+            result.shouldBeLeft(OperationNotNeededModuleResponse)
+        }
 
-    "should return OperationNotNeededModuleResponse when the comment is not public" {
-        val issue = mockIssue(
-            comments = listOf(
-                mockComment(
-                    body = "foo@example.com",
-                    visibilityType = "group",
-                    visibilityValue = "helper"
-                )
+        test("should mark as private when the email is contained in a link") {
+            var hasSetPrivate = false
+            var addedComment: CommentOptions? = null
+
+            val issue = mockIssue(
+                description = "[foo@example.com|mailto:foo@example.com]",
+                setPrivate = { hasSetPrivate = true },
+                addComment = { addedComment = it }
             )
-        )
 
-        val result = MODULE(issue, TWO_SECONDS_AGO)
+            val result = createModule()(issue, TWO_SECONDS_AGO)
 
-        result.shouldBeLeft(OperationNotNeededModuleResponse)
-    }
+            result.shouldBeRight(ModuleResponse)
+            hasSetPrivate shouldBe true
+            addedComment shouldBe CommentOptions(MADE_PRIVATE_MESSAGE)
+        }
 
-    "should return OperationNotNeededModuleResponse when the attachment is created before lastRun" {
-        val issue = mockIssue(
-            attachments = listOf(
-                mockAttachment(
-                    created = TEN_SECONDS_AGO,
-                    getContent = { "foo@example.com".toByteArray() }
-                )
+        test("should mark as private when the email address contains dots") {
+            var hasSetPrivate = false
+            var addedComment: CommentOptions? = null
+
+            val issue = mockIssue(
+                summary = "f.o.o@example.com",
+                setPrivate = { hasSetPrivate = true },
+                addComment = { addedComment = it }
             )
-        )
 
-        val result = MODULE(issue, TWO_SECONDS_AGO)
+            val result = createModule()(issue, TWO_SECONDS_AGO)
 
-        result.shouldBeLeft(OperationNotNeededModuleResponse)
-    }
+            result.shouldBeRight(ModuleResponse)
+            hasSetPrivate shouldBe true
+            addedComment shouldBe CommentOptions(MADE_PRIVATE_MESSAGE)
+        }
 
-    "should return OperationNotNeededModuleResponse when the attachment is not a text file" {
-        val issue = mockIssue(
-            attachments = listOf(
-                mockAttachment(
-                    mimeType = "image/png",
-                    getContent = { "foo@example.com".toByteArray() }
-                )
+        test("should mark as private when the email address uses .cc tld") {
+            var hasSetPrivate = false
+            var addedComment: CommentOptions? = null
+
+            val issue = mockIssue(
+                summary = "foo@example.cc",
+                setPrivate = { hasSetPrivate = true },
+                addComment = { addedComment = it }
             )
-        )
 
-        val result = MODULE(issue, TWO_SECONDS_AGO)
+            val result = createModule()(issue, TWO_SECONDS_AGO)
 
-        result.shouldBeLeft(OperationNotNeededModuleResponse)
-    }
+            result.shouldBeRight(ModuleResponse)
+            hasSetPrivate shouldBe true
+            addedComment shouldBe CommentOptions(MADE_PRIVATE_MESSAGE)
+        }
 
-    "should return OperationNotNeededModuleResponse when the change log item is created before lastRun" {
-        val issue = mockIssue(
-            changeLog = listOf(
-                mockChangeLogItem(
-                    created = TEN_SECONDS_AGO,
-                    changedFromString = null,
-                    changedToString = "foo@example.com"
-                )
+        test("should mark as private when the email address uses .americanexpress tld") {
+            var hasSetPrivate = false
+            var addedComment: CommentOptions? = null
+
+            val issue = mockIssue(
+                summary = "foo@example.americanexpress",
+                setPrivate = { hasSetPrivate = true },
+                addComment = { addedComment = it }
             )
-        )
 
-        val result = MODULE(issue, TWO_SECONDS_AGO)
+            val result = createModule()(issue, TWO_SECONDS_AGO)
 
-        result.shouldBeLeft(OperationNotNeededModuleResponse)
+            result.shouldBeRight(ModuleResponse)
+            hasSetPrivate shouldBe true
+            addedComment shouldBe CommentOptions(MADE_PRIVATE_MESSAGE)
+        }
+
+        test("should not mark as private when the change log item contains an allowed email") {
+            val allowedEmail = "allowed@example.com"
+            val allowedEmailRegexes = listOf(Regex.fromLiteral(allowedEmail))
+            val module = createModule(allowedEmailRegexes = allowedEmailRegexes)
+            var hasSetPrivate = false
+
+            val issue = mockIssue(
+                changeLog = listOf(
+                    mockChangeLogItem(
+                        field = "environment",
+                        changedFromString = null,
+                        changedToString = "My email is $allowedEmail."
+                    )
+                ),
+                setPrivate = { hasSetPrivate = true }
+            )
+
+            val result = module(issue, TWO_SECONDS_AGO)
+
+            result.shouldBeLeft(OperationNotNeededModuleResponse)
+            hasSetPrivate shouldBe false
+        }
+
+        test("should mark as private when the change log item contains an allowed email and a not allowed email") {
+            val allowedEmail = "allowed@example.com"
+            val allowedEmailRegexes = listOf(Regex.fromLiteral(allowedEmail))
+            val module = createModule(allowedEmailRegexes = allowedEmailRegexes)
+            var hasSetPrivate = false
+            var addedComment: CommentOptions? = null
+
+            val issue = mockIssue(
+                changeLog = listOf(
+                    mockChangeLogItem(
+                        field = "environment",
+                        changedFromString = null,
+                        changedToString = "My email is $allowedEmail but I also use foo@example.com."
+                    )
+                ),
+                setPrivate = { hasSetPrivate = true },
+                addComment = { addedComment = it }
+            )
+
+            val result = module(issue, TWO_SECONDS_AGO)
+
+            result.shouldBeRight(ModuleResponse)
+            hasSetPrivate shouldBe true
+            addedComment shouldBe CommentOptions(MADE_PRIVATE_MESSAGE)
+        }
     }
 
-    "should return OperationNotNeededModuleResponse when the ticket doesn't match the patterns" {
-        val issue = mockIssue(
-            summary = "Test"
-        )
-
-        val result = MODULE(issue, TWO_SECONDS_AGO)
-
-        result.shouldBeLeft(OperationNotNeededModuleResponse)
-    }
-
-    "should mark as private when the summary contains Email" {
-        var hasSetPrivate = false
-
-        val issue = mockIssue(
-            summary = "foo_bar@example.com",
-            setPrivate = { hasSetPrivate = true }
-        )
-
-        val result = MODULE(issue, TWO_SECONDS_AGO)
-
-        result.shouldBeRight(ModuleResponse)
-        hasSetPrivate shouldBe true
-    }
-
-    "should mark as private when the Email address contains dots" {
-        var hasSetPrivate = false
-
-        val issue = mockIssue(
-            summary = "f.o.o@example.com",
-            setPrivate = { hasSetPrivate = true }
-        )
-
-        val result = MODULE(issue, TWO_SECONDS_AGO)
-
-        result.shouldBeRight(ModuleResponse)
-        hasSetPrivate shouldBe true
-    }
-
-    "should mark as private when the Email address uses .cc tld" {
-        var hasSetPrivate = false
-
-        val issue = mockIssue(
-            summary = "foo@example.cc",
-            setPrivate = { hasSetPrivate = true }
-        )
-
-        val result = MODULE(issue, TWO_SECONDS_AGO)
-
-        result.shouldBeRight(ModuleResponse)
-        hasSetPrivate shouldBe true
-    }
-
-    "should mark as private when the Email address uses .americanexpress tld" {
-        var hasSetPrivate = false
-
-        val issue = mockIssue(
-            summary = "foo@example.americanexpress",
-            setPrivate = { hasSetPrivate = true }
-        )
-
-        val result = MODULE(issue, TWO_SECONDS_AGO)
-
-        result.shouldBeRight(ModuleResponse)
-        hasSetPrivate shouldBe true
-    }
-
-    "should mark as private when the environment contains Email" {
-        var hasSetPrivate = false
-
-        val issue = mockIssue(
-            environment = "foo@example.com",
-            setPrivate = { hasSetPrivate = true }
-        )
-
-        val result = MODULE(issue, TWO_SECONDS_AGO)
-
-        result.shouldBeRight(ModuleResponse)
-        hasSetPrivate shouldBe true
-    }
-
-    "should mark as private when the description contains Email" {
-        var hasSetPrivate = false
-
-        val issue = mockIssue(
-            description = "foo@example.com",
-            setPrivate = { hasSetPrivate = true }
-        )
-
-        val result = MODULE(issue, TWO_SECONDS_AGO)
-
-        result.shouldBeRight(ModuleResponse)
-        hasSetPrivate shouldBe true
-    }
-
-    "should mark as private when the description contains braintree transaction ID" {
-        var hasSetPrivate = false
-
-        val issue = mockIssue(
-            description = "My transaction id: *braintree:1a2b3c4d*",
-            setPrivate = { hasSetPrivate = true }
-        )
-
-        val result = MODULE(issue, TWO_SECONDS_AGO)
-
-        result.shouldBeRight(ModuleResponse)
-        hasSetPrivate shouldBe true
-    }
-
-    "should mark as private when the attachment contains Email" {
-        var hasSetPrivate = false
-
-        val issue = mockIssue(
-            attachments = listOf(
-                mockAttachment(
-                    getContent = { "foo@example.com".toByteArray() }
-                )
-            ),
-            setPrivate = { hasSetPrivate = true }
-        )
-
-        val result = MODULE(issue, TWO_SECONDS_AGO)
-
-        result.shouldBeRight(ModuleResponse)
-        hasSetPrivate shouldBe true
-    }
-
-    "should return OperationNotNeededModuleResponse when the email address is contained in a user mention" {
-        val issue = mockIssue(
-            summary = "[~foo@example.com]"
-        )
-
-        val result = MODULE(issue, TWO_SECONDS_AGO)
-
-        result.shouldBeLeft(OperationNotNeededModuleResponse)
-    }
-
-    "should mark as private when the Email is contained in a link" {
-        var hasSetPrivate = false
-
-        val issue = mockIssue(
-            description = "[foo@example.com|mailto:foo@example.com]",
-            setPrivate = { hasSetPrivate = true }
-        )
-
-        val result = MODULE(issue, TWO_SECONDS_AGO)
-
-        result.shouldBeRight(ModuleResponse)
-        hasSetPrivate shouldBe true
-    }
-
-    "should mark as private when the attachment contains session ID" {
-        var hasSetPrivate = false
-
-        val issue = mockIssue(
-            attachments = listOf(
-                mockAttachment(
-                    getContent = { "(Session ID is token:My1_hnfNSd3nyQ7IbbnGbTS1fgJuM6JkfH2WEKaTTOLPc)".toByteArray() }
-                )
-            ),
-            setPrivate = { hasSetPrivate = true }
-        )
-
-        val result = MODULE(issue, TWO_SECONDS_AGO)
-
-        result.shouldBeRight(ModuleResponse)
-        hasSetPrivate shouldBe true
-    }
-
-    "should mark as private when the attachment contains access token" {
-        var hasSetPrivate = false
-
-        val issue = mockIssue(
-            attachments = listOf(
-                mockAttachment(
-                    getContent = { "--uuid 1312dkkdk2kdart342 --accessToken eyJimfake.12345.fakestuff --userType mojang".toByteArray() }
-                )
-            ),
-            setPrivate = { hasSetPrivate = true }
-        )
-
-        val result = MODULE(issue, TWO_SECONDS_AGO)
-
-        result.shouldBeRight(ModuleResponse)
-        hasSetPrivate shouldBe true
-    }
-
-    "should mark as private when the change log item contains email" {
-        var hasSetPrivate = false
-
-        val issue = mockIssue(
-            changeLog = listOf(
-                mockChangeLogItem(
-                    field = "environment",
-                    changedFromString = null,
-                    changedToString = "My email is foo@example.com."
-                )
-            ),
-            setPrivate = { hasSetPrivate = true }
-        )
-
-        val result = MODULE(issue, TWO_SECONDS_AGO)
-
-        result.shouldBeRight(ModuleResponse)
-        hasSetPrivate shouldBe true
-    }
-
-    "should not mark as private when the change log item contains an allowed email" {
-        var hasSetPrivate = false
-
-        val issue = mockIssue(
-            changeLog = listOf(
-                mockChangeLogItem(
-                    field = "environment",
-                    changedFromString = null,
-                    changedToString = "My email is allowed@example.com."
-                )
-            ),
-            setPrivate = { hasSetPrivate = true }
-        )
-
-        val result = MODULE(issue, TWO_SECONDS_AGO)
-
-        result.shouldBeLeft(OperationNotNeededModuleResponse)
-        hasSetPrivate shouldBe false
-    }
-
-    "should mark as private when the change log item contains an allowed email and a not allowed email" {
-        var hasSetPrivate = false
-
-        val issue = mockIssue(
-            changeLog = listOf(
-                mockChangeLogItem(
-                    field = "environment",
-                    changedFromString = null,
-                    changedToString = "My email is allowed@example.com but I also use foo@example.com."
-                )
-            ),
-            setPrivate = { hasSetPrivate = true }
-        )
-
-        val result = MODULE(issue, TWO_SECONDS_AGO)
-
-        result.shouldBeRight(ModuleResponse)
-        hasSetPrivate shouldBe true
-    }
-
-    "should restrict to staff when the comment contains Email" {
-        var hasSetPrivate = false
-        var hasRestrictedComment = false
-
-        val issue = mockIssue(
-            comments = listOf(
-                mockComment(
-                    body = "foo@example.com",
-                    restrict = {
-                        hasRestrictedComment = true
-                        it shouldBe "foo@example.com\n----\nRestricted by PrivacyModule ??[~arisabot]??"
-                    }
-                )
-            ),
-            setPrivate = { hasSetPrivate = true }
-        )
-
-        val result = MODULE(issue, TWO_SECONDS_AGO)
-
-        result.shouldBeRight(ModuleResponse)
-        hasSetPrivate shouldBe false
-        hasRestrictedComment shouldBe true
-    }
-
-    "should mark as private when attachment has sensitive name" {
-        val sensitiveFileName = "sensitive.txt"
-        val module = PrivacyModule("message", "comment", ALLOWED_REGEX, listOf(sensitiveFileName))
-        var hasSetPrivate = false
-
-        val issue = mockIssue(
-            attachments = listOf(
-                mockAttachment(
-                    name = sensitiveFileName
-                )
-            ),
-            setPrivate = { hasSetPrivate = true }
-        )
-
-        val result = module(issue, TWO_SECONDS_AGO)
-
-        result.shouldBeRight(ModuleResponse)
-        hasSetPrivate shouldBe true
-    }
-
-    "should not mark as private when attachment has non-sensitive name" {
-        val sensitiveFileName = "sensitive.txt"
-        val module = PrivacyModule("message", "comment", ALLOWED_REGEX, listOf(sensitiveFileName))
-        var hasSetPrivate = false
-
-        val issue = mockIssue(
-            attachments = listOf(
-                mockAttachment(
-                    name = "non-$sensitiveFileName"
-                )
-            ),
-            setPrivate = { hasSetPrivate = true }
-        )
-
-        val result = module(issue, TWO_SECONDS_AGO)
-
-        result.shouldBeLeft(OperationNotNeededModuleResponse)
-        hasSetPrivate shouldBe false
+    context("sensitive file names") {
+            val sensitiveFileName = "sensitive.txt"
+            val module = createModule(sensitiveFileNameRegexes = listOf(Regex.fromLiteral(sensitiveFileName)))
+
+        test("should not mark as private when attachment has been created before last run") {
+            var hasSetPrivate = false
+
+            val issue = mockIssue(
+                attachments = listOf(
+                    mockAttachment(
+                        name = sensitiveFileName,
+                        created = TEN_SECONDS_AGO
+                    )
+                ),
+                setPrivate = { hasSetPrivate = true }
+            )
+
+            val result = module(issue, TWO_SECONDS_AGO)
+
+            result.shouldBeLeft(OperationNotNeededModuleResponse)
+            hasSetPrivate shouldBe false
+        }
+
+        test("should not mark as private when attachment has non-sensitive name") {
+            var hasSetPrivate = false
+
+            val issue = mockIssue(
+                attachments = listOf(
+                    mockAttachment(
+                        name = "non-$sensitiveFileName"
+                    )
+                ),
+                setPrivate = { hasSetPrivate = true }
+            )
+
+            val result = module(issue, TWO_SECONDS_AGO)
+
+            result.shouldBeLeft(OperationNotNeededModuleResponse)
+            hasSetPrivate shouldBe false
+        }
+
+        test("should mark as private when attachment has sensitive name") {
+            var hasSetPrivate = false
+            var addedComment: CommentOptions? = null
+
+            val issue = mockIssue(
+                attachments = listOf(
+                    mockAttachment(
+                        name = sensitiveFileName
+                    )
+                ),
+                setPrivate = { hasSetPrivate = true },
+                addComment = { addedComment = it }
+            )
+
+            val result = module(issue, TWO_SECONDS_AGO)
+
+            result.shouldBeRight(ModuleResponse)
+            hasSetPrivate shouldBe true
+            addedComment shouldBe CommentOptions(MADE_PRIVATE_MESSAGE)
+        }
+
+        test("should mark as private when non-text attachment has sensitive name") {
+            var hasSetPrivate = false
+            var addedComment: CommentOptions? = null
+
+            val issue = mockIssue(
+                attachments = listOf(
+                    mockAttachment(
+                        name = sensitiveFileName,
+                        mimeType = "image/png"
+                    )
+                ),
+                setPrivate = { hasSetPrivate = true },
+                addComment = { addedComment = it }
+            )
+
+            val result = module(issue, TWO_SECONDS_AGO)
+
+            result.shouldBeRight(ModuleResponse)
+            hasSetPrivate shouldBe true
+            addedComment shouldBe CommentOptions(MADE_PRIVATE_MESSAGE)
+        }
     }
 })


### PR DESCRIPTION
## Purpose
Refactor PrivacyModule (acts as a follow-up for #751).
Make config parsing stricter.

## Approach
Refactors the PrivacyModule to:
- allow specifying sensitive text patterns in the config instead of hardcoding them
- support regex patterns for sensitive file names

Additionally the test class PrivacyModuleTest is refactored to cover more cases and to reuse test code for email address and sensitive text detection.

The config parsing has also been made stricter, requiring that all required entries are present and that no unknown entries exist.
:warning: Please verify that the local config used by Arisa does not have unknown / unused entries.

#### Checklist
- [x] Included tests
- [x] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
