### PR TITLE
Scan newly created bug reports for spam

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -392,11 +392,8 @@ arisa:
     hideImpostors:
 
     removeSpam:
-      patterns:
-        - pattern: '\[~'
-          threshold: 5
-        - pattern: 'bugsbugsbugs'
-          threshold: 1
+      # Add patterns in `local.yml` to hide them from the public
+      patterns: []
 
     resolveTrash:
       projects:

--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -316,13 +316,21 @@ Removes specified tags added by non-volunteer users.
 | Name  | `RemoveSpam`                                                                  |
 | Class | [Link](../src/main/kotlin/io/github/mojira/arisa/modules/RemoveSpamModule.kt) |
 
-Restricts comments that follow certain patterns (can be configured in [config](../config/config.yml)).
+Restricts comments that follow certain patterns (can be configured in [config](../config/config.yml),
+if hidden from the public in `local.yml`).
+
+Bug reports that match these patterns are resolved as invalid, are made private,
+and the reporter is changed to `SpamBin`.
 
 ### Checks
 - The comment
     - is new (created after the last bot run)
     - was not posted by someone in the `helper`, `staff`, or `global-moderators` group
     - is not restricted already
+- The bug report
+    - is new (created after the last bot run)
+    - was not created by someone in the `helper`, `staff`, or `global-moderators` group
+    - matches any spam pattern either in the description, the environment, or the summary
 
 ## RemoveTriagedMeqs
 | Entry | Value                                                                                |

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
@@ -428,5 +428,5 @@ data class SpamPatternConfig(
     val pattern: String,
     val threshold: Int
 ) {
-    val regex = pattern.toRegex()
+    val regex = pattern.toRegex(RegexOption.IGNORE_CASE)
 }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RemoveSpamModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RemoveSpamModule.kt
@@ -9,22 +9,26 @@ import io.github.mojira.arisa.domain.Issue
 import io.github.mojira.arisa.infrastructure.config.SpamPatternConfig
 import java.time.Instant
 
