### PR TITLE
Compare securityLevel to null for checking if issue is private

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -390,9 +390,6 @@ arisa:
     keepPrivate:
       tag: MEQS_KEEP_PRIVATE
       message: panel-unmark-private-issue
-      privateLevels:
-        - '10318' # most projects
-        - '10502' # just MCL
 
     privateDuplicate:
       resolutions:

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
@@ -339,9 +339,6 @@ object Arisa : ConfigSpec() {
                 description = "The key of the message that is posted when this module succeeds."
             )
             val tag by optional<String?>(null)
-            val privateLevels by required<Set<String>>(
-                description = "All levels used to denote private security level"
-            )
         }
 
         object PrivateDuplicate : ModuleConfigSpec() {

--- a/src/main/kotlin/io/github/mojira/arisa/modules/LanguageModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/LanguageModule.kt
@@ -21,7 +21,7 @@ class LanguageModule(
     override fun invoke(issue: Issue, lastRun: Instant): Either<ModuleError, ModuleResponse> = with(issue) {
         Either.fx {
             assertAfter(created, lastRun).bind()
-            assertIsPublic(securityLevel, project.privateSecurity).bind()
+            assertNull(securityLevel).bind()
 
             val combinedText = combineSummaryAndDescription(summary ?: "", description ?: "")
             assertExceedLengthThreshold(combinedText).bind()
@@ -72,13 +72,6 @@ class LanguageModule(
         text.length < lengthThreshold -> OperationNotNeededModuleResponse.left()
         else -> Unit.right()
     }
-
-    private fun assertIsPublic(securityLevel: String?, privateLevel: String) =
-        if (securityLevel == privateLevel) {
-            OperationNotNeededModuleResponse.left()
-        } else {
-            Unit.right()
-        }
 
     private fun assertLanguageIsNotAllowed(allowedLanguages: List<String>, language: String) = when {
         allowedLanguages.any { language == it } -> OperationNotNeededModuleResponse.left()

--- a/src/main/kotlin/io/github/mojira/arisa/modules/PrivateDuplicateModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/PrivateDuplicateModule.kt
@@ -2,8 +2,6 @@ package io.github.mojira.arisa.modules
 
 import arrow.core.Either
 import arrow.core.extensions.fx
-import arrow.core.left
-import arrow.core.right
 import io.github.mojira.arisa.domain.Comment
 import io.github.mojira.arisa.domain.Issue
 import io.github.mojira.arisa.domain.Link

--- a/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
@@ -128,8 +128,7 @@ class InstantModuleRegistry(config: Config) : ModuleRegistry(config) {
             Arisa.Modules.KeepPrivate,
             KeepPrivateModule(
                 config[Arisa.Modules.KeepPrivate.tag],
-                config[Arisa.Modules.KeepPrivate.message],
-                config[Arisa.Modules.KeepPrivate.privateLevels]
+                config[Arisa.Modules.KeepPrivate.message]
             )
         )
 

--- a/src/test/kotlin/io/github/mojira/arisa/modules/PrivateDuplicateModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/PrivateDuplicateModuleTest.kt
@@ -11,13 +11,13 @@ import io.kotest.assertions.arrow.either.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
-private val duplicatesLink1 = mockLink(
+private val duplicatesLinkPrivate = mockLink(
     type = "Duplicate",
     issue = mockLinkedIssue(
         getFullIssue = { mockIssue(securityLevel = "private").right() }
     )
 )
-private val duplicatesLinkComment = mockLink(
+private val duplicatesLinkPrivateComment = mockLink(
     type = "Duplicate",
     issue = mockLinkedIssue(
         getFullIssue = {
@@ -34,10 +34,10 @@ private val duplicatesLinkComment = mockLink(
         }
     )
 )
-private val duplicatesLink2 = mockLink(
+private val duplicatesLinkPublic = mockLink(
     type = "Duplicate",
     issue = mockLinkedIssue(
-        getFullIssue = { mockIssue(securityLevel = "public").right() }
+        getFullIssue = { mockIssue(securityLevel = null).right() }
     )
 )
 private val relatesLink = mockLink(
@@ -51,7 +51,7 @@ class PrivateDuplicateModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse when keep private tag is null" {
         val module = PrivateDuplicateModule(null)
         val issue = mockIssue(
-            links = listOf(duplicatesLinkComment)
+            links = listOf(duplicatesLinkPrivateComment)
         )
 
         val result = module(issue, RIGHT_NOW)
@@ -63,7 +63,7 @@ class PrivateDuplicateModuleTest : StringSpec({
         val module = PrivateDuplicateModule("MEQS_KEEP_PRIVATE")
         val issue = mockIssue(
             securityLevel = "private",
-            links = listOf(duplicatesLink1)
+            links = listOf(duplicatesLinkPrivate)
         )
 
         val result = module(issue, RIGHT_NOW)
@@ -77,7 +77,7 @@ class PrivateDuplicateModuleTest : StringSpec({
 
         val module = PrivateDuplicateModule("MEQS_KEEP_PRIVATE")
         val issue = mockIssue(
-            links = listOf(duplicatesLinkComment),
+            links = listOf(duplicatesLinkPrivateComment),
             setPrivate = { didSetToPrivate = true; Unit.right() },
             addRawRestrictedComment = { _, _ -> didComment = true; Unit.right() }
         )
@@ -95,8 +95,8 @@ class PrivateDuplicateModuleTest : StringSpec({
 
         val module = PrivateDuplicateModule("MEQS_KEEP_PRIVATE")
         val issue = mockIssue(
-            securityLevel = "not private",
-            links = listOf(duplicatesLinkComment),
+            securityLevel = null,
+            links = listOf(duplicatesLinkPrivateComment),
             setPrivate = { didSetToPrivate = true; Unit.right() },
             addRawRestrictedComment = { _, _ -> didComment = true; Unit.right() }
         )
@@ -114,7 +114,7 @@ class PrivateDuplicateModuleTest : StringSpec({
 
         val module = PrivateDuplicateModule("MEQS_KEEP_PRIVATE")
         val issue = mockIssue(
-            links = listOf(duplicatesLink1),
+            links = listOf(duplicatesLinkPrivate),
             setPrivate = { didSetToPrivate = true; Unit.right() },
             addRawRestrictedComment = { _, _ -> didComment = true; Unit.right() }
         )
@@ -140,7 +140,7 @@ class PrivateDuplicateModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse when parent is not private" {
         val module = PrivateDuplicateModule("MEQS_KEEP_PRIVATE")
         val issue = mockIssue(
-            links = listOf(duplicatesLink2)
+            links = listOf(duplicatesLinkPublic)
         )
 
         val result = module(issue, RIGHT_NOW)


### PR DESCRIPTION
## Purpose
Some more issues with MCL security level happened

## Approach
Always check for `securityLevel == null` or not. We don't have a dedicated "Public" security level anymore, if a bug report is public, its level is null.

## Future work
N/A

#### Checklist

- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md)
  and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
