### PR TITLE
Fix incorrect creation of `CommandSyntaxException` with cause

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/ListUserActivityCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/ListUserActivityCommand.kt
@@ -28,7 +28,7 @@ class ListUserActivityCommand(
             is Either.Left ->
                 throw CommandExceptions.CANNOT_QUERY_USER_ACTIVITY
                     .create(sanitizedUserName, jql)
-                    .initCause(either.a)
+                    .apply { addSuppressed(either.a) }
 
             is Either.Right -> either.b
         }

--- a/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveContentCommand.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/commands/RemoveContentCommand.kt
@@ -76,7 +76,7 @@ class RemoveContentCommand(
             is Either.Left ->
                 throw CommandExceptions.CANNOT_QUERY_USER_ACTIVITY
                     .create(sanitizedUserName, jql)
-                    .initCause(either.a)
+                    .apply { addSuppressed(either.a) }
 
             is Either.Right -> either.b
         }


### PR DESCRIPTION
## Purpose
Fixes #786
At least the `IllegalStateException` thrown by `initCause`; the reason why the activity search failed in the first place is a different issue (and I don't know the reason for that at the moment)

## Approach
Use `Throwable#addSuppressed` instead of `Throwable#initCause`

#### Checklist

- [x] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md)
  and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
