### PR TITLE
fix: privacy module requests

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -172,6 +172,7 @@ arisa:
 
     privacy:
       message: panel-mark-private
+      commentMessage: panel-mark-private-comment
       commentNote: |-
 
         ----

--- a/src/main/kotlin/io/github/mojira/arisa/apiclient/JiraClient.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/apiclient/JiraClient.kt
@@ -17,6 +17,7 @@ import io.github.mojira.arisa.apiclient.models.IssueLink
 import io.github.mojira.arisa.apiclient.models.User
 import io.github.mojira.arisa.apiclient.models.Visibility
 import io.github.mojira.arisa.apiclient.requestModels.*
+import io.github.mojira.arisa.log
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -151,6 +152,7 @@ private inline fun <reified T> Call<T>.executeOrThrow(): T {
 
     if (!response.isSuccessful) {
         if (response.code() in 400..499) {
+            response.errorBody()?.let { log.error(it.string()) }
             throw ClientErrorException(
                 response.code(),
                 "Request failed - [${response.code()}] ${originalRequest.method} ${originalRequest.url}",

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
@@ -164,6 +164,10 @@ object Arisa : ConfigSpec() {
             val message by required<String>(
                 description = "The key of the message that is posted when this module succeeds."
             )
+            val commentMessage by required<String>(
+                description = "The key of the message that is posted when this module detects sensitive data within" +
+                    "the comment."
+            )
             val commentNote by optional(
                 "",
                 description = "The text which will be appended at the comments that are restricted by this module."

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
@@ -437,9 +437,8 @@ fun restrictCommentToGroup(
                     val payload = UpdateCommentBody(
                         body,
                         visibility = Visibility(
-                            identifier = group,
-                            type = Visibility.Type.Group.value,
-                            value = group
+                            value = group,
+                            type = Visibility.Type.Group.value
                         )
                     )
                     context.value.jiraClient.updateComment(

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
@@ -232,7 +232,7 @@ fun MojiraComment.toDomain(
         getUpdateAuthorGroups = { if (updateAuthor == null) emptyList() else getGroups(jiraClient, updateAuthor.accountId).fold({ null }, { it }) },
         created = created!!.toInstant(),
         updated = updated!!.toInstant(),
-        visibilityType = visibility?.type.toString(),
+        visibilityType = visibility?.type,
         visibilityValue = visibility?.value,
         restrict = ::restrictCommentToGroup.partially1(context).partially1(this).partially1("staff"),
         update = ::updateCommentBody.partially1(context).partially1(this),

--- a/src/main/kotlin/io/github/mojira/arisa/modules/privacy/PrivacyModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/privacy/PrivacyModule.kt
@@ -24,6 +24,7 @@ private val log = LoggerFactory.getLogger("PrivacyModule")
 
 class PrivacyModule(
     private val message: String,
+    private val commentMessage: String,
     private val commentNote: String,
     private val allowedEmailRegexes: List<Regex>,
     private val sensitiveTextRegexes: List<Regex>,
@@ -58,6 +59,9 @@ class PrivacyModule(
             }
 
             restrictCommentActions.forEach { it.invoke() }
+            if (restrictCommentActions.isNotEmpty()) {
+                addComment(CommentOptions(commentMessage))
+            }
         }
     }
 

--- a/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
@@ -28,6 +28,7 @@ class InstantModuleRegistry(config: Config) : ModuleRegistry<CloudIssue>(config)
             Arisa.Modules.Privacy,
             PrivacyModule(
                 config[Arisa.Modules.Privacy.message],
+                config[Arisa.Modules.Privacy.commentMessage],
                 config[Arisa.Modules.Privacy.commentNote],
                 config[Arisa.Modules.Privacy.allowedEmailRegexes].map(String::toRegex),
                 config[Arisa.Modules.Privacy.sensitiveTextRegexes].map(String::toRegex),

--- a/src/test/kotlin/io/github/mojira/arisa/modules/privacy/PrivacyModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/privacy/PrivacyModuleTest.kt
@@ -332,7 +332,7 @@ class PrivacyModuleTest : FunSpec({
                                 restrict = {
                                     hasRestrictedComment = true
                                     it shouldBe "${testData.sensitiveText}$COMMENT_NOTE"
-                                },
+                                }
                             )
                         ),
                         setPrivate = { hasSetPrivate = true },


### PR DESCRIPTION
## Purpose

- Logs error responses when client requests receives 4xx response,
- Adds config and logic in PrivacyModule to warn user when he posts comment with sensitive data,
- Fixes mapper to not stringify `null`,
- Fixes `restrictCommentToGroup` to not include mutually exclusive options.

![image](https://github.com/user-attachments/assets/1312e038-bb6e-4956-937a-4eef393725a7)


## Approach

## Future work

Merge the PR in [helper-messages](https://github.com/mojira/helper-messages/pull/245) first, so new message panel is available.

#### Checklist

- [x] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md)
  and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
