### PR TITLE
Rename GitHub workflow files and allow manual triggering of deployment

### DIFF
--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -1,7 +1,4 @@
-# This workflow will build a Java project with Gradle
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
-
-name: Java CI with Gradle
+name: Build (pull request)
 
 on:
   pull_request:

--- a/.github/workflows/push-build-deploy.yml
+++ b/.github/workflows/push-build-deploy.yml
@@ -1,10 +1,10 @@
-# This workflow will build a Java project with Gradle and deploy it
-
-name: Build and push
+name: Build and deploy
 
 on:
   push:
     branches: [ master ]
+  # Allow manually triggering deployment
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Purpose
- Renames the GitHub workflow files to express better what they are doing and in which situations they are running (feedback for better names is welcome though)
- Allow manual re-deployment; might be useful in certain situations, see a4156d76b192315686b17888e824e746884a7091
@violine1101, what was actually the context for that re-deployment?
