### PR TITLE
Format removal message correctly with command prefix

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -296,6 +296,7 @@ arisa:
       removalReason: Comment was not properly staff-restricted.
       removablePrefixes:
         - MEQS
+        - $ARISA
         - ARISA
 
     incomplete:


### PR DESCRIPTION
## Purpose
Format removal message correctly with command prefix ($ARISA)

(Leaves the old one there as well just in case someone forgets the $ in front of it and to remove it in tags)
