### PR TITLE
KeepPrivateModule: Special case for moving bug reports to MCL

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -390,6 +390,9 @@ arisa:
     keepPrivate:
       tag: MEQS_KEEP_PRIVATE
       message: panel-unmark-private-issue
+      privateLevels:
+        - '10318' # most projects
+        - '10502' # just MCL
 
     privateDuplicate:
       resolutions:

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
@@ -339,6 +339,9 @@ object Arisa : ConfigSpec() {
                 description = "The key of the message that is posted when this module succeeds."
             )
             val tag by optional<String?>(null)
+            val privateLevels by required<Set<String>>(
+                description = "All levels used to denote private security level"
+            )
         }
 
         object PrivateDuplicate : ModuleConfigSpec() {

--- a/src/main/kotlin/io/github/mojira/arisa/modules/KeepPrivateModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/KeepPrivateModule.kt
@@ -24,8 +24,8 @@ class KeepPrivateModule(
             setPrivate()
 
             val markedTime = comments.first(::isKeepPrivateTag).created
-            val securityChange = changeLog
-                .lastOrNull { isSecurityChangeToPublic(it, project.privateSecurity) }
+            val securityChange = changeLog.lastOrNull(::isSecurityChangeToPublic)
+
             val changedTime = securityChange?.created
             if (changedTime != null && changedTime.isAfter(markedTime)) {
                 if (
@@ -47,8 +47,8 @@ class KeepPrivateModule(
         comment.visibilityValue == "staff" &&
         (comment.body?.contains(keepPrivateTag!!) ?: false)
 
-    private fun isSecurityChangeToPublic(item: ChangeLogItem, privateLevel: String) =
-        item.field == "security" && item.changedFromString == privateLevel
+    private fun isSecurityChangeToPublic(item: ChangeLogItem) =
+        item.field == "security" && privateLevels.contains(item.changedFromString)
 
     private fun assertContainsKeepPrivateTag(comments: List<Comment>) = when {
         comments.any(::isKeepPrivateTag) -> Unit.right()

--- a/src/main/kotlin/io/github/mojira/arisa/modules/KeepPrivateModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/KeepPrivateModule.kt
@@ -12,13 +12,14 @@ import java.time.Instant
 
 class KeepPrivateModule(
     private val keepPrivateTag: String?,
-    private val message: String
+    private val message: String,
+    private val privateLevels: Set<String>
 ) : Module {
     override fun invoke(issue: Issue, lastRun: Instant): Either<ModuleError, ModuleResponse> = with(issue) {
         Either.fx {
             assertNotNull(keepPrivateTag).bind()
             assertContainsKeepPrivateTag(comments).bind()
-            assertIsPublic(securityLevel, project.privateSecurity).bind()
+            assertIsPublic(securityLevel).bind()
 
             setPrivate()
 
@@ -54,8 +55,8 @@ class KeepPrivateModule(
         else -> OperationNotNeededModuleResponse.left()
     }
 
-    private fun assertIsPublic(securityLevel: String?, privateLevel: String) =
-        if (securityLevel == privateLevel) {
+    private fun assertIsPublic(securityLevel: String?) =
+        if (privateLevels.contains(securityLevel)) {
             OperationNotNeededModuleResponse.left()
         } else {
             Unit.right()

--- a/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
@@ -128,7 +128,8 @@ class InstantModuleRegistry(config: Config) : ModuleRegistry(config) {
             Arisa.Modules.KeepPrivate,
             KeepPrivateModule(
                 config[Arisa.Modules.KeepPrivate.tag],
-                config[Arisa.Modules.KeepPrivate.message]
+                config[Arisa.Modules.KeepPrivate.message],
+                config[Arisa.Modules.KeepPrivate.privateLevels]
             )
         )
 

--- a/src/test/kotlin/io/github/mojira/arisa/modules/KeepPrivateModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/KeepPrivateModuleTest.kt
@@ -37,7 +37,7 @@ private val REMOVE_SECURITY_STAFF = mockChangeLogItem(
 
 class KeepPrivateModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse when keep private tag is null" {
-        val module = KeepPrivateModule(null, "message")
+        val module = KeepPrivateModule(null, "message", setOf(PRIVATE_SECURITY_LEVEL))
         val comment = mockComment(
             body = "MEQS_KEEP_PRIVATE",
             visibilityType = "group",
@@ -54,7 +54,7 @@ class KeepPrivateModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse when comments are empty" {
-        val module = KeepPrivateModule("MEQS_KEEP_PRIVATE", "message")
+        val module = KeepPrivateModule("MEQS_KEEP_PRIVATE", "message", setOf(PRIVATE_SECURITY_LEVEL))
         val issue = mockIssue(
             changeLog = listOf(REMOVE_SECURITY)
         )
@@ -65,7 +65,7 @@ class KeepPrivateModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse when no comment contains private tag" {
-        val module = KeepPrivateModule("MEQS_KEEP_PRIVATE", "message")
+        val module = KeepPrivateModule("MEQS_KEEP_PRIVATE", "message", setOf(PRIVATE_SECURITY_LEVEL))
         val comment = mockComment(
             body = "Hello world!",
             visibilityType = "group",
@@ -82,7 +82,7 @@ class KeepPrivateModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse when the comment isn't restricted to staff group" {
-        val module = KeepPrivateModule("MEQS_KEEP_PRIVATE", "message")
+        val module = KeepPrivateModule("MEQS_KEEP_PRIVATE", "message", setOf(PRIVATE_SECURITY_LEVEL))
         val comment = mockComment(
             body = "MEQS_KEEP_PRIVATE"
         )
@@ -97,7 +97,7 @@ class KeepPrivateModuleTest : StringSpec({
     }
 
     "should return OperationNotNeededModuleResponse when security level is set to private" {
-        val module = KeepPrivateModule("MEQS_KEEP_PRIVATE", "message")
+        val module = KeepPrivateModule("MEQS_KEEP_PRIVATE", "message", setOf(PRIVATE_SECURITY_LEVEL))
         val comment = mockComment(
             body = "MEQS_KEEP_PRIVATE",
             visibilityType = "group",
@@ -117,7 +117,7 @@ class KeepPrivateModuleTest : StringSpec({
         var didSetToPrivate = false
         var didComment = false
 
-        val module = KeepPrivateModule("MEQS_KEEP_PRIVATE", "message")
+        val module = KeepPrivateModule("MEQS_KEEP_PRIVATE", "message", setOf(PRIVATE_SECURITY_LEVEL))
         val comment = mockComment(
             body = "MEQS_KEEP_PRIVATE",
             created = RIGHT_NOW.minusSeconds(20),
@@ -142,7 +142,7 @@ class KeepPrivateModuleTest : StringSpec({
         var didSetToPrivate = false
         var didComment = false
 
-        val module = KeepPrivateModule("MEQS_KEEP_PRIVATE", "message")
+        val module = KeepPrivateModule("MEQS_KEEP_PRIVATE", "message", setOf(PRIVATE_SECURITY_LEVEL))
         val comment = mockComment(
             body = "MEQS_KEEP_PRIVATE",
             created = RIGHT_NOW.minusSeconds(20),
@@ -163,11 +163,33 @@ class KeepPrivateModuleTest : StringSpec({
         didComment shouldBe true
     }
 
+    "should not set to private if bug report is already private but with different security level" {
+        var didSetToPrivate = false
+
+        val module = KeepPrivateModule("MEQS_KEEP_PRIVATE", "message", setOf(PRIVATE_SECURITY_LEVEL, "special-private"))
+        val comment = mockComment(
+            body = "MEQS_KEEP_PRIVATE",
+            created = RIGHT_NOW.minusSeconds(20),
+            visibilityType = "group",
+            visibilityValue = "staff"
+        )
+        val issue = mockIssue(
+            securityLevel = "special-private",
+            comments = listOf(comment),
+            setPrivate = { didSetToPrivate = true; Unit.right() }
+        )
+
+        val result = module(issue, RIGHT_NOW)
+
+        result.shouldBeLeft(OperationNotNeededModuleResponse)
+        didSetToPrivate shouldBe false
+    }
+
     "should both set to private and comment when security level is not private" {
         var didSetToPrivate = false
         var didComment = false
 
-        val module = KeepPrivateModule("MEQS_KEEP_PRIVATE", "message")
+        val module = KeepPrivateModule("MEQS_KEEP_PRIVATE", "message", setOf(PRIVATE_SECURITY_LEVEL))
         val comment = mockComment(
             body = "MEQS_KEEP_PRIVATE",
             created = RIGHT_NOW.minusSeconds(20),
@@ -193,7 +215,7 @@ class KeepPrivateModuleTest : StringSpec({
         var didSetToPrivate = false
         var didComment = false
 
-        val module = KeepPrivateModule("MEQS_KEEP_PRIVATE", "message")
+        val module = KeepPrivateModule("MEQS_KEEP_PRIVATE", "message", setOf(PRIVATE_SECURITY_LEVEL))
         val comment = mockComment(
             body = "MEQS_KEEP_PRIVATE",
             created = RIGHT_NOW.minusSeconds(20),
@@ -230,7 +252,7 @@ class KeepPrivateModuleTest : StringSpec({
         var didSetToPrivate = false
         var didComment = false
 
-        val module = KeepPrivateModule("MEQS_KEEP_PRIVATE", "message")
+        val module = KeepPrivateModule("MEQS_KEEP_PRIVATE", "message", setOf(PRIVATE_SECURITY_LEVEL))
         val comment = mockComment(
             body = "MEQS_KEEP_PRIVATE",
             visibilityType = "group",
@@ -253,7 +275,7 @@ class KeepPrivateModuleTest : StringSpec({
         var didSetToPrivate = false
         var didComment = false
 
-        val module = KeepPrivateModule("MEQS_KEEP_PRIVATE", "message")
+        val module = KeepPrivateModule("MEQS_KEEP_PRIVATE", "message", setOf(PRIVATE_SECURITY_LEVEL))
         val comment = mockComment(
             body = "MEQS_KEEP_PRIVATE",
             created = RIGHT_NOW.minusSeconds(2),


### PR DESCRIPTION
## Purpose
Moving private bug reports to MCL would prompt Arisa to change their security level to an invalid one, making them inaccessible.

## Approach
Changed the function for determining whether a bug report is public by checking if the security level is a private security level for _any_ project, not just the current one.

## Future work
This is more of a bandaid solution, the actual problem likely lies somewhere deeper: Moving bug reports might actually cause some weird things to happen in regards to the data that Arisa receives.

So, further monitoring is necessary and potentially a better solution should be found at some point in the future - if we do not end up merging the MCL security level with the regular one anyway.

#### Checklist

- [x] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md)
  and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
