### PR TITLE
Update mc-crash-lib to latest version with forge logs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
 
     implementation("com.uchuhimo", "konf", "1.1.2")
     implementation("com.github.rcarz", "jira-client", "868a5ca897")
-    implementation("com.urielsalis", "mc-crash-lib", "2.0.8")
+    implementation("com.urielsalis", "mc-crash-lib", "2.0.10")
     implementation("com.github.napstr", "logback-discord-appender", "bda874138e")
     implementation("org.slf4j", "slf4j-api", "2.0.3")
     implementation("ch.qos.logback", "logback-classic", logBackVersion)


### PR DESCRIPTION
## Purpose
Update mc-crash-lib to latest version with forge logs
## Approach

## Future work

#### Checklist

- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md)
  and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
