### PR TITLE
Add shadowban command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ arisa.yml
 # Files and folders created when running Arisa
 /logs/
 last-run
+lastrun.json
 helper-messages.json
 mc-mappings/

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -155,3 +155,15 @@ Keys and type are case insensitive
 
 Reopens tickets resolved as Awaiting Response
 
+## $ARISA_SHADOWBAN
+| Entry       | Value                         |
+| ----------- | ----------------------------- |
+| Syntax      | `$ARISA_SHADOWBAN <username>` |
+| Permissions | Mod+                          |
+
+Shadowbans a user for the next 24 hours.
+
+Note: The user's previous actions still need to be reverted manually (or e.g. via `$ARISA_REMOVE_CONTENT` and bulk change),
+as running this command will only cause the bot auto-undo actions done by the shadowbanned user in the future.
+
+For more information on how shadowbans work, see "Modules → Shadowban".

--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -430,6 +430,33 @@ instead.
 - At most `maxImagesCount` as specified in the [config](../config/config.yml) (defaults to 10) will be processed per
   issue description respectively per comment
 
+## Shadowban
+| Entry | Value                                                                        |
+| ----- | ---------------------------------------------------------------------------- |
+| Name  | `Shadowban`                                                                  |
+| Class | [Link](../src/main/kotlin/io/github/mojira/arisa/modules/ShadowbanModule.kt) |
+
+Revert all bug reports, comments, and attachments that have been
+created by shadowbanned users (via `$ARISA_SHADOWBAN`).
+
+- Bug reports are resolved as invalid, are made private, and the reporter is changed to `SpamBin`.
+- Comments are restricted to `staff`.
+- Attachments are immediately deleted.
+
+### Checks
+- The bug report
+  - was reported by someone who is currently shadowbanned
+  - was not posted by someone in the `helper`, `staff`, or `global-moderators` group
+- The comment
+  - was created by someone who is currently shadowbanned
+  - has been created while that user was banned
+  - is not restricted already
+  - was not posted by someone in the `helper`, `staff`, or `global-moderators` group
+- The attachment
+  - was uploaded by someone who is currently shadowbanned
+  - has been uploaded while that user was banned
+  - was not uploaded by someone in the `helper`, `staff`, or `global-moderators` group
+
 ## TransferLinks
 | Entry | Value                                                                               |
 | ----- | ----------------------------------------------------------------------------------- |

--- a/src/main/kotlin/io/github/mojira/arisa/ExecutionTimeframe.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ExecutionTimeframe.kt
@@ -10,6 +10,7 @@ import java.time.temporal.ChronoUnit
 class ExecutionTimeframe(
     val lastRunTime: Instant,
     val currentRunTime: Instant,
+    val shadowbans: Map<String, Shadowban>,
     private val openEnded: Boolean
 ) {
     companion object {
@@ -35,7 +36,12 @@ class ExecutionTimeframe(
                 endOfMaxTimeframe
             }
 
-            return ExecutionTimeframe(lastRun.time, currentRunTime, runOpenEnded)
+            return ExecutionTimeframe(
+                lastRun.time,
+                currentRunTime,
+                lastRun.getCurrentlyShadowbannedUsers(),
+                runOpenEnded
+            )
         }
     }
 
@@ -55,6 +61,8 @@ class ExecutionTimeframe(
         val checkEnd = currentRunTime.minus(offset)
         return "updated > ${checkStart.toEpochMilli()} AND updated <= ${checkEnd.toEpochMilli()}"
     }
