### PR TITLE
Fix special security level retrieval

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -36,7 +36,7 @@ arisa:
   privateSecurityLevel:
     default: '10318'
     special:
-      MCL: '10502'
+      mcl: '10502'
 
   modules:
     affectedVersionMessage:

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
@@ -58,7 +58,7 @@ fun getCreationDate(issue: JiraIssue, id: String, default: Instant) = issue.chan
     ?.toInstant() ?: default
 
 fun JiraProject.getSecurityLevelId(config: Config) =
-    config[Arisa.PrivateSecurityLevel.special][key] ?: config[Arisa.PrivateSecurityLevel.default]
+    config[Arisa.PrivateSecurityLevel.special][key.lowercase()] ?: config[Arisa.PrivateSecurityLevel.default]
 
 fun JiraVersion.toDomain() = Version(
     id,


### PR DESCRIPTION
## Purpose
Arisa thought that MCL had the security level 10318, while it is actually 10502, as is specified in the config.

## Approach
Apparently the config converts every key to lowercase, so convert the key to lowercase before retreiving it from the config. This might have been caused by some update to the konf library that we missed, not sure.

## Future work
Change MCL on the bug tracker to use same security level as all the other projects.

#### Checklist

- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md)
  and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
