### PR TITLE
Fix logback failing to parse log config XML

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,11 +64,32 @@ dependencies {
     implementation("com.mojang", "brigadier", "1.0.18")
     implementation("org.apache.commons", "commons-imaging", "1.0-alpha3")
 
+    components {
+        /*
+         * Clears all dependencies of dom4j (which is used transitively) because they are actually optional
+         * dependencies, see:
+         * - https://github.com/dom4j/dom4j/issues/99#issuecomment-830063159
+         * - https://github.com/dom4j/dom4j/blob/7fbdc6d58623ec0b54b9b44a4738781b65191df1/build.gradle#L92-L96
+         *
+         * One of the optional dependencies (pull-parser) is causing issues because it registers itself as
+         * javax.xml.parsers.SAXParserFactory implementation, but it does not support all features, causing
+         * failures for logback.
+         */
+        withModule<ClearDependencies>("org.dom4j:dom4j")
+    }
+
     testImplementation("io.kotest", "kotest-assertions-core-jvm", kotestVersion)
     testImplementation("io.kotest", "kotest-runner-junit5", kotestVersion)
     testImplementation("io.kotest", "kotest-assertions-arrow", kotestVersion)
     testImplementation("io.mockk", "mockk", "1.13.2")
     testImplementation("org.reflections", "reflections", "0.10.2")
+}
+
+// Used for removing dependencies of dom4j, see usage above
+class ClearDependencies : ComponentMetadataRule {
+    override fun execute(context: ComponentMetadataContext) {
+        context.details.allVariants { withDependencies { clear() } }
+    }
 }
 
 tasks {


### PR DESCRIPTION
## Purpose
Fixes #783

Was apparently caused by a combination of optional dom4j dependencies not being declared as optional which were replacing the standard `SAXParserFactory`, and by recent logback changes which require features not supported by that `SAXParserFactory` implementation.

<details>
<summary>Full error output</summary>

```
ch.qos.logback.core.joran.spi.JoranException: Error during parser creation or parser configuration
	at ch.qos.logback.core.joran.event.SaxEventRecorder.buildSaxParser(SaxEventRecorder.java:100)
	at ch.qos.logback.core.joran.event.SaxEventRecorder.recordEvents(SaxEventRecorder.java:62)
	at ch.qos.logback.core.joran.GenericXMLConfigurator.populateSaxEventRecorder(GenericXMLConfigurator.java:178)
	at ch.qos.logback.core.joran.GenericXMLConfigurator.doConfigure(GenericXMLConfigurator.java:159)
	at ch.qos.logback.core.joran.GenericXMLConfigurator.doConfigure(GenericXMLConfigurator.java:122)
	at ch.qos.logback.core.joran.GenericXMLConfigurator.doConfigure(GenericXMLConfigurator.java:65)
	at ch.qos.logback.classic.util.DefaultJoranConfigurator.configureByResource(DefaultJoranConfigurator.java:53)
	at ch.qos.logback.classic.util.DefaultJoranConfigurator.configure(DefaultJoranConfigurator.java:34)
	at ch.qos.logback.classic.util.ContextInitializer.autoConfig(ContextInitializer.java:98)
	at ch.qos.logback.classic.util.ContextInitializer.autoConfig(ContextInitializer.java:77)
	at ch.qos.logback.classic.spi.LogbackServiceProvider.initializeLoggerContext(LogbackServiceProvider.java:50)
	at ch.qos.logback.classic.spi.LogbackServiceProvider.initialize(LogbackServiceProvider.java:41)
	at org.slf4j.LoggerFactory.bind(LoggerFactory.java:152)
	at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:139)
	at org.slf4j.LoggerFactory.getProvider(LoggerFactory.java:422)
	at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:408)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:357)
	at io.github.mojira.arisa.ArisaMainKt.<clinit>(ArisaMain.kt:8)
Caused by: org.xml.sax.SAXNotRecognizedException: unrecognized feature http://xml.org/sax/features/external-general-entities
	at org.gjt.xpp.sax2.Driver.setFeature(Driver.java:178)
	at org.gjt.xpp.jaxp11.SAXParserImpl.setFeatures(SAXParserImpl.java:149)
	at org.gjt.xpp.jaxp11.SAXParserImpl.<init>(SAXParserImpl.java:132)
	at org.gjt.xpp.jaxp11.SAXParserFactoryImpl.newSAXParserImpl(SAXParserFactoryImpl.java:114)
	at org.gjt.xpp.jaxp11.SAXParserFactoryImpl.setFeature(SAXParserFactoryImpl.java:142)
	at ch.qos.logback.core.joran.event.SaxEventRecorder.buildSaxParser(SaxEventRecorder.java:89)
	... 17 more
23:43:20,468 |-INFO in ch.qos.logback.classic.LoggerContext[default] - This is logback-classic version 1.4.3
23:43:20,542 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.xml]
23:43:20,566 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Found resource [logback.xml] at [file:arisa-kt/build/resources/main/logback.xml]
23:43:20,660 |-ERROR in ch.qos.logback.core.joran.event.SaxEventRecorder@641147d0 - Error during parser creation or parser configuration org.xml.sax.SAXNotRecognizedException: unrecognized feature http://xml.org/sax/features/external-general-entities
	at org.xml.sax.SAXNotRecognizedException: unrecognized feature http://xml.org/sax/features/external-general-entities
	at 	at org.gjt.xpp.sax2.Driver.setFeature(Driver.java:178)
	at 	at org.gjt.xpp.jaxp11.SAXParserImpl.setFeatures(SAXParserImpl.java:149)
	at 	at org.gjt.xpp.jaxp11.SAXParserImpl.<init>(SAXParserImpl.java:132)
	at 	at org.gjt.xpp.jaxp11.SAXParserFactoryImpl.newSAXParserImpl(SAXParserFactoryImpl.java:114)
	at 	at org.gjt.xpp.jaxp11.SAXParserFactoryImpl.setFeature(SAXParserFactoryImpl.java:142)
	at 	at ch.qos.logback.core.joran.event.SaxEventRecorder.buildSaxParser(SaxEventRecorder.java:89)
	at 	at ch.qos.logback.core.joran.event.SaxEventRecorder.recordEvents(SaxEventRecorder.java:62)
	at 	at ch.qos.logback.core.joran.GenericXMLConfigurator.populateSaxEventRecorder(GenericXMLConfigurator.java:178)
	at 	at ch.qos.logback.core.joran.GenericXMLConfigurator.doConfigure(GenericXMLConfigurator.java:159)
	at 	at ch.qos.logback.core.joran.GenericXMLConfigurator.doConfigure(GenericXMLConfigurator.java:122)
	at 	at ch.qos.logback.core.joran.GenericXMLConfigurator.doConfigure(GenericXMLConfigurator.java:65)
	at 	at ch.qos.logback.classic.util.DefaultJoranConfigurator.configureByResource(DefaultJoranConfigurator.java:53)
	at 	at ch.qos.logback.classic.util.DefaultJoranConfigurator.configure(DefaultJoranConfigurator.java:34)
	at 	at ch.qos.logback.classic.util.ContextInitializer.autoConfig(ContextInitializer.java:98)
	at 	at ch.qos.logback.classic.util.ContextInitializer.autoConfig(ContextInitializer.java:77)
	at 	at ch.qos.logback.classic.spi.LogbackServiceProvider.initializeLoggerContext(LogbackServiceProvider.java:50)
	at 	at ch.qos.logback.classic.spi.LogbackServiceProvider.initialize(LogbackServiceProvider.java:41)
	at 	at org.slf4j.LoggerFactory.bind(LoggerFactory.java:152)
	at 	at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:139)
	at 	at org.slf4j.LoggerFactory.getProvider(LoggerFactory.java:422)
	at 	at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:408)
	at 	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:357)
	at 	at io.github.mojira.arisa.ArisaMainKt.<clinit>(ArisaMain.kt:8)
```

</details>

## Approach
Exclude the optional dependencies of dom4j, including `pull-parser` which was causing these issues.

That seems to fix the log config parsing issue. If have also let Arisa run locally (though without it being logged into Mojira) and it seems to still work fine; though feel free to test this more extensively if you want.
