### PR TITLE
RevokePriorityModule: Ignore helpers when determining correct Mojang Priority

### DIFF
--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -430,7 +430,7 @@ Revokes changes to `Mojang Priority` done by non-volunteers.
 
 ### Checks
 - The `Mojang Priority` is not the same as the last one changed by users with group
-  `helper`, `global-moderators`, or `staff`.
+  `global-moderators` or `staff`.
 
 ## Thumbnail
 | Entry | Value                                                                                  |

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RevokePriorityModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RevokePriorityModule.kt
@@ -12,7 +12,7 @@ class RevokePriorityModule : Module {
         Either.fx {
             val originalPriority = changeLog
                 .filter(::isPriorityChange)
-                .lastOrNull(::changedByVolunteer)
+                .lastOrNull(::changedByStaff)
                 ?.changedTo.getOrDefaultNull("-1")
 
             assertNotEquals(getId(priority), originalPriority).bind()
@@ -32,8 +32,8 @@ class RevokePriorityModule : Module {
     private fun isPriorityChange(item: ChangeLogItem) =
         item.field == "Mojang Priority"
 
-    private fun changedByVolunteer(item: ChangeLogItem) = !updateIsRecent(item) ||
-            item.getAuthorGroups()?.any { it == "helper" || it == "global-moderators" || it == "staff" } ?: true
+    private fun changedByStaff(item: ChangeLogItem) = !updateIsRecent(item) ||
+            item.getAuthorGroups()?.any { it == "global-moderators" || it == "staff" } ?: true
 
     private fun updateIsRecent(item: ChangeLogItem) =
         item


### PR DESCRIPTION
## Purpose
Helpers are not able to set Mojang Priority, yet the RevokePriorityModule thinks they are. This causes issues

## Approach
Remove helpers from privileged roles in RevokePriorityModule

## Future work
N/A

#### Checklist
- [ ] Included tests
- [x] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
