### PR TITLE
Remove newline in Discord log pattern

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -30,9 +30,7 @@
             <level>INFO</level>
         </filter>
         <layout class="ch.qos.logback.classic.PatternLayout">
-            <pattern>`%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -
-                %msg`%n%replace(```%ex{full}```){'``````',''}%nopex
-            </pattern>
+            <pattern>`%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg`%n%replace(```%ex{full}```){'``````',''}%nopex</pattern>
         </layout>
         <username>Arisa</username>
         <avatarUrl>https://raw.githubusercontent.com/mojira/arisa-kt/master/arisa.png</avatarUrl>


### PR DESCRIPTION
Newlines were showing up on Discord:
![grafik](https://user-images.githubusercontent.com/12451842/202916877-95fed94d-ed06-40fd-a69e-ec82c3b82551.png)

This PR fixes that issue by reverting the formatting change for that particular pattern.