+@Suppress("TooManyFunctions")
 class RemoveSpamModule(private val patternConfigs: List<SpamPatternConfig>) : Module {
     override fun invoke(issue: Issue, lastRun: Instant): Either<ModuleError, ModuleResponse> = with(issue) {
         Either.fx {
-            val removeSpamComments = comments
-                .asSequence()
-                .filter(::createdSinceLastRun.partially2(lastRun))
-                .filter(::userIsNotVolunteer)
-                .filter(::isNotStaffRestricted)
-                .filter(::isSpam)
-                .map { ::restrictComment.partially1(it) }
-                .toList()
+            val actions = removeSpamComments(comments, lastRun) + checkIssue(issue, lastRun)
 
-            assertNotEmpty(removeSpamComments).bind()
-            removeSpamComments.forEach { it.invoke() }
+            assertNotEmpty(actions).bind()
+            actions.forEach { it.invoke() }
         }
     }
+
+    private fun removeSpamComments(comments: List<Comment>, lastRun: Instant): List<() -> Unit> =
+        comments
+            .asSequence()
+            .filter(::createdSinceLastRun.partially2(lastRun))
+            .filter(::userIsNotVolunteer)
+            .filter(::isNotStaffRestricted)
+            .filter(::isCommentSpam)
+            .map { ::restrictComment.partially1(it) }
+            .toList()
 
     private fun createdSinceLastRun(comment: Comment, lastRun: Instant) =
         comment.created.isAfter(lastRun)
@@ -35,14 +39,47 @@ class RemoveSpamModule(private val patternConfigs: List<SpamPatternConfig>) : Mo
     private fun isNotStaffRestricted(comment: Comment) =
         comment.visibilityType != "group" || comment.visibilityValue != "staff"
 
-    private fun isSpam(comment: Comment): Boolean {
-        val commentContent = comment.body ?: return false
-        return patternConfigs.any {
-            it.regex.findAll(commentContent).count() >= it.threshold
-        }
+    private fun isCommentSpam(comment: Comment): Boolean {
+        return isTextSpam(comment.body ?: return false)
     }
+
+    private fun isTextSpam(text: String): Boolean =
+        patternConfigs.any {
+            it.regex.findAll(text).count() >= it.threshold
+        }
 
     private fun restrictComment(comment: Comment) {
         comment.restrict("${comment.body}\nRemoved by Arisa (RemoveSpamModule)")
+    }
+
+    private fun checkIssue(issue: Issue, lastRun: Instant): List<() -> Unit> {
+        val shouldTakeAction = isBugreportNew(issue, lastRun) && isBugreportSpam(issue)
+
+        return if (shouldTakeAction)
+            listOf {
+                issue.putInSpamBin()
+            }
+        else
+            emptyList()
+    }
+
+    private fun isBugreportNew(issue: Issue, lastRun: Instant) =
+        issue.created.isAfter(lastRun)
+
+    private fun isBugreportSpam(issue: Issue): Boolean {
+        val reporter = issue.reporter ?: return false
+        val groups = reporter.getGroups() ?: listOf()
+        val userIsVolunteer = groups.any { listOf("helper", "global-moderators", "staff").contains(it) }
+
+        return if (userIsVolunteer) false
+        else isTextSpam(issue.summary ?: "") ||
+            isTextSpam(issue.description ?: "") ||
+            isTextSpam(issue.environment ?: "")
+    }
+
+    private fun Issue.putInSpamBin() {
+        changeReporter("SpamBin")
+        if (securityLevel == null) setPrivate()
+        if (resolution == null || resolution == "Unresolved") resolveAsInvalid()
     }
 }

--- a/src/test/kotlin/io/github/mojira/arisa/modules/RemoveSpamModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/RemoveSpamModuleTest.kt
@@ -4,10 +4,13 @@ import io.github.mojira.arisa.infrastructure.config.SpamPatternConfig
 import io.github.mojira.arisa.utils.RIGHT_NOW
 import io.github.mojira.arisa.utils.mockComment
 import io.github.mojira.arisa.utils.mockIssue
+import io.github.mojira.arisa.utils.mockUser
 import io.kotest.assertions.arrow.either.shouldBeLeft
 import io.kotest.assertions.arrow.either.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
@@ -56,6 +59,22 @@ class RemoveSpamModuleTest : StringSpec({
         var isRestricted = false
         val comment = mockComment(
             body = "HEY THIS IS AN ANNOYING COMMENT SPAM SPAM SPAM",
+            restrict = { isRestricted = true }
+        )
+        val issue = mockIssue(
+            comments = listOf(comment)
+        )
+
+        val result = module(issue, YESTERDAY)
+
+        result.shouldBeRight(ModuleResponse)
+        isRestricted.shouldBeTrue()
+    }
+
+    "should trigger regardless of capitalization" {
+        var isRestricted = false
+        val comment = mockComment(
+            body = "hey this is an annoying comment sPam spam SpAm",
             restrict = { isRestricted = true }
         )
         val issue = mockIssue(
@@ -120,5 +139,172 @@ class RemoveSpamModuleTest : StringSpec({
         val result = module(issue, YESTERDAY)
 
         result.shouldBeLeft(OperationNotNeededModuleResponse)
+    }
+
+    "should close bug report if it contains spam in description" {
+        var setToPrivate = false
+        var resolution = "Unresolved"
+        var reporterName = "annoying"
+
+        val reporter = mockUser(name = reporterName)
+
+        val issue = mockIssue(
+            description = "spam spam spam spam spam",
+            setPrivate = { setToPrivate = true },
+            resolveAsInvalid = { resolution = "Invalid" },
+            changeReporter = { reporterName = it },
+            reporter = reporter
+        )
+
+        val result = module(issue, YESTERDAY)
+
+        result.shouldBeRight(ModuleResponse)
+        setToPrivate.shouldBeTrue()
+        resolution shouldBe "Invalid"
+        reporterName shouldBe "SpamBin"
+    }
+
+    "should close bug report if it contains spam in environment" {
+        var setToPrivate = false
+        var resolution = "Unresolved"
+        var reporterName = "annoying"
+
+        val reporter = mockUser(name = reporterName)
+
+        val issue = mockIssue(
+            environment = "spam spam spam spam spam",
+            setPrivate = { setToPrivate = true },
+            resolveAsInvalid = { resolution = "Invalid" },
+            changeReporter = { reporterName = it },
+            reporter = reporter
+        )
+
+        val result = module(issue, YESTERDAY)
+
+        result.shouldBeRight(ModuleResponse)
+        setToPrivate.shouldBeTrue()
+        resolution shouldBe "Invalid"
+        reporterName shouldBe "SpamBin"
+    }
+
+    "should close bug report if it contains spam in summary" {
+        var setToPrivate = false
+        var resolution = "Unresolved"
+        var reporterName = "annoying"
+
+        val reporter = mockUser(name = reporterName)
+
+        val issue = mockIssue(
+            summary = "spam spam spam spam spam",
+            setPrivate = { setToPrivate = true },
+            resolveAsInvalid = { resolution = "Invalid" },
+            changeReporter = { reporterName = it },
+            reporter = reporter
+        )
+
+        val result = module(issue, YESTERDAY)
+
+        result.shouldBeRight(ModuleResponse)
+        setToPrivate.shouldBeTrue()
+        resolution shouldBe "Invalid"
+        reporterName shouldBe "SpamBin"
+    }
+
+    "should not close bug report if it was created before last run" {
+        var setToPrivate = false
+        var resolution = "Unresolved"
+        var reporterName = "annoying"
+
+        val reporter = mockUser(name = reporterName)
+
+        val issue = mockIssue(
+            description = "spam spam spam spam spam",
+            setPrivate = { setToPrivate = true },
+            resolveAsInvalid = { resolution = "Invalid" },
+            changeReporter = { reporterName = it },
+            reporter = reporter,
+            created = YESTERDAY.minus(1, ChronoUnit.DAYS)
+        )
+
+        val result = module(issue, YESTERDAY)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+        setToPrivate.shouldBeFalse()
+        resolution shouldBe "Unresolved"
+        reporterName shouldBe "annoying"
+    }
+
+    "should not close bug report if reporter is volunteer" {
+        var setToPrivate = false
+        var resolution = "Unresolved"
+        var reporterName = "annoying"
+
+        val reporter = mockUser(
+            name = reporterName,
+            getGroups = { listOf("staff") }
+        )
+
+        val issue = mockIssue(
+            description = "spam spam spam spam spam",
+            setPrivate = { setToPrivate = true },
+            resolveAsInvalid = { resolution = "Invalid" },
+            changeReporter = { reporterName = it },
+            reporter = reporter
+        )
+
+        val result = module(issue, YESTERDAY)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+        setToPrivate.shouldBeFalse()
+        resolution shouldBe "Unresolved"
+        reporterName shouldBe "annoying"
+    }
+
+    "should not set to private if already set to private" {
+        var setToPrivate = false
+        var resolution = "Unresolved"
+        var reporterName = "annoying"
+
+        val reporter = mockUser(name = reporterName)
+
+        val issue = mockIssue(
+            description = "spam spam spam spam spam",
+            setPrivate = { setToPrivate = true },
+            resolveAsInvalid = { resolution = "Invalid" },
+            changeReporter = { reporterName = it },
+            reporter = reporter,
+            securityLevel = "Private"
+        )
+
+        val result = module(issue, YESTERDAY)
+
+        result.shouldBeRight(ModuleResponse)
+        setToPrivate.shouldBeFalse()
+        resolution shouldBe "Invalid"
+        reporterName shouldBe "SpamBin"
+    }
+
+    "should not resolve if already resolved" {
+        var setToPrivate = false
+        var resolution = "Incomplete"
+        var reporterName = "annoying"
+
+        val reporter = mockUser(name = reporterName)
+
+        val issue = mockIssue(
+            description = "spam spam spam spam spam",
+            setPrivate = { setToPrivate = true },
+            resolveAsInvalid = { resolution = "Invalid" },
+            changeReporter = { reporterName = it },
+            reporter = reporter,
+            resolution = resolution
+        )
+
+        val result = module(issue, YESTERDAY)
+
+        result.shouldBeRight(ModuleResponse)
+        setToPrivate.shouldBeTrue()
+        resolution shouldBe "Incomplete"
+        reporterName shouldBe "SpamBin"
     }
 })


### PR DESCRIPTION
## Purpose
Add a new spam pattern + also check newly created bug reports for spam

## Approach
If a bug report matches the spam patterns, it's put in the spam bin.

Also patterns have been hidden and need to be specified in the `local.yml` file now.

## Future work

#### Checklist
- [x] Included tests
- [x] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
