### PR TITLE
Fix range argument in $ARISA_PURGE_ATTACHMENT

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -105,10 +105,10 @@ the Security Level.
 This command only has an effect once; the reporter is able to make the ticket public afterwards again.
 
 ## $ARISA_PURGE_ATTACHMENT
-| Entry       | Value                                                                   |
-| ----------- | ----------------------------------------------------------------------- |
+| Entry       | Value                                                                 |
+| ----------- | --------------------------------------------------------------------- |
 | Syntax      | `$ARISA_PURGE_ATTACHMENT [from <minId>] [to <maxId>] [by <username>]` |
-| Permissions | Mod+                                                                    |
+| Permissions | Mod+                                                                  |
 
 - `<minId>` and `<maxId>`: The numeric ID of an attachment that can be found in the change log or in the link of it.
 - `<username>`: Copy from the Username field on the user's profile as-is (not from the URL, where spaces may get encoded as plus signs). Do not put quotes around it. Note that there might be a trailing space in the Username field -- you can leave it in the command as Arisa doesn't mind it.

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -105,18 +105,27 @@ the Security Level.
 This command only has an effect once; the reporter is able to make the ticket public afterwards again.
 
 ## $ARISA_PURGE_ATTACHMENT
-| Entry       | Value                                                      |
-| ----------- | ---------------------------------------------------------- |
-| Syntax      | `$ARISA_PURGE_ATTACHMENT <username> [<min ID>] [<max ID>]` |
-| Permissions | Mod+                                                       |
+| Entry       | Value                                                                   |
+| ----------- | ----------------------------------------------------------------------- |
+| Syntax      | `$ARISA_PURGE_ATTACHMENT [from <minId>] [to <maxId>] [by <username>]` |
+| Permissions | Mod+                                                                    |
 
+- `<minId>` and `<maxId>`: The numeric ID of an attachment that can be found in the change log or in the link of it.
 - `<username>`: Copy from the Username field on the user's profile as-is (not from the URL, where spaces may get encoded as plus signs). Do not put quotes around it. Note that there might be a trailing space in the Username field -- you can leave it in the command as Arisa doesn't mind it.
 
-Deletes all attachments on the ticket by user with the username if the attachment ID is between min ID and max ID.
+Deletes all attachments on the ticket by user with the username if the attachment ID is between minId and maxId (inclusive).
 
