### PR TITLE
Update GitHub actions & enable Dependabot for them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -12,5 +12,5 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1.1.0
+      - uses: actions/checkout@v4
+      - uses: gradle/actions/wrapper-validation@v3

--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17
-      - name: Setup and build with Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: build
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+      - name: Build with Gradle
+        run: ./gradlew build

--- a/.github/workflows/push-build-deploy.yml
+++ b/.github/workflows/push-build-deploy.yml
@@ -12,16 +12,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: temurin
-      - name: Setup and build with Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: clean installDist
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+      - name: Build with Gradle
+        run: ./gradlew clean installDist
       - name: Upload new libraries
         uses: urielsalis/rsync-deploy@master
         env:


### PR DESCRIPTION
## Purpose
Updates GitHub actions used by the workflows, and configures Dependabot to also update GitHub actions.

The previous workflow executions were already causing warnings due to Node.js 16 actions being deprecated.

## Approach
For the Gradle actions I changed the repository because https://github.com/gradle/actions is now the main repository for all Gradle-related actions. See also the README of https://github.com/gradle/wrapper-validation-action and https://github.com/gradle/gradle-build-action.

Note that I did not (and cannot) test the changes in `push-build-deploy.yml`, but I think they should be equivalent to the previous setup.