### PR TITLE
Copy config on deploy

### DIFF
--- a/.github/workflows/push-build-deploy.yml
+++ b/.github/workflows/push-build-deploy.yml
@@ -50,4 +50,5 @@ jobs:
           /usr/bin/screen -ls | /bin/egrep 'Detached|Attached' | /usr/bin/cut -d. -f1 | /usr/bin/awk '{print $1}' | /usr/bin/xargs /bin/kill
           sleep 1
           cd arisa-kt
+          mv -f /home/arisakt/arisa-kt/config.yml /home/arisakt/arisa-kt/config/config.yml
           /usr/bin/screen -d -m bash -c '/home/arisakt/arisa-kt/bin/arisa-kt; exec sh'


### PR DESCRIPTION
Copy config when deploying, as rsync is copying it directly to the root directory instead of the config folder

## Purpose

## Approach

## Future work

#### Checklist

- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md)
  and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
