### PR TITLE
Detect profilekeys attachments as sensitive

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -187,6 +187,9 @@ arisa:
         # At the moment braintree transaction IDs seem to have 8 chars, but to be future-proof
         # match if there are more chars as well
         - '\bbraintree:[a-f0-9]{6,12}\b'
+        # Used in profilekeys JSON files
+        - 'private_key'
+        - 'BEGIN RSA PRIVATE KEY'
       sensitiveFileNameRegexes:
         - 'launcher_accounts\.json'
         - 'launcher_entitlements\.json'

--- a/src/main/kotlin/io/github/mojira/arisa/domain/Attachment.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/domain/Attachment.kt
@@ -14,7 +14,8 @@ data class Attachment(
     val uploader: User?
 ) {
     /** Returns whether the type of the content is text */
-    fun hasTextContent() = mimeType.startsWith("text/")
+    fun hasTextContent() = mimeType.startsWith("text/") or
+            (mimeType == "application/json") or (mimeType == "application/xml")
 
     /** Decodes the content as UTF-8 String */
     fun getTextContent() = String(getContent())

--- a/src/test/kotlin/io/github/mojira/arisa/modules/privacy/PrivacyModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/privacy/PrivacyModuleTest.kt
@@ -173,6 +173,28 @@ class PrivacyModuleTest : FunSpec({
                     addedComment shouldBe CommentOptions(MADE_PRIVATE_MESSAGE)
                 }
 
+                test("should mark as private when JSON attachment contains sensitive data") {
+                    var hasSetPrivate = false
+                    var addedComment: CommentOptions? = null
+
+                    val issue = mockIssue(
+                        attachments = listOf(
+                            mockAttachment(
+                                mimeType = "application/json",
+                                getContent = { "{\"data\":\"${testData.sensitiveText}\"}".toByteArray() }
+                            )
+                        ),
+                        setPrivate = { hasSetPrivate = true },
+                        addComment = { addedComment = it }
+                    )
+
+                    val result = testData.module(issue, TWO_SECONDS_AGO)
+
+                    result.shouldBeRight(ModuleResponse)
+                    hasSetPrivate shouldBe true
+                    addedComment shouldBe CommentOptions(MADE_PRIVATE_MESSAGE)
+                }
+
                 test("should mark as private when the summary contains sensitive data") {
                     var hasSetPrivate = false
                     var addedComment: CommentOptions? = null


### PR DESCRIPTION
## Purpose
The JSON files in the `profilekeys` directory of the game installation directory contain RSA private keys used for authentication at
servers and for signing chat messages. Therefore they should be treated as sensitive.

## Approach
- Update `sensitiveTextRegexes` in config
- Treat MIME types `application/json` (and `application/xml`) as text

#### Checklist
- [x] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md) and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
