### PR TITLE
Update mc-crash-lib to 2.0.7

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.4.30"
+    kotlin("jvm") version "1.6.21"
     id("org.jlleitschuh.gradle.ktlint") version "9.2.1"
     application
     id("io.gitlab.arturbosch.detekt") version "1.17.0"
@@ -65,7 +65,7 @@ dependencies {
 
     implementation("com.uchuhimo", "konf", "0.22.1")
     implementation("com.github.rcarz", "jira-client", "868a5ca897")
-    implementation("com.urielsalis", "mc-crash-lib", "2.0.5")
+    implementation("com.urielsalis", "mc-crash-lib", "2.0.7")
     implementation("com.github.napstr", "logback-discord-appender", "a20617d401")
     implementation("org.slf4j", "slf4j-api", "1.7.25")
     implementation("ch.qos.logback", "logback-classic", logBackVersion)


### PR DESCRIPTION
## Purpose
Fixes #764

## Approach
Upgrades mc-crash-lib to the fixed version

## Future work

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
