### PR TITLE
Add Minecraft Legends project

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -6,6 +6,7 @@ arisa:
       - MCPE
       - MCL
       - MCD
+      - MCLG
       - BDS
       - REALMS
       - WEB
@@ -241,6 +242,7 @@ arisa:
     multiplePlatforms:
       projects:
         - MCD
+        - MCLG
         - MCPE
       resolutions:
         - Unresolved
@@ -271,6 +273,7 @@ arisa:
     keepPlatform:
       projects:
         - MCD
+        - MCLG
         - MCPE
       resolutions:
         - Unresolved
@@ -369,6 +372,7 @@ arisa:
         - MCPE
         - BDS
         - MCD
+        - MCLG
       resolutions:
         - Unresolved
       excludedStatuses:
@@ -418,6 +422,7 @@ arisa:
         - MCPE
         - MCL
         - MCD
+        - MCLG
         - BDS
         - REALMS
         - WEB

--- a/config/config.yml
+++ b/config/config.yml
@@ -242,7 +242,6 @@ arisa:
     multiplePlatforms:
       projects:
         - MCD
-        - MCLG
         - MCPE
       resolutions:
         - Unresolved
@@ -273,7 +272,6 @@ arisa:
     keepPlatform:
       projects:
         - MCD
-        - MCLG
         - MCPE
       resolutions:
         - Unresolved


### PR DESCRIPTION
## Purpose
Add the new Minecraft Legends (MCLG) project to Arisa.

## Approach
Update the config -- to my knowledge no updates are needed anywhere else.

Note that MCLG uses a custom platform field, similar to Dungeons. I've not adjusted this yet and as such the platform modules are disabled for now.

## Future work
Hope for the best and that things don't break.

Enable the platform modules for MCLG soon.