-Without specifying min/max ID, all attachments by that user are deleted.
-
-Note: the numeric ID of an attachment can be found in the change log or in the link of it.
+Examples:
+```
+$ARISA_PURGE_ATTACHMENT                   // Remove all attachments from the report.
+$ARISA_PURGE_ATTACHMENT by Annoying User  // Remove all attachments uploaded by "Annoying User" from the report.
+$ARISA_PURGE_ATTACHMENT from 10000
+$ARISA_PURGE_ATTACHMENT from 10000 by Annoying User
+$ARISA_PURGE_ATTACHMENT from 10000 to 20000
+$ARISA_PURGE_ATTACHMENT from 10000 to 20000 by Annoying User
+$ARISA_PURGE_ATTACHMENT to 20000
+$ARISA_PURGE_ATTACHMENT to 20000 by Annoying User
+```
 
 ## $ARISA_REMOVE_COMMENTS
 | Entry       | Value                               |

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/CommandDispatcher.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/CommandDispatcher.kt
@@ -204,37 +204,110 @@ fun getCommandDispatcher(
         val purgeAttachmentCommandNode =
             literal<CommandSource>("${prefix}_PURGE_ATTACHMENT")
                 .requires(::sentByModerator)
+                .executes {
+                    purgeAttachmentCommand(
+                        it.source.issue,
+                        null,
+                        0,
+                        Int.MAX_VALUE
+                    )
+                }
                 .then(
-                    argument<CommandSource, String>("username", greedyString())
-                        .executes {
-                            purgeAttachmentCommand(
-                                it.source.issue,
-                                it.getString("username"),
-                                0,
-                                Int.MAX_VALUE
-                            )
-                        }
+                    literal<CommandSource>("from")
                         .then(
                             argument<CommandSource, Int>("minId", integer(0))
                                 .executes {
                                     purgeAttachmentCommand(
                                         it.source.issue,
-                                        it.getString("username"),
+                                        null,
                                         it.getInt("minId"),
                                         Int.MAX_VALUE
                                     )
                                 }
                                 .then(
-                                    argument<CommandSource, Int>("maxId", integer(0))
-                                        .executes {
-                                            purgeAttachmentCommand(
-                                                it.source.issue,
-                                                it.getString("username"),
-                                                it.getInt("minId"),
-                                                it.getInt("maxId")
-                                            )
-                                        }
+                                    literal<CommandSource>("to")
+                                        .then(
+                                            argument<CommandSource, Int>("maxId", integer(0))
+                                                .executes {
+                                                    purgeAttachmentCommand(
+                                                        it.source.issue,
+                                                        null,
+                                                        it.getInt("minId"),
+                                                        it.getInt("maxId")
+                                                    )
+                                                }
+                                                .then(
+                                                    literal<CommandSource>("by")
+                                                        .then(
+                                                            argument<CommandSource, String>("username", greedyString())
+                                                                .executes {
+                                                                    purgeAttachmentCommand(
+                                                                        it.source.issue,
+                                                                        it.getString("username"),
+                                                                        it.getInt("minId"),
+                                                                        it.getInt("maxId")
+                                                                    )
+                                                                }
+                                                        )
+                                                )
+                                        )
                                 )
+                                .then(
+                                    literal<CommandSource>("by")
+                                        .then(
+                                            argument<CommandSource, String>("username", greedyString())
+                                                .executes {
+                                                    purgeAttachmentCommand(
+                                                        it.source.issue,
+                                                        it.getString("username"),
+                                                        it.getInt("minId"),
+                                                        Int.MAX_VALUE
+                                                    )
+                                                }
+                                        )
+                                )
+                        )
+                )
+                .then(
+                    literal<CommandSource>("to")
+                        .then(
+                            argument<CommandSource, Int>("maxId", integer(0))
+                                .executes {
+                                    purgeAttachmentCommand(
+                                        it.source.issue,
+                                        null,
+                                        0,
+                                        it.getInt("maxId")
+                                    )
+                                }
+                                .then(
+                                    literal<CommandSource>("by")
+                                        .then(
+                                            argument<CommandSource, String>("username", greedyString())
+                                                .executes {
+                                                    purgeAttachmentCommand(
+                                                        it.source.issue,
+                                                        it.getString("username"),
+                                                        0,
+                                                        it.getInt("maxId")
+                                                    )
+                                                }
+                                        )
+                                )
+                        )
+                )
+                .then(
+                    literal<CommandSource>("by")
+                        .then(
+                            argument<CommandSource, String>("username", greedyString())
+                                .executes {
+                                    purgeAttachmentCommand(
+                                        it.source.issue,
+                                        it.getString("username"),
+                                        0,
+                                        Int.MAX_VALUE
+                                    )
+                                }
                         )
                 )
 

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/PurgeAttachmentCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/PurgeAttachmentCommand.kt
@@ -3,11 +3,11 @@ package io.github.mojira.arisa.modules.commands
 import io.github.mojira.arisa.domain.Issue
 
 class PurgeAttachmentCommand {
-    operator fun invoke(issue: Issue, userName: String, minId: Int, maxId: Int): Int {
+    operator fun invoke(issue: Issue, userName: String?, minId: Int, maxId: Int): Int {
         return issue.attachments
             .filter {
                 // Make sure that attachment is uploaded by the specified user
-                it.uploader?.name == userName
+                userName == null || it.uploader?.name == userName
             }
             .filter {
                 // Don't delete attachments with an ID outside of ID range

--- a/src/test/kotlin/io/github/mojira/arisa/modules/commands/PurgeAttachmentCommandTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/commands/PurgeAttachmentCommandTest.kt
@@ -124,4 +124,38 @@ class PurgeAttachmentCommandTest : StringSpec({
         attachment1Removed.shouldBeFalse()
         attachment2Removed.shouldBeTrue()
     }
+
+    "should purge attachments by all users when user argument is null" {
+        var attachment0Removed = false
+        var attachment1Removed = false
+        var attachment2Removed = false
+        val command = PurgeAttachmentCommand()
+
+        val issue = mockIssue(
+            attachments = listOf(
+                mockAttachment(
+                    id = "0",
+                    remove = { attachment0Removed = true },
+                    uploader = mockUser(name = "annoyingUser1")
+                ),
+                mockAttachment(
+                    id = "1",
+                    remove = { attachment1Removed = true },
+                    uploader = mockUser(name = "annoyingUser2")
+                ),
+                mockAttachment(
+                    id = "2",
+                    remove = { attachment2Removed = true },
+                    uploader = mockUser(name = "annoyingUser3")
+                )
+            )
+        )
+
+        val result = command(issue, null, 0, Int.MAX_VALUE)
+
+        result shouldBe 3
+        attachment0Removed.shouldBeTrue()
+        attachment1Removed.shouldBeTrue()
+        attachment2Removed.shouldBeTrue()
+    }
 })


### PR DESCRIPTION
## Purpose
Fix #759.

## Approach
By changing the syntax of the command from

```
$ARISA_PURGE_ATTACHMENT <username> [<minId> [<maxId>]]
```

to

```
$ARISA_PURGE_ATTACHMENT [from <minId>] [to <maxId>] [by <username>]
```

This makes all eight possible combinations of ways to filter attachments legal:

```
$ARISA_PURGE_ATTACHMENT                   // Remove all attachments from the report.
$ARISA_PURGE_ATTACHMENT by Annoying User  // Remove all attachments uploaded by "Annoying User" from the report.
$ARISA_PURGE_ATTACHMENT from 10000
$ARISA_PURGE_ATTACHMENT from 10000 by Annoying User
$ARISA_PURGE_ATTACHMENT from 10000 to 20000
$ARISA_PURGE_ATTACHMENT from 10000 to 20000 by Annoying User
$ARISA_PURGE_ATTACHMENT to 20000
$ARISA_PURGE_ATTACHMENT to 20000 by Annoying User
```

## Future work

#### Checklist
- [x] Included tests
- [x] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
