### PR TITLE
Make MCL use the same security level as the rest of the projects

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -35,8 +35,6 @@ arisa:
 
   privateSecurityLevel:
     default: '10318'
-    special:
-      mcl: '10502'
 
   modules:
     affectedVersionMessage:

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
@@ -45,10 +45,6 @@ object Arisa : ConfigSpec() {
         val default by required<String>(
             description = "The default security id used by projects not defined in special."
         )
-        val special by required<Map<String, String>>(
-            description = "Some projects define their own security level. These projects need to be defined here with" +
-                " their own ID.. Default is all projects use the default ID"
-        )
     }
 
     object Debug : ConfigSpec() {

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
@@ -57,8 +57,7 @@ fun getCreationDate(issue: JiraIssue, id: String, default: Instant) = issue.chan
     ?.created
     ?.toInstant() ?: default
 
-fun JiraProject.getSecurityLevelId(config: Config) =
-    config[Arisa.PrivateSecurityLevel.special][key.lowercase()] ?: config[Arisa.PrivateSecurityLevel.default]
+fun JiraProject.getSecurityLevelId(config: Config) = config[Arisa.PrivateSecurityLevel.default]
 
 fun JiraVersion.toDomain() = Version(
     id,


### PR DESCRIPTION
DO NOT MERGE
## Purpose
Make MCL use the same security level as the rest of the projects
## Approach

## Future work

#### Checklist

- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md)
  and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
