### PR TITLE
Fix errors and bugs in RevokePriorityModule

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/RevokePriorityModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RevokePriorityModule.kt
@@ -77,6 +77,6 @@ class RevokePriorityModule : Module {
     private fun updateIsRecent(item: ChangeLogItem) =
         item
             .created
-            .plus(1, ChronoUnit.DAYS)
+            .plus(1, ChronoUnit.YEARS)
             .isAfter(Instant.now())
 }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/RevokePriorityModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/RevokePriorityModule.kt
@@ -2,21 +2,50 @@ package io.github.mojira.arisa.modules
 
 import arrow.core.Either
 import arrow.core.extensions.fx
+import arrow.core.left
+import arrow.core.right
 import io.github.mojira.arisa.domain.ChangeLogItem
 import io.github.mojira.arisa.domain.Issue
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
 class RevokePriorityModule : Module {
+    val log: Logger = LoggerFactory.getLogger("RevokePriorityModule")
+
     override fun invoke(issue: Issue, lastRun: Instant): Either<ModuleError, ModuleResponse> = with(issue) {
         Either.fx {
-            val originalPriority = changeLog
+            // Check if there are recent changes to priority in the changelog
+            val recentPriorityChanges = changeLog
+                .filter { item -> item.created >= lastRun }
+                .filter(::isPriorityChange)
+
+            // If there aren't any recent changes to priority, there's nothing to revoke
+            assertNotEmpty(recentPriorityChanges).bind()
+
+            // Try to recover original priority by getting entries from the changelog
+            val originalPriorityItem = changeLog
                 .filter(::isPriorityChange)
                 .lastOrNull(::changedByStaff)
-                ?.changedTo.getOrDefaultNull("-1")
 
-            assertNotEquals(getId(priority), originalPriority).bind()
-            updatePriority(originalPriority)
+            val originalPriorityId = originalPriorityItem?.changedTo.getOrDefaultNull("-1")
+            val originalPriorityName = originalPriorityItem?.changedToString.getOrDefaultNull("None")
+
+            // Check whether the original priority differs from the current priority
+            assertNotEquals(getId(priority), originalPriorityId).bind()
+
+            // Ensure that the priority from the changelog is a currently valid priority value
+            // (e.g. 11602 was the original value for 'Normal', which is no longer valid)
+            assertValidPriority(originalPriorityId).mapLeft { result ->
+                log.error(
+                    "[${issue.key}] Cannot revoke change to priority: " +
+                        "Unknown mojang priority value '$originalPriorityName' [$originalPriorityId]"
+                )
+                result
+            }.bind()
+
+            updatePriority(originalPriorityId)
         }
     }
 
@@ -28,6 +57,16 @@ class RevokePriorityModule : Module {
         "Low" -> "11703"
         else -> "-1"
     }
+
+    private fun assertValidPriority(priorityId: String) =
+        if (isValidPriority(priorityId)) {
+            Unit.right()
+        } else {
+            OperationNotNeededModuleResponse.left()
+        }
+
+    private fun isValidPriority(priority: String): Boolean =
+        setOf("-1", "11700", "11701", "11702", "11703").contains(priority)
 
     private fun isPriorityChange(item: ChangeLogItem) =
         item.field == "Mojang Priority"


### PR DESCRIPTION
## Purpose
This addresses multiple issues with the RevokePriorityModule:
* The module would error if it encountered an outdated priority value in a changelog
* The module would succeed and try to reset priority even if priority hasn't been changed recently
* The module would consider all changes in the changelog to be authoritative if they're more than one day old - since the changelog isn't accurate for Mojang Priority it shouldn't do this.

## Approach
Added more checks:
* The module now checks if any changes to mojang priority have been made since last run
* The module now checks that the priority from the changelog is a valid priority, and otherwise logs an error (for manual correction)
* I've increased the limit for old priority changelog items to be considered canonical from one day to one year. This is not perfect! But it should be better than before, where as a regular user you could unsuccessfully try to change priority 2 days in a row, and on the second day Arisa would perform the change for you.
In this case I'm not sure if it even makes sense to still have the `updateIsRecent` check there. Since the changelog is messed up for mojang priority I don't see any other way though without it getting more involved.

## Future work
Perhaps we should disable this module and only enable it when it is needed?

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