+
+    fun contains(instant: Instant): Boolean = instant in lastRunTime..currentRunTime
 
     /**
      * Adds a cap to a JQL query if this time frame is not open.

--- a/src/main/kotlin/io/github/mojira/arisa/ExecutionTimeframe.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/ExecutionTimeframe.kt
@@ -39,7 +39,7 @@ class ExecutionTimeframe(
             return ExecutionTimeframe(
                 lastRun.time,
                 currentRunTime,
-                lastRun.getCurrentlyShadowbannedUsers(),
+                lastRun.getShadowbannedUsers(),
                 runOpenEnded
             )
         }

--- a/src/main/kotlin/io/github/mojira/arisa/Executor.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/Executor.kt
@@ -64,7 +64,7 @@ class Executor(
 
         registry.getEnabledModules().forEach { (moduleName, _, execute, moduleExecutor) ->
             log.debug("Executing module $moduleName")
-            moduleExecutor.executeModule(issues, addFailedTicket) { issue -> execute(issue, timeframe.lastRunTime) }
+            moduleExecutor.executeModule(issues, addFailedTicket) { issue -> execute(issue, timeframe) }
         }
     }
 

--- a/src/main/kotlin/io/github/mojira/arisa/LastRun.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/LastRun.kt
@@ -10,9 +10,6 @@ import java.io.File
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
-private const val DEFAULT_START_TIME_MINUTES_BEFORE_NOW = 5L
-private const val SHADOWBAN_DURATION_IN_HOURS = 24L
-
 class EpochMilliInstantConverter : Converter {
     override fun canConvert(cls: Class<*>) = cls == Instant::class.java
     override fun toJson(value: Any) = (value as Instant).toEpochMilli().toString()
@@ -26,7 +23,7 @@ val instantConverter = EpochMilliInstantConverter()
 data class Shadowban(
     val user: String,
     val since: Instant,
-    val until: Instant,
+    val until: Instant
 ) {
     fun banTimeContains(instant: Instant): Boolean = instant in since..until
 }
@@ -38,7 +35,7 @@ data class LastRunFile(
 ) {
     companion object {
         fun defaultTime(): Instant =
-            Instant.now().minus(DEFAULT_START_TIME_MINUTES_BEFORE_NOW, ChronoUnit.MINUTES)
+            Instant.now().minus(LastRun.DEFAULT_START_TIME_MINUTES_BEFORE_NOW, ChronoUnit.MINUTES)
 
         fun read(readFromFile: () -> String): LastRunFile {
             val result = Klaxon().converter(instantConverter).parse<LastRunFile>(readFromFile())
@@ -65,6 +62,9 @@ class LastRun(
     private val writeToFile: (String) -> Unit
 ) {
     companion object {
+        const val DEFAULT_START_TIME_MINUTES_BEFORE_NOW = 5L
+        const val SHADOWBAN_DURATION_IN_HOURS = 24L
+
         fun getLastRun(config: Config): LastRun {
             val lastRunFile = File("lastrun.json")
             if (!lastRunFile.exists()) migrateLegacyFile()

--- a/src/main/kotlin/io/github/mojira/arisa/LastRun.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/LastRun.kt
@@ -1,109 +1,33 @@
 package io.github.mojira.arisa
 
-import com.beust.klaxon.Converter
-import com.beust.klaxon.JsonValue
-import com.beust.klaxon.Klaxon
 import com.uchuhimo.konf.Config
 import io.github.mojira.arisa.infrastructure.config.Arisa
 import io.github.mojira.arisa.modules.commands.ShadowbanCommand
-import java.io.File
 import java.time.Instant
 import java.time.temporal.ChronoUnit
-
-class EpochMilliInstantConverter : Converter {
-    override fun canConvert(cls: Class<*>) = cls == Instant::class.java
-    override fun toJson(value: Any) = (value as Instant).toEpochMilli().toString()
-    override fun fromJson(jv: JsonValue): Instant = jv.longValue?.let { long ->
-        Instant.ofEpochMilli(long)
-    } ?: LastRunFile.defaultTime()
-}
-
-val instantConverter = EpochMilliInstantConverter()
-
-data class Shadowban(
-    val user: String,
-    val since: Instant,
-    val until: Instant
-) {
-    fun banTimeContains(instant: Instant): Boolean = instant in since..until
-}
-
-data class LastRunFile(
-    val time: Instant,
-    val failedTickets: Set<String>,
-    val shadowbans: List<Shadowban>
-) {
-    companion object {
-        fun defaultTime(): Instant =
-            Instant.now().minus(LastRun.DEFAULT_START_TIME_MINUTES_BEFORE_NOW, ChronoUnit.MINUTES)
-
-        fun read(readFromFile: () -> String): LastRunFile {
-            val result = Klaxon().converter(instantConverter).parse<LastRunFile>(readFromFile())
-
-            return result ?: LastRunFile(
-                time = defaultTime(),
-                failedTickets = setOf(),
-                shadowbans = listOf()
-            )
-        }
-    }
-
-    fun write(writeToFile: (String) -> Unit) {
-        val result = Klaxon().converter(instantConverter).toJsonString(this)
-        writeToFile(result)
-    }
-}
 
 /**
  * Stores information about the previous run (start time, and tickets that failed during the run)
  */
 class LastRun(
-    private val readFromFile: () -> String,
-    private val writeToFile: (String) -> Unit
+    private val readFromFile: () -> LastRunFile,
+    private val writeToFile: (LastRunFile) -> Unit
 ) {
     companion object {
         const val DEFAULT_START_TIME_MINUTES_BEFORE_NOW = 5L
         const val SHADOWBAN_DURATION_IN_HOURS = 24L
 
-        fun getLastRun(config: Config): LastRun {
-            val lastRunFile = File("lastrun.json")
-            if (!lastRunFile.exists()) migrateLegacyFile()
+        private val lastRunFileService = LastRunFileService("lastrun.json", "last-run")
 
+        fun getLastRun(config: Config): LastRun {
             return LastRun(
-                readFromFile = {
-                    if (lastRunFile.exists()) lastRunFile.readText()
-                    else ""
-                },
-                writeToFile = { contents ->
+                readFromFile = { lastRunFileService.getLastRunFile() },
+                writeToFile = { file ->
                     if (config[Arisa.Debug.updateLastRun]) {
-                        lastRunFile.writeText(contents)
+                        lastRunFileService.writeLastRunFile(file)
                     }
                 }
             )
-        }
-
-        // Migrate old last-run file
-        private fun migrateLegacyFile() {
-            val legacyFile = File("last-run")
-            if (legacyFile.exists()) {
-                val fileComponents = legacyFile.readText().trim().split(',')
-
-                val time = if (fileComponents[0].isNotEmpty()) {
-                    Instant.ofEpochMilli(fileComponents[0].toLong())
-                } else {
-                    LastRunFile.defaultTime()
-                }
-
-                val failedTickets = fileComponents.subList(1, fileComponents.size).toSet()
-
-                val fileContents = LastRunFile(time, failedTickets, shadowbans = emptyList())
-                fileContents.write {
-                    val newFile = File("lastrun.json")
-                    newFile.writeText(it)
-                }
-
-                legacyFile.delete()
-            }
         }
     }
 
@@ -119,10 +43,10 @@ class LastRun(
         failedTickets = newFailedTickets
         shadowbans.removeIf { it.until.isBefore(newTime) }
 
-        LastRunFile(time, failedTickets, shadowbans).write(writeToFile)
+        writeToFile(LastRunFile(time, failedTickets, shadowbans))
     }
 
-    private fun addShadowbannedUser(userName: String) {
+    fun addShadowbannedUser(userName: String) {
         shadowbans.add(
             Shadowban(
                 user = userName,
@@ -132,16 +56,19 @@ class LastRun(
         )
     }
 
-    fun getCurrentlyShadowbannedUsers(): Map<String, Shadowban> =
+    fun getShadowbannedUsers(): Map<String, Shadowban> =
+        // We want the earliest applicable ban frame for a particular user.
+        // Since `associateBy` always picks the last one, we'll reverse the list.
+        // Shadowbans that are no longer active get removed through `update`, so we don't need to worry about those.
         shadowbans
-            .filter { it.banTimeContains(time) }
+            .reversed()
             .associateBy { it.user }
 
     init {
-        val file = LastRunFile.read(readFromFile)
-        time = file.time
-        failedTickets = file.failedTickets
-        shadowbans = file.shadowbans.toMutableList()
+        val file = readFromFile()
+        time = file.time ?: LastRunFile.defaultTime()
+        failedTickets = file.failedTickets ?: emptySet()
+        shadowbans = file.shadowbans?.toMutableList() ?: mutableListOf()
 
         // Initialize shadowban command
         ShadowbanCommand.addShadowbannedUser = this::addShadowbannedUser

--- a/src/main/kotlin/io/github/mojira/arisa/LastRun.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/LastRun.kt
@@ -1,10 +1,61 @@
 package io.github.mojira.arisa
 
+import com.beust.klaxon.Converter
+import com.beust.klaxon.JsonValue
+import com.beust.klaxon.Klaxon
 import com.uchuhimo.konf.Config
 import io.github.mojira.arisa.infrastructure.config.Arisa
+import io.github.mojira.arisa.modules.commands.ShadowbanCommand
 import java.io.File
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+
+private const val DEFAULT_START_TIME_MINUTES_BEFORE_NOW = 5L
+private const val SHADOWBAN_DURATION_IN_HOURS = 24L
+
+class EpochMilliInstantConverter : Converter {
+    override fun canConvert(cls: Class<*>) = cls == Instant::class.java
+    override fun toJson(value: Any) = (value as Instant).toEpochMilli().toString()
+    override fun fromJson(jv: JsonValue): Instant = jv.longValue?.let { long ->
+        Instant.ofEpochMilli(long)
+    } ?: LastRunFile.defaultTime()
+}
+
+val instantConverter = EpochMilliInstantConverter()
+
+data class Shadowban(
+    val user: String,
+    val since: Instant,
+    val until: Instant,
+) {
+    fun banTimeContains(instant: Instant): Boolean = instant in since..until
+}
+
+data class LastRunFile(
+    val time: Instant,
+    val failedTickets: Set<String>,
+    val shadowbans: List<Shadowban>
+) {
+    companion object {
+        fun defaultTime(): Instant =
+            Instant.now().minus(DEFAULT_START_TIME_MINUTES_BEFORE_NOW, ChronoUnit.MINUTES)
+
+        fun read(readFromFile: () -> String): LastRunFile {
+            val result = Klaxon().converter(instantConverter).parse<LastRunFile>(readFromFile())
+
+            return result ?: LastRunFile(
+                time = defaultTime(),
+                failedTickets = setOf(),
+                shadowbans = listOf()
+            )
+        }
+    }
+
+    fun write(writeToFile: (String) -> Unit) {
+        val result = Klaxon().converter(instantConverter).toJsonString(this)
+        writeToFile(result)
+    }
+}
 
 /**
  * Stores information about the previous run (start time, and tickets that failed during the run)
@@ -14,10 +65,10 @@ class LastRun(
     private val writeToFile: (String) -> Unit
 ) {
     companion object {
-        const val DEFAULT_START_TIME_MINUTES_BEFORE_NOW = 5L
-
         fun getLastRun(config: Config): LastRun {
-            val lastRunFile = File("last-run")
+            val lastRunFile = File("lastrun.json")
+            if (!lastRunFile.exists()) migrateLegacyFile()
+
             return LastRun(
                 readFromFile = {
                     if (lastRunFile.exists()) lastRunFile.readText()
@@ -30,32 +81,69 @@ class LastRun(
                 }
             )
         }
+
+        // Migrate old last-run file
+        private fun migrateLegacyFile() {
+            val legacyFile = File("last-run")
+            if (legacyFile.exists()) {
+                val fileComponents = legacyFile.readText().trim().split(',')
+
+                val time = if (fileComponents[0].isNotEmpty()) {
+                    Instant.ofEpochMilli(fileComponents[0].toLong())
+                } else {
+                    LastRunFile.defaultTime()
+                }
+
+                val failedTickets = fileComponents.subList(1, fileComponents.size).toSet()
+
+                val fileContents = LastRunFile(time, failedTickets, shadowbans = emptyList())
+                fileContents.write {
+                    val newFile = File("lastrun.json")
+                    newFile.writeText(it)
+                }
+
+                legacyFile.delete()
+            }
+        }
     }
 
     var time: Instant
     var failedTickets: Set<String>
+    private var shadowbans: MutableList<Shadowban>
 
     /**
-     * Updates last run and writes it to the `last-run` file
+     * Updates last run and writes it to the `lastrun.json` file
      */
     fun update(newTime: Instant, newFailedTickets: Set<String>) {
         time = newTime
         failedTickets = newFailedTickets
+        shadowbans.removeIf { it.until.isBefore(newTime) }
 
-        val failedString = failedTickets.joinToString("") { ",$it" } // even first entry should start with a comma
-
-        writeToFile("${time.toEpochMilli()}$failedString")
+        LastRunFile(time, failedTickets, shadowbans).write(writeToFile)
     }
 
+    private fun addShadowbannedUser(userName: String) {
+        shadowbans.add(
+            Shadowban(
+                user = userName,
+                since = time,
+                until = time.plus(SHADOWBAN_DURATION_IN_HOURS, ChronoUnit.HOURS)
+            )
+        )
+    }
+
+    fun getCurrentlyShadowbannedUsers(): Map<String, Shadowban> =
+        shadowbans
+            .filter { it.banTimeContains(time) }
+            .associateBy { it.user }
+
     init {
-        val lastRunFileComponents = readFromFile().trim().split(',')
+        val file = LastRunFile.read(readFromFile)
+        time = file.time
+        failedTickets = file.failedTickets
+        shadowbans = file.shadowbans.toMutableList()
 
-        time = if (lastRunFileComponents[0].isNotEmpty()) {
-            Instant.ofEpochMilli(lastRunFileComponents[0].toLong())
-        } else {
-            Instant.now().minus(DEFAULT_START_TIME_MINUTES_BEFORE_NOW, ChronoUnit.MINUTES)
-        }
-
-        failedTickets = lastRunFileComponents.subList(1, lastRunFileComponents.size).toSet()
+        // Initialize shadowban command
+        ShadowbanCommand.addShadowbannedUser = this::addShadowbannedUser
     }
 }

--- a/src/main/kotlin/io/github/mojira/arisa/LastRunFile.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/LastRunFile.kt
@@ -1,0 +1,111 @@
+package io.github.mojira.arisa
+
+import com.beust.klaxon.Converter
+import com.beust.klaxon.JsonValue
+import com.beust.klaxon.Klaxon
+import com.beust.klaxon.KlaxonException
+import java.io.File
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class EpochMilliInstantConverter : Converter {
+    override fun canConvert(cls: Class<*>) = cls == Instant::class.java
+    override fun toJson(value: Any) = '"' + (value as Instant).toEpochMilli().toString() + '"'
+    override fun fromJson(jv: JsonValue): Instant = jv.string?.let { str ->
+        Instant.ofEpochMilli(str.toLong())
+    } ?: run {
+        println("Can't read $jv from json")
+        LastRunFile.defaultTime()
+    }
+}
+
+val instantConverter = EpochMilliInstantConverter()
+
+data class Shadowban(
+    val user: String,
+    val since: Instant,
+    val until: Instant
+) {
+    fun banTimeContains(instant: Instant): Boolean = instant in since..until
+}
+
+data class LastRunFile(
+    val time: Instant? = defaultTime(),
+    val failedTickets: Set<String>? = emptySet(),
+    val shadowbans: List<Shadowban>? = emptyList()
+) {
+    companion object {
+        fun defaultTime(): Instant =
+            Instant.now().minus(LastRun.DEFAULT_START_TIME_MINUTES_BEFORE_NOW, ChronoUnit.MINUTES)
+
+        fun read(readFromFile: () -> String): LastRunFile {
+            val default = LastRunFile(
+                time = defaultTime(),
+                failedTickets = setOf(),
+                shadowbans = listOf()
+            )
+
+            @SuppressWarnings("SwallowedException")
+            val result = try {
+                Klaxon().converter(instantConverter).parse<LastRunFile>(readFromFile())
+            } catch (e: KlaxonException) {
+                default
+            }
+
+            return result ?: default
+        }
+    }
+
+    fun write(writeToFile: (String) -> Unit) {
+        val result = Klaxon().converter(instantConverter).toJsonString(this)
+        writeToFile(result)
+    }
+}
+
+class LastRunFileService(
+    private val fileName: String,
+    private val legacyFileName: String
+) {
+    fun writeLastRunFile(file: LastRunFile) {
+        val lastRunFile = File(fileName)
+        file.write(lastRunFile::writeText)
+    }
+
+    fun getLastRunFile(): LastRunFile {
+        val lastRunFile = File(fileName)
+        if (!lastRunFile.exists()) migrateLegacyFile()
+
+        return LastRunFile.read(lastRunFile::readText)
+    }
+
+    // Migrate old last-run file
+    private fun migrateLegacyFile() {
+        val legacyFile = File(legacyFileName)
+
+        val legacyContents = if (legacyFile.exists()) legacyFile.readText() else ""
+
+        val newFileContents = convertLegacyFile(legacyContents)
+        newFileContents.write {
+            val newFile = File(fileName)
+            newFile.writeText(it)
+        }
+
+        legacyFile.delete()
+    }
+
+    companion object {
+        fun convertLegacyFile(legacyContents: String): LastRunFile {
+            val fileComponents = legacyContents.trim().split(',')
+
+            val time = if (fileComponents[0].isNotEmpty()) {
+                Instant.ofEpochMilli(fileComponents[0].toLong())
+            } else {
+                LastRunFile.defaultTime()
+            }
+
+            val failedTickets = fileComponents.subList(1, fileComponents.size).toSet()
+
+            return LastRunFile(time, failedTickets, shadowbans = emptyList())
+        }
+    }
+}

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
@@ -74,6 +74,11 @@ object Arisa : ConfigSpec() {
             description = "Whether or not the lastRun file should be saved after each run. " +
                     "Do not disable this unless you've enabled the ticket whitelist."
         )
+
+        val ignoreOwnCommands by optional(
+            true,
+            description = "Whether to ignore commands from the bot user itself."
+        )
     }
 
     object Modules : ConfigSpec() {

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
@@ -407,6 +407,8 @@ object Arisa : ConfigSpec() {
                 description = "The key to search for in a bot comment to trigger the removal of the comment"
             )
         }
+
+        object Shadowban : ModuleConfigSpec()
     }
 }
 

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
@@ -450,7 +450,7 @@ fun markAsFixedWithSpecificVersion(context: Lazy<IssueUpdateContext>, fixVersion
 }
 
 fun changeReporter(context: Lazy<IssueUpdateContext>, reporter: String) {
-    context.value.update.field(Field.REPORTER, reporter)
+    context.value.edit.field(Field.REPORTER, reporter)
 }
 
 // Allows some basic Jira formatting characters to be used by helper message arguments;

--- a/src/main/kotlin/io/github/mojira/arisa/modules/CommandModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/CommandModule.kt
@@ -25,6 +25,7 @@ private val log: Logger = LoggerFactory.getLogger("CommandModule")
 class CommandModule(
     private val prefix: String,
     private val botUserName: String,
+    private val ignoreOwnCommands: Boolean,
     attachmentUtils: AttachmentUtils,
     private val getDispatcher: (String) -> CommandDispatcher<CommandSource> =
         ::getCommandDispatcher.partially2(attachmentUtils)
@@ -157,7 +158,7 @@ class CommandModule(
     private fun userIsVolunteer(comment: Comment): Boolean {
         // Ignore comments from the bot itself to prevent accidental infinite recursion and command
         // injection by malicious user
-        if (comment.author.name == botUserName) {
+        if (ignoreOwnCommands && comment.author.name == botUserName) {
             return false
         }
 

--- a/src/main/kotlin/io/github/mojira/arisa/modules/Module.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/Module.kt
@@ -1,11 +1,19 @@
 package io.github.mojira.arisa.modules
 
 import arrow.core.Either
+import io.github.mojira.arisa.ExecutionTimeframe
 import io.github.mojira.arisa.domain.Issue
 import java.time.Instant
 
 interface Module {
     operator fun invoke(issue: Issue, lastRun: Instant): Either<ModuleError, ModuleResponse>
+
+    // In case more details than just `lastRun` are needed, this function can be overridden
+    operator fun invoke(
+        issue: Issue,
+        timeframe: ExecutionTimeframe
+    ): Either<ModuleError, ModuleResponse> =
+        invoke(issue, timeframe.lastRunTime)
 }
 
 typealias ModuleResponse = Unit

--- a/src/main/kotlin/io/github/mojira/arisa/modules/ShadowbanModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ShadowbanModule.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import arrow.core.extensions.fx
 import arrow.core.right
 import io.github.mojira.arisa.ExecutionTimeframe
+import io.github.mojira.arisa.domain.Comment
 import io.github.mojira.arisa.domain.Issue
 import io.github.mojira.arisa.domain.User
 import org.slf4j.LoggerFactory
@@ -51,6 +52,7 @@ class ShadowbanModule : Module {
 
     private fun Issue.checkCommentsForShadowban(timeframe: ExecutionTimeframe): Int =
         comments
+            .filter { it.isNotStaffRestricted() }
             .filter { it.author.isNotVolunteer() }
             .filter {
                 timeframe.shadowbans[it.author.name]?.banTimeContains(it.created) ?: false
@@ -71,6 +73,9 @@ class ShadowbanModule : Module {
 
     private fun User.isNotVolunteer() =
         getGroups()?.none { it -> listOf("helper", "global-moderators", "staff").contains(it) } ?: true
+
+    private fun Comment.isNotStaffRestricted() =
+        visibilityType != "group" || visibilityValue != "staff"
 
     private fun Issue.putInSpamBin() {
         changeReporter("SpamBin")

--- a/src/main/kotlin/io/github/mojira/arisa/modules/ShadowbanModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ShadowbanModule.kt
@@ -1,0 +1,80 @@
+package io.github.mojira.arisa.modules
+
+import arrow.core.Either
+import arrow.core.extensions.fx
+import arrow.core.right
+import io.github.mojira.arisa.ExecutionTimeframe
+import io.github.mojira.arisa.domain.Issue
+import io.github.mojira.arisa.domain.User
+import org.slf4j.LoggerFactory
+import java.time.Instant
+
+class ShadowbanModule : Module {
+    private val log = LoggerFactory.getLogger("ShadowbanModule")
+
+    override fun invoke(issue: Issue, lastRun: Instant): Either<ModuleError, ModuleResponse> {
+        // This implementation should never be run, but if it is anyway, just print to log and move on
+        log.error("Tried to invoke ShadowbanModule without details about shadowbans")
+        return Either.left(OperationNotNeededModuleResponse)
+    }
+
+    override fun invoke(
+        issue: Issue,
+        timeframe: ExecutionTimeframe
+    ): Either<ModuleError, ModuleResponse> = with(issue) {
+        Either.fx {
+            val bugReportRemoved = checkReporterForShadowban(timeframe)
+            val removedComments = checkCommentsForShadowban(timeframe)
+            val removedAttachments = checkAttachmentsForShadowban(timeframe)
+
+            if (bugReportRemoved) log.info("[ShadowbanModule] Put $key into the spam bin")
+            if (removedComments > 0) log.info("[ShadowbanModule] Removed $removedComments comments from $key")
+            if (removedAttachments > 0) log.info("[ShadowbanModule] Removed $removedAttachments attachments from $key")
+
+            val actionTaken = bugReportRemoved || removedComments > 0 || removedAttachments > 0
+
+            assertTrue(actionTaken).bind()
+
+            ModuleResponse.right().bind()
+        }
+    }
+
+    private fun Issue.checkReporterForShadowban(timeframe: ExecutionTimeframe): Boolean {
+        val reporterIsShadowbanned = reporter?.let { user ->
+            user.isNotVolunteer() && (timeframe.shadowbans[user.name]?.banTimeContains(created) ?: false)
+        } ?: false
+
+        if (reporterIsShadowbanned) putInSpamBin()
+
+        return reporterIsShadowbanned
+    }
+
+    private fun Issue.checkCommentsForShadowban(timeframe: ExecutionTimeframe): Int =
+        comments
+            .filter { it.author.isNotVolunteer() }
+            .filter {
+                timeframe.shadowbans[it.author.name]?.banTimeContains(it.created) ?: false
+            }
+            .map { it.restrict("${ it.body }\n\n_Removed by Arisa -- User is shadowbanned_") }
+            .size
+
+    private fun Issue.checkAttachmentsForShadowban(timeframe: ExecutionTimeframe): Int =
+        attachments
+            .filter { it.uploader?.isNotVolunteer() ?: false }
+            .filter {
+                it.uploader?.let { uploader ->
+                    timeframe.shadowbans[uploader.name]?.banTimeContains(it.created)
+                } ?: false
+            }
+            .map { it.remove() }
+            .size
+
+    private fun User.isNotVolunteer() =
+        getGroups()?.none { it -> listOf("helper", "global-moderators", "staff").contains(it) } ?: true
+
+    private fun Issue.putInSpamBin() {
+        changeReporter("SpamBin")
+        setPrivate()
+        resolveAsInvalid()
+    }
+}

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/CommandDispatcher.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/CommandDispatcher.kt
@@ -49,6 +49,7 @@ fun getCommandDispatcher(
         },
         { Thread(it).start() }
     )
+    val shadowbanCommand = ShadowbanCommand()
 
     return CommandDispatcher<CommandSource>().apply {
         val addLinksCommandNode =
@@ -258,6 +259,18 @@ fun getCommandDispatcher(
                     )
                 }
 
+        val shadowbanCommandNode =
+            literal<CommandSource>("${prefix}_SHADOWBAN")
+                .requires(::sentByModerator)
+                .then(
+                    argument<CommandSource, String>("username", greedyString())
+                        .executes {
+                            shadowbanCommand(
+                                it.getString("username")
+                            )
+                        }
+                )
+
         register(addLinksCommandNode)
         register(addVersionCommandNode)
         register(clearProjectCacheCommandNode)
@@ -273,6 +286,7 @@ fun getCommandDispatcher(
         register(removeLinksCommandNode)
         register(removeContentCommandNode)
         register(reopenCommandNode)
+        register(shadowbanCommandNode)
     }
 }
 

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/ShadowbanCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/ShadowbanCommand.kt
@@ -1,0 +1,16 @@
+package io.github.mojira.arisa.modules.commands
+
+class ShadowbanCommand {
+    companion object {
+        // This function gets set at initialization of the `LastRun` class.
+        // Horrible hack but threading this through to the very top where `lastRun` is accessible would be difficult.
+        var addShadowbannedUser: (String) -> Unit = { }
+    }
+
+    operator fun invoke(
+        userName: String
+    ): Int {
+        addShadowbannedUser(userName)
+        return 1
+    }
+}

--- a/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
@@ -230,6 +230,7 @@ class InstantModuleRegistry(config: Config) : ModuleRegistry(config) {
             CommandModule(
                 config[Arisa.Modules.Command.commandPrefix],
                 config[Arisa.Credentials.username],
+                config[Arisa.Debug.ignoreOwnCommands],
                 attachmentUtils
             )
         )

--- a/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
@@ -35,6 +35,7 @@ import io.github.mojira.arisa.modules.ThumbnailModule
 import io.github.mojira.arisa.modules.TransferLinksModule
 import io.github.mojira.arisa.modules.TransferVersionsModule
 import io.github.mojira.arisa.modules.RemoveBotCommentModule
+import io.github.mojira.arisa.modules.ShadowbanModule
 
 /**
  * This class is the registry for modules that get executed immediately after a ticket has been updated.
@@ -251,6 +252,11 @@ class InstantModuleRegistry(config: Config) : ModuleRegistry(config) {
                 config[Arisa.Credentials.username],
                 config[Arisa.Modules.RemoveBotComment.removalTag]
             )
+        )
+
+        register(
+            Arisa.Modules.Shadowban,
+            ShadowbanModule()
         )
     }
 }

--- a/src/main/kotlin/io/github/mojira/arisa/registry/ModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/registry/ModuleRegistry.kt
@@ -12,7 +12,6 @@ import io.github.mojira.arisa.modules.FailedModuleResponse
 import io.github.mojira.arisa.modules.Module
 import io.github.mojira.arisa.modules.ModuleError
 import io.github.mojira.arisa.modules.ModuleResponse
-import java.time.Instant
 
 // All defined module registries
 val getModuleRegistries = { config: Config ->
@@ -27,7 +26,7 @@ abstract class ModuleRegistry(protected val config: Config) {
     data class Entry(
         val name: String,
         val config: ModuleConfigSpec,
-        val execute: (issue: Issue, lastRun: Instant) -> Pair<String, Either<ModuleError, ModuleResponse>>,
+        val execute: (issue: Issue, timeframe: ExecutionTimeframe) -> Pair<String, Either<ModuleError, ModuleResponse>>,
         val executor: ModuleExecutor
     )
 
@@ -60,8 +59,9 @@ abstract class ModuleRegistry(protected val config: Config) {
         )
     }
 
-    private fun getModuleResult(moduleName: String, module: Module) = { issue: Issue, lastRun: Instant ->
-        moduleName to tryExecuteModule { module(issue, lastRun) }
+    private fun getModuleResult(moduleName: String, module: Module) = {
+        issue: Issue, timeframe: ExecutionTimeframe ->
+        moduleName to tryExecuteModule { module(issue, timeframe) }
     }
 
     private fun getJqlWithDebug(timeframe: ExecutionTimeframe): String {

--- a/src/test/kotlin/io/github/mojira/arisa/ExecutionTimeframeTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/ExecutionTimeframeTest.kt
@@ -16,7 +16,7 @@ class ExecutionTimeframeTest : StringSpec({
             .truncatedTo(ChronoUnit.MILLIS)
 
         val lastRun = LastRun(
-            { lastRunTime.toEpochMilli().toString() },
+            { LastRunFile(lastRunTime, emptySet(), emptyList()) },
             { }
         )
 
@@ -48,7 +48,7 @@ class ExecutionTimeframeTest : StringSpec({
             .truncatedTo(ChronoUnit.MILLIS)
 
         val lastRun = LastRun(
-            { lastRunTime.toEpochMilli().toString() },
+            { LastRunFile(lastRunTime, emptySet(), emptyList()) },
             { }
         )
 

--- a/src/test/kotlin/io/github/mojira/arisa/ExecutorTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/ExecutorTest.kt
@@ -23,7 +23,7 @@ private val failedModuleRegistryMock = mockk<ModuleRegistry>()
 private val moduleExecutorMock = mockk<ModuleExecutor>()
 private val failedModuleExecutorMock = mockk<ModuleExecutor>()
 
-private val dummyTimeframe = ExecutionTimeframe(Instant.now(), Instant.now(), true)
+private val dummyTimeframe = ExecutionTimeframe(Instant.now(), Instant.now(), mapOf(), true)
 
 class ExecutorTest : StringSpec({
     every { moduleRegistryMock.getEnabledModules() } returns listOf(

--- a/src/test/kotlin/io/github/mojira/arisa/LastRunTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/LastRunTest.kt
@@ -4,65 +4,138 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotBeEmpty
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
 class LastRunTest : StringSpec({
     "should use default time before now if input file is empty" {
-        val lastRun = LastRun(
-            { "" },
-            { }
-        )
+        val lastRunFile = LastRunFile.read { "" }
 
-        val time = Instant.now().minus(LastRun.DEFAULT_START_TIME_MINUTES_BEFORE_NOW, ChronoUnit.MINUTES)
+        val time = LastRunFile.defaultTime()
 
-        lastRun.time.isAfter(time) shouldBe false
-        lastRun.failedTickets.shouldBeEmpty()
+        lastRunFile.time?.isAfter(time) shouldBe false
+        lastRunFile.failedTickets.shouldBeEmpty()
+    }
+
+    "should use default time before now if input file is invalid JSON" {
+        val lastRunFile = LastRunFile.read { "{ hey this is invalid json }" }
+
+        val time = LastRunFile.defaultTime()
+
+        lastRunFile.time?.isAfter(time) shouldBe false
+        lastRunFile.failedTickets.shouldBeEmpty()
     }
 
     "should read time from input file" {
         val time = Instant.ofEpochMilli(123456789)
 
-        val lastRun = LastRun(
-            { time.toEpochMilli().toString() },
-            { }
-        )
+        val lastRunFile = LastRunFile.read { """{"time": "123456789"}""" }
 
-        lastRun.time shouldBe time
-        lastRun.failedTickets.shouldBeEmpty()
+        lastRunFile.time shouldBe time
+        lastRunFile.failedTickets.shouldBeEmpty()
     }
 
     "should read failed tickets from input file" {
         val time = Instant.now().truncatedTo(ChronoUnit.MILLIS)
         val tickets = listOf("MC-1234", "MCL-5678", "MCPE-9012")
 
-        val lastRun = LastRun(
-            { "${ time.toEpochMilli() },${ tickets.joinToString(",") }" },
-            { }
-        )
+        val lastRun = LastRunFile.read {
+            """{"time": "${ time.toEpochMilli() }", "failedTickets": ["MC-1234", "MCL-5678", "MCPE-9012"]}"""
+        }
 
         lastRun.time shouldBe time
         lastRun.failedTickets shouldContainExactly tickets
     }
 
+    "should read shadowbans from input file" {
+        val time = Instant.ofEpochMilli(222222222222)
+
+        val shadowbans = listOf(
+            Shadowban(
+                user = "Spammer Mc Spamface",
+                since = Instant.ofEpochMilli(1000000),
+                until = Instant.ofEpochMilli(2000000)
+            ),
+            Shadowban(
+                user = "Monty Python",
+                since = Instant.ofEpochMilli(3000000),
+                until = Instant.ofEpochMilli(4000000)
+            ),
+            Shadowban(
+                user = "Nigerian Prince",
+                since = Instant.ofEpochMilli(5000000),
+                until = Instant.ofEpochMilli(6000000)
+            )
+        )
+
+        val lastRun = LastRunFile.read {
+            """{
+                "time": "222222222222",
+                "shadowbans": [
+                    {"user": "Spammer Mc Spamface", "since": "1000000", "until": "2000000"},
+                    {"user": "Monty Python", "since": "3000000", "until": "4000000"},
+                    {"user": "Nigerian Prince", "since": "5000000", "until": "6000000"}
+                ]
+            }""".trimMargin()
+        }
+
+        lastRun.time shouldBe time
+        lastRun.shadowbans shouldContainExactly shadowbans
+    }
+
+    "should write to file properly" {
+        val shadowbans = listOf(
+            Shadowban(
+                user = "Spammer Mc Spamface",
+                since = Instant.ofEpochMilli(1000000),
+                until = Instant.ofEpochMilli(2000000)
+            ),
+            Shadowban(
+                user = "Monty Python",
+                since = Instant.ofEpochMilli(3000000),
+                until = Instant.ofEpochMilli(4000000)
+            ),
+            Shadowban(
+                user = "Nigerian Prince",
+                since = Instant.ofEpochMilli(5000000),
+                until = Instant.ofEpochMilli(6000000)
+            )
+        )
+
+        val lastRunFile = LastRunFile(
+            time = Instant.ofEpochMilli(123456789),
+            failedTickets = setOf("MC-1234", "WEB-12345", "MCPE-123"),
+            shadowbans = shadowbans
+        )
+
+        var written = ""
+        lastRunFile.write { written = it }
+
+        written.shouldNotBeEmpty()
+
+        val newLastRunFile = LastRunFile.read { written }
+        newLastRunFile shouldBe lastRunFile
+    }
+
     "should update time and failed tickets" {
         val time = Instant.now()
-        val tickets = listOf("MC-1234", "MCL-5678", "MCPE-9012")
+        val tickets = setOf("MC-1234", "MCL-5678", "MCPE-9012")
 
         var writtenToFile = false
-        var fileContents = "${ time.toEpochMilli() },${ tickets.joinToString(",") }"
+        var file = LastRunFile(time, tickets, emptyList())
 
         val lastRun = LastRun(
-            { fileContents },
-            { contents ->
+            { file },
+            { newFile ->
                 writtenToFile = true
-                fileContents = contents
+                file = newFile
             }
         )
 
         val newTime = Instant.now()
         val newTickets = setOf("MC-4", "MCPE-9012")
-        val newFileContents = "${ newTime.toEpochMilli() },${ newTickets.joinToString(",") }"
+        val newFile = LastRunFile(newTime, newTickets, emptyList())
 
         lastRun.update(newTime, newTickets)
 
@@ -70,6 +143,109 @@ class LastRunTest : StringSpec({
         lastRun.failedTickets shouldContainExactly newTickets
 
         writtenToFile shouldBe true
-        fileContents shouldBe newFileContents
+        file shouldBe newFile
+    }
+
+    "should update shadowbans" {
+        val time = Instant.ofEpochMilli(0)
+
+        var shadowbans: List<Shadowban>? = null
+
+        val lastRun = LastRun(
+            {
+                LastRunFile(time, emptySet(), listOf(
+                    Shadowban(
+                        user = "Spammer Mc Spamface",
+                        since = Instant.ofEpochMilli(1000000),
+                        until = Instant.ofEpochMilli(2000000)
+                    ),
+                    Shadowban(
+                        user = "Monty Python",
+                        since = Instant.ofEpochMilli(4000000),
+                        until = Instant.ofEpochMilli(6000000)
+                    )
+                ))
+            },
+            { newFile -> shadowbans = newFile.shadowbans }
+        )
+
+        val newTime = Instant.ofEpochMilli(5000000)
+        lastRun.update(newTime, emptySet())
+
+        lastRun.getShadowbannedUsers() shouldBe mapOf(
+            "Monty Python" to Shadowban(
+                user = "Monty Python",
+                since = Instant.ofEpochMilli(4000000),
+                until = Instant.ofEpochMilli(6000000)
+            )
+        )
+        shadowbans shouldBe listOf(Shadowban(
+            user = "Monty Python",
+            since = Instant.ofEpochMilli(4000000),
+            until = Instant.ofEpochMilli(6000000)
+        ))
+    }
+
+    "should add shadowbans" {
+        val time = Instant.ofEpochMilli(0)
+
+        var shadowbans: List<Shadowban>? = null
+
+        val lastRun = LastRun(
+            {
+                LastRunFile(time, emptySet(), listOf(
+                    Shadowban(
+                        user = "Spammer Mc Spamface",
+                        since = Instant.ofEpochMilli(1000000),
+                        until = Instant.ofEpochMilli(2000000)
+                    )
+                ))
+            },
+            { newFile -> shadowbans = newFile.shadowbans }
+        )
+
+        lastRun.addShadowbannedUser("Nigerian Prince")
+        val aDayLater = time.plus(24, ChronoUnit.HOURS)
+
+        lastRun.update(Instant.ofEpochMilli(0), emptySet())
+
+        lastRun.getShadowbannedUsers() shouldBe mapOf(
+            "Spammer Mc Spamface" to Shadowban(
+                user = "Spammer Mc Spamface",
+                since = Instant.ofEpochMilli(1000000),
+                until = Instant.ofEpochMilli(2000000)
+            ),
+            "Nigerian Prince" to Shadowban(
+                user = "Nigerian Prince",
+                since = time,
+                until = aDayLater
+            )
+        )
+
+        shadowbans shouldContainExactly listOf(
+            Shadowban(
+                user = "Spammer Mc Spamface",
+                since = Instant.ofEpochMilli(1000000),
+                until = Instant.ofEpochMilli(2000000)
+            ),
+            Shadowban(
+                user = "Nigerian Prince",
+                since = time,
+                until = aDayLater
+            )
+        )
+    }
+
+    "legacy last-run file upgrade should work properly" {
+        LastRunFileService.convertLegacyFile("123456789,MC-1234,WEB-234") shouldBe LastRunFile(
+            Instant.ofEpochMilli(123456789), setOf("MC-1234", "WEB-234"), emptyList()
+        )
+
+        LastRunFileService.convertLegacyFile("123456789") shouldBe LastRunFile(
+            Instant.ofEpochMilli(123456789), emptySet(), emptyList()
+        )
+
+        val now = Instant.now()
+        LastRunFileService.convertLegacyFile("").time?.isBefore(now) shouldBe true
     }
 })

--- a/src/test/kotlin/io/github/mojira/arisa/modules/CommandModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/CommandModuleTest.kt
@@ -26,7 +26,7 @@ private const val BOT_USER_NAME = "botName"
 
 class CommandModuleTest : StringSpec({
     val attachmentUtils = AttachmentUtils(emptyList(), CrashReader(), BOT_USER_NAME)
-    val module = CommandModule(PREFIX, BOT_USER_NAME, attachmentUtils, ::getDispatcher)
+    val module = CommandModule(PREFIX, BOT_USER_NAME, true, attachmentUtils, ::getDispatcher)
 
     "should return OperationNotNeededModuleResponse when no comments" {
         val issue = mockIssue()
@@ -200,7 +200,7 @@ class CommandModuleTest : StringSpec({
     "should work for other prefixes" {
         var updatedComment = ""
         @Suppress("NAME_SHADOWING")
-        val module = CommandModule("TESTING_COMMAND", "userName", attachmentUtils, ::getDispatcher)
+        val module = CommandModule("TESTING_COMMAND", "userName", true, attachmentUtils, ::getDispatcher)
         val comment = getComment(
             author = mockUser(
                 name = "SPTesting"

--- a/src/test/kotlin/io/github/mojira/arisa/modules/ShadowbanModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/ShadowbanModuleTest.kt
@@ -1,0 +1,244 @@
+package io.github.mojira.arisa.modules
+
+import io.github.mojira.arisa.ExecutionTimeframe
+import io.github.mojira.arisa.Shadowban
+import io.github.mojira.arisa.utils.mockAttachment
+import io.github.mojira.arisa.utils.mockComment
+import io.github.mojira.arisa.utils.mockIssue
+import io.github.mojira.arisa.utils.mockUser
+import io.kotest.assertions.arrow.either.shouldBeLeft
+import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.time.Instant
+
+class ShadowbanModuleTest : StringSpec({
+    val module = ShadowbanModule()
+
+    val shadowbannedUser = mockUser(name = "shadowbanned")
+    val noLongerShadowbannedUser = mockUser(name = "nolongerbanned")
+
+    val timeframe = ExecutionTimeframe(
+        lastRunTime = Instant.ofEpochMilli(0),
+        currentRunTime = Instant.ofEpochMilli(1000),
+        shadowbans = mapOf(
+            (
+                "shadowbanned" to Shadowban(
+                    user = "shadowbanned",
+                    since = Instant.ofEpochMilli(500),
+                    until = Instant.ofEpochMilli(1500)
+                )
+            ),
+            (
+                "nolongerbanned" to Shadowban(
+                    user = "nolongerbanned",
+                    since = Instant.ofEpochMilli(0),
+                    until = Instant.ofEpochMilli(500)
+                )
+            )
+        ),
+        openEnded = false
+    )
+
+    "should remove bug reports created during shadowban" {
+        var reporter = "shadowbanned"
+        var isPrivate = false
+        var resolution = "Unresolved"
+
+        val issue = mockIssue(
+            reporter = shadowbannedUser,
+            changeReporter = { reporter = it },
+            setPrivate = { isPrivate = true },
+            resolveAsInvalid = { resolution = "Invalid" },
+            created = Instant.ofEpochMilli(800)
+        )
+
+        val result = module(issue, timeframe)
+        result.shouldBeRight(ModuleResponse)
+        reporter shouldBe "SpamBin"
+        isPrivate shouldBe true
+        resolution shouldBe "Invalid"
+    }
+
+    "should not remove bug reports created outside of shadowban duration" {
+        var reporter = "shadowbanned"
+        var isPrivate = false
+        var resolution = "Unresolved"
+
+        val issue = mockIssue(
+            reporter = shadowbannedUser,
+            changeReporter = { reporter = it },
+            setPrivate = { isPrivate = true },
+            resolveAsInvalid = { resolution = "Invalid" },
+            created = Instant.ofEpochMilli(200)
+        )
+
+        val result = module(issue, timeframe)
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+        reporter shouldBe "shadowbanned"
+        isPrivate shouldBe false
+        resolution shouldBe "Unresolved"
+    }
+
+    "should not remove bug reports from unbanned users" {
+        var reporter = "nolongerbanned"
+        var isPrivate = false
+        var resolution = "Unresolved"
+
+        val issue = mockIssue(
+            reporter = noLongerShadowbannedUser,
+            changeReporter = { reporter = it },
+            setPrivate = { isPrivate = true },
+            resolveAsInvalid = { resolution = "Invalid" },
+            created = Instant.ofEpochMilli(800)
+        )
+
+        val result = module(issue, timeframe)
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+        reporter shouldBe "nolongerbanned"
+        isPrivate shouldBe false
+        resolution shouldBe "Unresolved"
+    }
+
+    "should remove comments created during shadowban" {
+        var commentRestricted = false
+        var otherCommentRestricted = false
+
+        val shadowbannedComment = mockComment(
+            author = shadowbannedUser,
+            created = Instant.ofEpochMilli(800),
+            restrict = { commentRestricted = true }
+        )
+
+        val otherComment = mockComment(
+            created = Instant.ofEpochMilli(900),
+            restrict = { otherCommentRestricted = true }
+        )
+
+        val issue = mockIssue(
+            comments = listOf(shadowbannedComment, otherComment)
+        )
+
+        val result = module(issue, timeframe)
+        result.shouldBeRight(ModuleResponse)
+        commentRestricted shouldBe true
+        otherCommentRestricted shouldBe false
+    }
+
+    "should not restrict restricted comments" {
+        var commentRestricted = false
+
+        val shadowbannedComment = mockComment(
+            author = shadowbannedUser,
+            created = Instant.ofEpochMilli(800),
+            restrict = { commentRestricted = true },
+            visibilityType = "group",
+            visibilityValue = "staff"
+        )
+
+        val issue = mockIssue(
+            comments = listOf(shadowbannedComment)
+        )
+
+        val result = module(issue, timeframe)
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+        commentRestricted shouldBe false
+    }
+
+    "should not remove comments created outside of shadowban duration" {
+        var commentRestricted = false
+
+        val shadowbannedComment = mockComment(
+            author = shadowbannedUser,
+            created = Instant.ofEpochMilli(200),
+            restrict = { commentRestricted = true }
+        )
+
+        val issue = mockIssue(
+            comments = listOf(shadowbannedComment)
+        )
+
+        val result = module(issue, timeframe)
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+        commentRestricted shouldBe false
+    }
+
+    "should not remove comments created by unbanned users" {
+        var commentRestricted = false
+
+        val shadowbannedComment = mockComment(
+            author = noLongerShadowbannedUser,
+            created = Instant.ofEpochMilli(800),
+            restrict = { commentRestricted = true }
+        )
+
+        val issue = mockIssue(
+            comments = listOf(shadowbannedComment)
+        )
+
+        val result = module(issue, timeframe)
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+        commentRestricted shouldBe false
+    }
+
+    "should remove attachments created during shadowban" {
+        var attachmentRemoved = false
+        var otherAttachmentRemoved = false
+
+        val shadowbannedAttachment = mockAttachment(
+            uploader = shadowbannedUser,
+            created = Instant.ofEpochMilli(800),
+            remove = { attachmentRemoved = true }
+        )
+
+        val otherAttachment = mockAttachment(
+            created = Instant.ofEpochMilli(900),
+            remove = { otherAttachmentRemoved = true }
+        )
+
+        val issue = mockIssue(
+            attachments = listOf(shadowbannedAttachment, otherAttachment)
+        )
+
+        val result = module(issue, timeframe)
+        result.shouldBeRight(ModuleResponse)
+        attachmentRemoved shouldBe true
+        otherAttachmentRemoved shouldBe false
+    }
+
+    "should not remove attachments created outside of shadowban duration" {
+        var attachmentRemoved = false
+
+        val shadowbannedAttachment = mockAttachment(
+            uploader = shadowbannedUser,
+            created = Instant.ofEpochMilli(200),
+            remove = { attachmentRemoved = true }
+        )
+
+        val issue = mockIssue(
+            attachments = listOf(shadowbannedAttachment)
+        )
+
+        val result = module(issue, timeframe)
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+        attachmentRemoved shouldBe false
+    }
+
+    "should not remove attachments created by unbanned users" {
+        var attachmentRemoved = false
+
+        val shadowbannedAttachment = mockAttachment(
+            uploader = noLongerShadowbannedUser,
+            created = Instant.ofEpochMilli(800),
+            remove = { attachmentRemoved = true }
+        )
+
+        val issue = mockIssue(
+            attachments = listOf(shadowbannedAttachment)
+        )
+
+        val result = module(issue, timeframe)
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+        attachmentRemoved shouldBe false
+    }
+})


### PR DESCRIPTION
## Purpose
Add a shadowban command to revert all actions for a specific user, for a duration of 24 hours.

## Approach
Save shadowbans in last run file. I've completely reworked the last run file on the occasion. Have a module that checks for any actions of shadowbanned users on any updated ticket, by looking it up in the last run file essentially. The command just adds the ban to the last run file.

See the commit messages of the individual commits for more information.

There are some shady things I did, please review thoroughly. If you have a better idea on how to solve the communication between command and last run file, feel free to provide suggestions. I felt like threading through the last run file just for this was a bit much.

## Future work
General clean up.

#### Checklist
- [x] Included tests
- [x] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [x] Tested in WEB-5505
