### PR TITLE
fix: use yyyy-mm-dd serializer for version dates

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/apiclient/models/Version.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/apiclient/models/Version.kt
@@ -1,9 +1,9 @@
 package io.github.mojira.arisa.apiclient.models
 
-import io.github.mojira.arisa.apiclient.serializers.OffsetDateTimeSerializer
+import io.github.mojira.arisa.apiclient.serializers.DateSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import java.time.OffsetDateTime
+import java.time.LocalDate
 
 @Serializable
 data class Version(
@@ -13,6 +13,8 @@ data class Version(
     val isArchived: Boolean,
     @SerialName("released")
     val isReleased: Boolean,
-    @Serializable(with = OffsetDateTimeSerializer::class)
-    val releaseDate: OffsetDateTime? = null
+    @Serializable(with = DateSerializer::class)
+    val startDate: LocalDate? = null,
+    @Serializable(with = DateSerializer::class)
+    val releaseDate: LocalDate? = null
 )

--- a/src/main/kotlin/io/github/mojira/arisa/apiclient/serializers/DateSerializer.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/apiclient/serializers/DateSerializer.kt
@@ -1,0 +1,30 @@
+package io.github.mojira.arisa.apiclient.serializers
+
+import java.time.format.DateTimeFormatter
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.time.LocalDate
+
+/**
+ * Serializer for [LocalDate].
+ *
+ * Example of supported format: "2025-02-13"
+ *
+ * @throws DateTimeParseException when the input string cannot be parsed
+ */
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+object DateSerializer : KSerializer<LocalDate> {
+    override val descriptor = PrimitiveSerialDescriptor("LocalDate", PrimitiveKind.STRING)
+    private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+
+    override fun serialize(encoder: Encoder, value: LocalDate) {
+        encoder.encodeString(formatter.format(value))
+    }
+
+    override fun deserialize(decoder: Decoder): LocalDate {
+        return LocalDate.parse(decoder.decodeString(), formatter)
+    }
+}

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
@@ -30,6 +30,8 @@ import io.github.mojira.arisa.apiclient.JiraClient as MojiraClient
 import net.rcarz.jiraclient.JiraException
 import java.text.SimpleDateFormat
 import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
 import io.github.mojira.arisa.apiclient.models.AttachmentBean as MojiraAttachment
 import io.github.mojira.arisa.apiclient.models.Changelog as MojiraChangeLogEntry
 import io.github.mojira.arisa.apiclient.models.ChangeDetails as MojiraChangeLogItem
@@ -60,12 +62,16 @@ fun getCreationDate(issue: MojiraIssue, id: String, default: Instant) = (issue.c
 
 fun MojiraProject.getSecurityLevelId(config: Config) = config[Arisa.PrivateSecurityLevel.default]
 
+fun localDateToInstant(date: LocalDate): Instant {
+    return date.atStartOfDay(ZoneId.systemDefault()).toInstant()
+}
+
 fun MojiraVersion.toDomain() = Version(
     id,
     name,
     isReleased,
     isArchived,
-    releaseDate?.toInstant()
+    releaseDate?.let { localDateToInstant(it) }
 )
 
 fun MojiraIssue.getUpdateContext(jiraClient: MojiraClient): Lazy<IssueUpdateContext> =

--- a/src/test/kotlin/io/github/mojira/arisa/apiclient/models/ProjectTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/apiclient/models/ProjectTest.kt
@@ -1,0 +1,22 @@
+package io.github.mojira.arisa.apiclient.models
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeTypeOf
+import java.time.LocalDate
+
+class ProjectTest : StringSpec({
+    "it should deserialize project with versions" {
+        val json = loadJsonFile("project-with-versions.json")
+        val project = JSON.decodeFromString<Project>(json)
+
+        project shouldNotBe null
+        project.versions shouldHaveSize 3
+        project.versions.shouldBeTypeOf<ArrayList<Version>>()
+        val versionWithDates = project.versions.first { it.startDate != null }
+        versionWithDates.startDate shouldBe LocalDate.of(2025, 2, 25)
+        versionWithDates.releaseDate shouldBe LocalDate.of(2025, 3, 2)
+    }
+})

--- a/src/test/resources/responses/project-with-versions.json
+++ b/src/test/resources/responses/project-with-versions.json
@@ -1,0 +1,120 @@
+{
+  "expand": "description,lead,issueTypes,url,projectKeys,permissions,insight",
+  "self": "https://jira-connection.atlassian.net/rest/api/2/project/10034",
+  "id": "10034",
+  "key": "ATP",
+  "description": "",
+  "lead": {
+    "self": "https://jira-connection.atlassian.net/rest/api/2/user?accountId=712020:33043866-64fe-4184-b28e-32ae8e3bd15f",
+    "accountId": "712020:33043866-64fe-4184-b28e-32ae8e3bd15f",
+    "avatarUrls": {
+      "48x48": "https://secure.gravatar.com/avatar/69c44aeb6021261d0ae89f0b12370e9e?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJK-0.png",
+      "24x24": "https://secure.gravatar.com/avatar/69c44aeb6021261d0ae89f0b12370e9e?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJK-0.png",
+      "16x16": "https://secure.gravatar.com/avatar/69c44aeb6021261d0ae89f0b12370e9e?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJK-0.png",
+      "32x32": "https://secure.gravatar.com/avatar/69c44aeb6021261d0ae89f0b12370e9e?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJK-0.png"
+    },
+    "displayName": "Jakub Kazimierczak",
+    "active": true
+  },
+  "components": [],
+  "issueTypes": [
+    {
+      "self": "https://jira-connection.atlassian.net/rest/api/2/issuetype/10038",
+      "id": "10038",
+      "description": "A small, distinct piece of work.",
+      "iconUrl": "https://jira-connection.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium",
+      "name": "Task",
+      "subtask": false,
+      "avatarId": 10318,
+      "hierarchyLevel": 0
+    },
+    {
+      "self": "https://jira-connection.atlassian.net/rest/api/2/issuetype/10039",
+      "id": "10039",
+      "description": "A small piece of work that's part of a larger task.",
+      "iconUrl": "https://jira-connection.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium",
+      "name": "Sub-task",
+      "subtask": true,
+      "avatarId": 10316,
+      "hierarchyLevel": -1
+    },
+    {
+      "self": "https://jira-connection.atlassian.net/rest/api/2/issuetype/10004",
+      "id": "10004",
+      "description": "Stories track functionality or features expressed as user goals.",
+      "iconUrl": "https://jira-connection.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10300?size=medium",
+      "name": "Story",
+      "subtask": false,
+      "avatarId": 10300,
+      "hierarchyLevel": 0
+    },
+    {
+      "self": "https://jira-connection.atlassian.net/rest/api/2/issuetype/10040",
+      "id": "10040",
+      "description": "A problem or error.",
+      "iconUrl": "https://jira-connection.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium",
+      "name": "Bug",
+      "subtask": false,
+      "avatarId": 10303,
+      "hierarchyLevel": 0
+    },
+    {
+      "self": "https://jira-connection.atlassian.net/rest/api/2/issuetype/10000",
+      "id": "10000",
+      "description": "A big user story that needs to be broken down. Created by Jira Software - do not edit or delete.",
+      "iconUrl": "https://jira-connection.atlassian.net/images/icons/issuetypes/epic.svg",
+      "name": "Epic",
+      "subtask": false,
+      "hierarchyLevel": 1
+    }
+  ],
+  "assigneeType": "UNASSIGNED",
+  "versions": [
+    {
+      "self": "https://jira-connection.atlassian.net/rest/api/2/version/10000",
+      "id": "10000",
+      "name": "v0.1.0",
+      "archived": false,
+      "released": false,
+      "projectId": 10034
+    },
+    {
+      "self": "https://jira-connection.atlassian.net/rest/api/2/version/10001",
+      "id": "10001",
+      "name": "v0.2.0",
+      "archived": false,
+      "released": false,
+      "projectId": 10034
+    },
+    {
+      "self": "https://jira-connection.atlassian.net/rest/api/2/version/10033",
+      "id": "10033",
+      "name": "v0.3.0",
+      "archived": false,
+      "released": false,
+      "startDate": "2025-02-25",
+      "releaseDate": "2025-03-02",
+      "overdue": false,
+      "userStartDate": "25/Feb/25",
+      "userReleaseDate": "02/Mar/25",
+      "projectId": 10034
+    }
+  ],
+  "name": "Arisa Test Project",
+  "roles": {
+    "atlassian-addons-project-access": "https://jira-connection.atlassian.net/rest/api/2/project/10034/role/10003",
+    "Administrators": "https://jira-connection.atlassian.net/rest/api/2/project/10034/role/10002",
+    "staff": "https://jira-connection.atlassian.net/rest/api/2/project/10034/role/10041"
+  },
+  "avatarUrls": {
+    "48x48": "https://jira-connection.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407",
+    "24x24": "https://jira-connection.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small",
+    "16x16": "https://jira-connection.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall",
+    "32x32": "https://jira-connection.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"
+  },
+  "projectTypeKey": "software",
+  "simplified": false,
+  "style": "classic",
+  "isPrivate": false,
+  "properties": {}
+}


### PR DESCRIPTION
## Purpose

Fixes (de)serialization bug where date format used on `Version` model was set to ISO-8601 instead of YYYY-MM-DD.

## Approach

Add new serializer for affected fields. Test deserialization against example response.

## Future work

#### Checklist

- [x] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md)
  and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
