### PR TITLE
fix: enable reopen awaiting module

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/apiclient/JiraClient.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/apiclient/JiraClient.kt
@@ -2,41 +2,48 @@
 
 package io.github.mojira.arisa.apiclient
 
-import io.github.mojira.arisa.apiclient.exceptions.JiraClientException
 import io.github.mojira.arisa.apiclient.exceptions.ClientErrorException
+import io.github.mojira.arisa.apiclient.exceptions.JiraClientException
 import io.github.mojira.arisa.apiclient.interceptors.BasicAuthInterceptor
 import io.github.mojira.arisa.apiclient.interceptors.LoggingInterceptor
-import io.github.mojira.arisa.apiclient.models.IssueBean
-import io.github.mojira.arisa.apiclient.models.Project
-import io.github.mojira.arisa.apiclient.models.SearchResults
 import io.github.mojira.arisa.apiclient.models.AttachmentBean
 import io.github.mojira.arisa.apiclient.models.BodyType
 import io.github.mojira.arisa.apiclient.models.Comment
 import io.github.mojira.arisa.apiclient.models.GroupName
+import io.github.mojira.arisa.apiclient.models.IssueBean
 import io.github.mojira.arisa.apiclient.models.IssueLink
+import io.github.mojira.arisa.apiclient.models.Project
+import io.github.mojira.arisa.apiclient.models.SearchResults
+import io.github.mojira.arisa.apiclient.models.Transitions
 import io.github.mojira.arisa.apiclient.models.User
 import io.github.mojira.arisa.apiclient.models.Visibility
-import io.github.mojira.arisa.apiclient.requestModels.*
+import io.github.mojira.arisa.apiclient.requestModels.AddCommentBody
+import io.github.mojira.arisa.apiclient.requestModels.CreateIssueLinkBody
+import io.github.mojira.arisa.apiclient.requestModels.EditIssueBody
+import io.github.mojira.arisa.apiclient.requestModels.JiraSearchRequest
+import io.github.mojira.arisa.apiclient.requestModels.TransitionIssueBody
+import io.github.mojira.arisa.apiclient.requestModels.UpdateCommentBody
+import io.github.mojira.arisa.apiclient.requestModels.UpdateCommentQueryParams
 import io.github.mojira.arisa.log
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.ResponseBody
-import okhttp3.MultipartBody
 import retrofit2.Call
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import retrofit2.http.Body
-import retrofit2.http.GET
-import retrofit2.http.POST
-import retrofit2.http.Path
-import retrofit2.http.Query
-import retrofit2.http.Part
 import retrofit2.http.DELETE
+import retrofit2.http.GET
 import retrofit2.http.Headers
 import retrofit2.http.Multipart
+import retrofit2.http.POST
 import retrofit2.http.PUT
+import retrofit2.http.Part
+import retrofit2.http.Path
+import retrofit2.http.Query
 import retrofit2.http.QueryMap
 import java.io.File
 import java.io.InputStream
@@ -134,7 +141,7 @@ interface JiraApi {
     @GET("issue/{issueIdOrKey}/transitions")
     fun getTransition(
         @Path("issueIdOrKey") issueIdOrKey: String,
-    ): Call<Unit>
+    ): Call<Transitions>
 
     @POST("issue/{issueIdOrKey}/transitions")
     fun performTransition(
@@ -317,8 +324,8 @@ class JiraClient(
         jiraApi.deleteIssueLink(linkId).executeOrThrow()
     }
 
-    fun getTransition(issueIdOrKey: String) {
-        jiraApi.deleteIssueLink(issueIdOrKey).executeOrThrow()
+    fun getTransitions(issueIdOrKey: String): Transitions {
+        return jiraApi.getTransition(issueIdOrKey).executeOrThrow()
     }
 
     fun performTransition(issueIdOrKey: String, body: TransitionIssueBody) {

--- a/src/main/kotlin/io/github/mojira/arisa/apiclient/models/IssueFields.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/apiclient/models/IssueFields.kt
@@ -35,7 +35,8 @@ data class IssueFields(
     val versions: List<JsonElement> = emptyList(),
     val timeoriginalestimate: JsonElement? = null,
     val timespent: Long? = null,
-    val updated: String? = null,
+    @Serializable(with = OffsetDateTimeSerializer::class)
+    val updated: OffsetDateTime? = null,
     val workratio: Int? = null,
     @Transient
     private val additionalProperties: Map<String, JsonElement> = emptyMap()

--- a/src/main/kotlin/io/github/mojira/arisa/apiclient/models/Transitions.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/apiclient/models/Transitions.kt
@@ -1,0 +1,15 @@
+package io.github.mojira.arisa.apiclient.models
+
+import kotlinx.serialization.Serializable
+
+/**
+ * List of issue transitions.
+ *
+ * @param expand Expand options that include additional transitions details in the response.
+ * @param transitions List of issue transitions.
+ */
+@Serializable
+data class Transitions(
+    val expand: String? = null,
+    val transitions: List<IssueTransition>? = null
+)

--- a/src/main/kotlin/io/github/mojira/arisa/domain/User.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/domain/User.kt
@@ -6,6 +6,5 @@ data class User(
     val name: String?,
     val displayName: String?,
     val getGroups: () -> List<String>?,
-    val isNewUser: () -> Boolean,
     val isBotUser: () -> Boolean
 )

--- a/src/main/kotlin/io/github/mojira/arisa/domain/cloud/CloudIssue.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/domain/cloud/CloudIssue.kt
@@ -5,6 +5,7 @@ import io.github.mojira.arisa.domain.ChangeLogItem
 import io.github.mojira.arisa.domain.Comment
 import io.github.mojira.arisa.domain.CommentOptions
 import io.github.mojira.arisa.domain.Project
+import io.github.mojira.arisa.domain.User
 import java.io.File
 import java.time.Instant
 
@@ -15,10 +16,10 @@ data class CloudIssue(
     val description: String?,
     val environment: String?,
     val securityLevel: String?,
-//    val reporter: User?,
+    val reporter: User?,
     val resolution: String?,
     val created: Instant,
-//    val updated: Instant,
+    val updated: Instant,
 //    val resolved: Instant?,
 //    val chk: String?,
 //    val confirmationStatus: String?,
@@ -35,7 +36,7 @@ data class CloudIssue(
     val comments: List<Comment>,
     val links: List<CloudLink>,
     val changeLog: List<ChangeLogItem>,
-//    val reopen: () -> Unit,
+    val reopen: () -> Unit,
 //    val resolveAsAwaitingResponse: () -> Unit,
 //    val resolveAsInvalid: () -> Unit,
 //    val resolveAsDuplicate: () -> Unit,

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
@@ -23,10 +23,7 @@ import io.github.mojira.arisa.infrastructure.ProjectCache
 import io.github.mojira.arisa.apiclient.builders.FluentObjectBuilder
 import io.github.mojira.arisa.apiclient.models.Changelog
 import io.github.mojira.arisa.infrastructure.config.Arisa
-import io.github.mojira.arisa.infrastructure.escapeIssueFunction
-import net.rcarz.jiraclient.JiraClient
 import io.github.mojira.arisa.apiclient.JiraClient as MojiraClient
-import net.rcarz.jiraclient.JiraException
 import java.text.SimpleDateFormat
 import java.time.Instant
 import java.time.LocalDate
@@ -244,7 +241,7 @@ fun MojiraUserDetails.toDomain(jiraClient: MojiraClient, config: Config) = User(
     accountId = accountId,
     name = displayName,
     displayName = displayName,
-    getGroups = ::getUserGroups.partially1(jiraClient).partially1(accountId),
+    getGroups = ::getUserGroups.partially1(jiraClient).partially1(accountId)
 ) {
     accountId.equals(config[Arisa.Credentials.accountId], ignoreCase = true)
 }
@@ -253,7 +250,7 @@ fun MojiraUser.toDomain(jiraClient: MojiraClient, config: Config) = User(
     accountId = accountId,
     name = displayName,
     displayName = displayName,
-    getGroups = ::getUserGroups.partially1(jiraClient).partially1(accountId),
+    getGroups = ::getUserGroups.partially1(jiraClient).partially1(accountId)
 ) {
     accountId.equals(config[Arisa.Credentials.accountId], ignoreCase = true)
 }

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
@@ -8,7 +8,6 @@ import arrow.core.right
 import arrow.syntax.function.partially1
 import com.uchuhimo.konf.Config
 import io.github.mojira.arisa.domain.Attachment
-// import io.github.mojira.arisa.domain.Attachment
 import io.github.mojira.arisa.domain.ChangeLogItem
 import io.github.mojira.arisa.domain.Comment
 import io.github.mojira.arisa.domain.IssueUpdateContext
@@ -39,6 +38,7 @@ import io.github.mojira.arisa.apiclient.models.Comment as MojiraComment
 import io.github.mojira.arisa.apiclient.models.IssueBean as MojiraIssue
 import io.github.mojira.arisa.apiclient.models.IssueLink as MojiraIssueLink
 import io.github.mojira.arisa.apiclient.models.Project as MojiraProject
+import io.github.mojira.arisa.apiclient.models.User as MojiraUser
 import io.github.mojira.arisa.apiclient.models.UserDetails as MojiraUserDetails
 import io.github.mojira.arisa.apiclient.models.Version as MojiraVersion
 
@@ -100,10 +100,10 @@ fun MojiraIssue.toDomain(
         description = fields.description,
         environment = fields.environment,
         securityLevel = fields.security?.id,
-//        reporter?.toDomain(jiraClient, config),
+        reporter = fields.reporter?.toDomain(jiraClient, config),
         resolution = fields.resolution?.name,
         created = fields.created?.toInstant() ?: Instant.now(),
-//        updatedDate.toInstant(),
+        updated = fields.updated?.toInstant() ?: Instant.now(),
 //        resolutionDate?.toInstant(),
 //        getCHK(config),
 //        getConfirmation(config),
@@ -120,7 +120,7 @@ fun MojiraIssue.toDomain(
         comments = mapComments(jiraClient, config),
         links = mapLinks(jiraClient, config),
         changeLog = getChangeLogEntries(jiraClient, config),
-//        ::reopen.partially1(context),
+        reopen = ::reopen.partially1(context),
 //        ::resolveAs.partially1(context).partially1("Awaiting Response"),
 //        ::resolveAs.partially1(context).partially1("Invalid"),
 //        ::resolveAs.partially1(context).partially1("Duplicate"),
@@ -241,6 +241,16 @@ fun MojiraComment.toDomain(
 }
 
 fun MojiraUserDetails.toDomain(jiraClient: MojiraClient, config: Config) = User(
+    accountId = accountId,
+    name = displayName,
+    displayName = displayName,
+    getGroups = ::getUserGroups.partially1(jiraClient).partially1(accountId),
+    isNewUser = { false }
+) {
+    accountId.equals(config[Arisa.Credentials.accountId], ignoreCase = true)
+}
+
+fun MojiraUser.toDomain(jiraClient: MojiraClient, config: Config) = User(
     accountId = accountId,
     name = displayName,
     displayName = displayName,

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Mappers.kt
@@ -245,7 +245,6 @@ fun MojiraUserDetails.toDomain(jiraClient: MojiraClient, config: Config) = User(
     name = displayName,
     displayName = displayName,
     getGroups = ::getUserGroups.partially1(jiraClient).partially1(accountId),
-    isNewUser = { false }
 ) {
     accountId.equals(config[Arisa.Credentials.accountId], ignoreCase = true)
 }
@@ -255,7 +254,6 @@ fun MojiraUser.toDomain(jiraClient: MojiraClient, config: Config) = User(
     name = displayName,
     displayName = displayName,
     getGroups = ::getUserGroups.partially1(jiraClient).partially1(accountId),
-    isNewUser = { false }
 ) {
     accountId.equals(config[Arisa.Credentials.accountId], ignoreCase = true)
 }
@@ -264,28 +262,6 @@ private fun getUserGroups(jiraClient: MojiraClient, accountId: String) = getGrou
     jiraClient,
     accountId
 ).fold({ null }, { it })
-
-private fun isNewUser(jiraClient: JiraClient, username: String): Boolean {
-    val commentJql = "issueFunction IN commented(${escapeIssueFunction(username) { "by $it before -24h" }})"
-
-    val oldCommentsExist = try {
-        jiraClient.countIssues(commentJql) > 0
-    } catch (_: JiraException) {
-        false
-    }
-
-    if (oldCommentsExist) return false
-
-    val reportJql = """project != TRASH AND reporter = '${username.replace("'", "\\'")}' AND created < -24h"""
-
-    val oldReportsExist = try {
-        jiraClient.countIssues(reportJql) > 0
-    } catch (_: JiraException) {
-        true
-    }
-
-    return !oldReportsExist
-}
 
 @Suppress("LongParameterList")
 fun MojiraIssue.toLinkedIssue(

--- a/src/main/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModule.kt
@@ -27,7 +27,7 @@ class ReopenAwaitingModule(
             assertCreationIsNotRecent(updated.toEpochMilli(), created.toEpochMilli()).bind()
 
             val resolveTime = changeLog.last(::isAwaitingResolve).created
-            val validComments = getValidComments(comments, reporter, resolveTime, lastRun)
+            val validComments = getValidComments(comments, resolveTime, lastRun)
             val validChangeLog = getValidChangeLog(changeLog, reporter, resolveTime)
 
             assertAny(
@@ -82,12 +82,11 @@ class ReopenAwaitingModule(
 
     private fun getValidComments(
         comments: List<Comment>,
-        reporter: User?,
         resolveTime: Instant,
         lastRun: Instant
     ): List<Comment> = comments
         .filter { it.created.isAfter(resolveTime) && it.created.isAfter(lastRun) }
-        .filter { it.author != null && (!it.author.isNewUser() || it.author.accountId == reporter?.accountId) }
+        .filter { it.author != null }
         .filter {
             val roles = it.getAuthorGroups()
             roles == null || roles.intersect(blacklistedRoles).isEmpty()

--- a/src/main/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModule.kt
@@ -39,7 +39,7 @@ class ReopenAwaitingModule(
             if (shouldReopen) {
                 reopen()
             } else {
-                assertNotEquals(changeLog.maxByOrNull { it.created }?.author?.name, "arisabot")
+                assertNotEquals(changeLog.maxByOrNull { it.created }?.author?.isBotUser?.invoke(), true)
                 if (comments.none { isKeepARMessage(it) }) {
                     addRawBotComment(message)
                 }
@@ -78,7 +78,7 @@ class ReopenAwaitingModule(
         (comment.body?.contains(keepARTag) ?: false)
 
     private fun isKeepARMessage(comment: Comment) =
-        comment.author?.name == "arisabot" && comment.body?.contains(message) ?: false
+        comment.author?.isBotUser?.invoke() == true && comment.body?.contains(message) ?: false
 
     private fun getValidComments(
         comments: List<Comment>,

--- a/src/main/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModule.kt
@@ -6,8 +6,8 @@ import arrow.core.left
 import arrow.core.right
 import io.github.mojira.arisa.domain.ChangeLogItem
 import io.github.mojira.arisa.domain.Comment
-import io.github.mojira.arisa.domain.Issue
 import io.github.mojira.arisa.domain.User
+import io.github.mojira.arisa.domain.cloud.CloudIssue
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
@@ -20,8 +20,8 @@ class ReopenAwaitingModule(
     private val keepARTag: String,
     private val onlyOPTag: String,
     private val message: String
-) : Module {
-    override fun invoke(issue: Issue, lastRun: Instant): Either<ModuleError, ModuleResponse> = with(issue) {
+) : CloudModule {
+    override fun invoke(issue: CloudIssue, lastRun: Instant): Either<ModuleError, ModuleResponse> = with(issue) {
         Either.fx {
             assertEquals(resolution, "Awaiting Response").bind()
             assertCreationIsNotRecent(updated.toEpochMilli(), created.toEpochMilli()).bind()

--- a/src/main/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModule.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModule.kt
@@ -66,7 +66,7 @@ class ReopenAwaitingModule(
             // regular users can reopen and have commented OR
             (!onlyOp && isSoftAR) ||
             // reporter has commented
-            validComments.any { it.author?.name == reporter?.name }
+            validComments.any { it.author?.accountId == reporter?.accountId }
     }
 
     private fun isOPTag(comment: Comment) = comment.visibilityType == "group" &&
@@ -87,7 +87,7 @@ class ReopenAwaitingModule(
         lastRun: Instant
     ): List<Comment> = comments
         .filter { it.created.isAfter(resolveTime) && it.created.isAfter(lastRun) }
-        .filter { it.author != null && (!it.author.isNewUser() || it.author.name == reporter?.name) }
+        .filter { it.author != null && (!it.author.isNewUser() || it.author.accountId == reporter?.accountId) }
         .filter {
             val roles = it.getAuthorGroups()
             roles == null || roles.intersect(blacklistedRoles).isEmpty()
@@ -100,7 +100,7 @@ class ReopenAwaitingModule(
         resolveTime: Instant
     ): List<ChangeLogItem> = changeLog
         .filter { it.created.isAfter(resolveTime) }
-        .filter { it.author.name == reporter?.name }
+        .filter { it.author.accountId == reporter?.accountId }
         .filter { it.field != "Comment" }
 
     private fun isAwaitingResolve(change: ChangeLogItem) =

--- a/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/registry/InstantModuleRegistry.kt
@@ -3,8 +3,10 @@ package io.github.mojira.arisa.registry
 import com.uchuhimo.konf.Config
 import io.github.mojira.arisa.ExecutionTimeframe
 import io.github.mojira.arisa.domain.cloud.CloudIssue
+import io.github.mojira.arisa.infrastructure.HelperMessageService
 import io.github.mojira.arisa.infrastructure.config.Arisa
 import io.github.mojira.arisa.modules.PrivateDuplicateModule
+import io.github.mojira.arisa.modules.ReopenAwaitingModule
 import io.github.mojira.arisa.modules.privacy.AccessTokenRedactor
 import io.github.mojira.arisa.modules.privacy.PrivacyModule
 
@@ -34,6 +36,18 @@ class InstantModuleRegistry(config: Config) : ModuleRegistry<CloudIssue>(config)
                 config[Arisa.Modules.Privacy.sensitiveTextRegexes].map(String::toRegex),
                 AccessTokenRedactor,
                 config[Arisa.Modules.Privacy.sensitiveFileNameRegexes].map(String::toRegex)
+            )
+        )
+
+        register(
+            Arisa.Modules.ReopenAwaiting,
+            ReopenAwaitingModule(
+                config[Arisa.Modules.ReopenAwaiting.blacklistedRoles].toSetNoDuplicates(),
+                config[Arisa.Modules.ReopenAwaiting.blacklistedVisibilities].toSetNoDuplicates(),
+                config[Arisa.Modules.ReopenAwaiting.softARDays],
+                config[Arisa.Modules.ReopenAwaiting.keepARTag],
+                config[Arisa.Modules.ReopenAwaiting.onlyOPTag],
+                HelperMessageService.getMessage("MC", keys = listOf(config[Arisa.Modules.ReopenAwaiting.message]))
             )
         )
     }

--- a/src/test/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModuleTest.kt
@@ -17,7 +17,6 @@ import java.time.temporal.ChronoUnit
 private val REPORTER = getUser(name = "reporter")
 private val ARISA = getUser(name = "arisabot")
 private val RANDOM_USER = getUser(name = "randomUser")
-private val NEWBIE = getUser(name = "newbieUser")
 
 private val TEN_SECONDS_AGO = RIGHT_NOW.minusSeconds(10)
 private val TWO_YEARS_AGO = RIGHT_NOW.minus(730, ChronoUnit.DAYS)
@@ -720,52 +719,6 @@ class ReopenAwaitingModuleTest : StringSpec({
             reporter = REPORTER,
             comments = listOf(comment),
             changeLog = listOf(AWAITING_RESOLVE, changeLog),
-            reopen = { hasReopened = true; Unit.right() },
-            addComment = { hasCommented = true; Unit.right() }
-        )
-
-        val result = MODULE(issue, TEN_SECONDS_AGO)
-
-        result.shouldBeRight(ModuleResponse)
-        hasReopened shouldBe true
-        hasCommented shouldBe false
-    }
-
-    "should not reopen when the commenter is a new user" {
-        var hasReopened = false
-        var hasCommented = false
-
-        val comment = getComment(author = NEWBIE)
-        val updated = RIGHT_NOW.plusSeconds(3)
-        val issue = mockCloudIssue(
-            resolution = "Awaiting Response",
-            updated = updated,
-            reporter = REPORTER,
-            comments = listOf(comment),
-            changeLog = listOf(AWAITING_RESOLVE),
-            reopen = { hasReopened = true; Unit.right() },
-            addComment = { hasCommented = true; Unit.right() }
-        )
-
-        val result = MODULE(issue, TEN_SECONDS_AGO)
-
-        result.shouldBeLeft(OperationNotNeededModuleResponse)
-        hasReopened shouldBe false
-        hasCommented shouldBe false
-    }
-
-    "should reopen when the commenter is a new user but also the reporter" {
-        var hasReopened = false
-        var hasCommented = false
-
-        val comment = getComment(author = NEWBIE)
-        val updated = RIGHT_NOW.plusSeconds(3)
-        val issue = mockCloudIssue(
-            resolution = "Awaiting Response",
-            updated = updated,
-            reporter = NEWBIE,
-            comments = listOf(comment),
-            changeLog = listOf(AWAITING_RESOLVE),
             reopen = { hasReopened = true; Unit.right() },
             addComment = { hasCommented = true; Unit.right() }
         )

--- a/src/test/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModuleTest.kt
@@ -17,7 +17,7 @@ import java.time.temporal.ChronoUnit
 private val REPORTER = getUser(name = "reporter")
 private val ARISA = getUser(name = "arisabot")
 private val RANDOM_USER = getUser(name = "randomUser")
-private val NEWBIE = getUser(name = "newbieUser", newUser = true)
+private val NEWBIE = getUser(name = "newbieUser")
 
 private val TEN_SECONDS_AGO = RIGHT_NOW.minusSeconds(10)
 private val TWO_YEARS_AGO = RIGHT_NOW.minus(730, ChronoUnit.DAYS)
@@ -913,5 +913,5 @@ private fun getComment(
     visibilityValue = visibilityValue
 )
 
-private fun getUser(name: String, newUser: Boolean = false) =
-    mockUser(name = name, displayName = "User", isNewUser = { newUser })
+private fun getUser(name: String) =
+    mockUser(name = name, displayName = "User")

--- a/src/test/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModuleTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/modules/ReopenAwaitingModuleTest.kt
@@ -5,7 +5,7 @@ import io.github.mojira.arisa.domain.User
 import io.github.mojira.arisa.utils.RIGHT_NOW
 import io.github.mojira.arisa.utils.mockChangeLogItem
 import io.github.mojira.arisa.utils.mockComment
-import io.github.mojira.arisa.utils.mockIssue
+import io.github.mojira.arisa.utils.mockCloudIssue
 import io.github.mojira.arisa.utils.mockUser
 import io.kotest.assertions.arrow.either.shouldBeLeft
 import io.kotest.assertions.arrow.either.shouldBeRight
@@ -47,7 +47,7 @@ private val OLD_AWAITING_RESOLVE = mockChangeLogItem(
 class ReopenAwaitingModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse when there is no resolution" {
         val updated = RIGHT_NOW.plusSeconds(3)
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             updated = updated,
             reporter = REPORTER,
             comments = listOf(getComment()),
@@ -61,7 +61,7 @@ class ReopenAwaitingModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when ticket is not in awaiting response" {
         val updated = RIGHT_NOW.plusSeconds(3)
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Test",
             updated = updated,
             reporter = REPORTER,
@@ -76,7 +76,7 @@ class ReopenAwaitingModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when ticket is less than 2 seconds old" {
         val updated = RIGHT_NOW.plusSeconds(1)
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -91,7 +91,7 @@ class ReopenAwaitingModuleTest : StringSpec({
 
     "should return OperationNotNeededModuleResponse when there are no comments" {
         val updated = RIGHT_NOW.plusSeconds(3)
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -109,7 +109,7 @@ class ReopenAwaitingModuleTest : StringSpec({
             RIGHT_NOW.minusSeconds(20),
             RIGHT_NOW.minusSeconds(20)
         )
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -133,7 +133,7 @@ class ReopenAwaitingModuleTest : StringSpec({
             RIGHT_NOW.minusSeconds(20),
             RIGHT_NOW.minusSeconds(20)
         )
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -158,7 +158,7 @@ class ReopenAwaitingModuleTest : StringSpec({
             field = "customfield_00042",
             changedToString = "Confirmed"
         )
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -173,7 +173,7 @@ class ReopenAwaitingModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse when just the comment was updated" {
         val comment = getComment(RIGHT_NOW.plusSeconds(3), RIGHT_NOW.minusSeconds(20))
         val updated = RIGHT_NOW.plusSeconds(3)
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             comments = listOf(comment),
             updated = updated,
@@ -189,7 +189,7 @@ class ReopenAwaitingModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse when comment is restricted" {
         val comment = getComment(visibilityType = "group", visibilityValue = "helper")
         val updated = RIGHT_NOW.plusSeconds(3)
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             comments = listOf(comment),
             updated = updated,
@@ -205,7 +205,7 @@ class ReopenAwaitingModuleTest : StringSpec({
     "should return OperationNotNeededModuleResponse when comment author is staff" {
         val comment = getComment(authorGroups = listOf("staff"))
         val updated = RIGHT_NOW.plusSeconds(3)
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             comments = listOf(comment),
             updated = updated,
@@ -226,7 +226,7 @@ class ReopenAwaitingModuleTest : StringSpec({
             author = REPORTER
         )
         val updated = RIGHT_NOW.plusSeconds(3)
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -245,7 +245,7 @@ class ReopenAwaitingModuleTest : StringSpec({
             changedToString = "1.15.2"
         )
         val updated = RIGHT_NOW.plusSeconds(3)
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -264,7 +264,7 @@ class ReopenAwaitingModuleTest : StringSpec({
             changedToString = "1.15.2"
         )
         val updated = RIGHT_NOW.plusSeconds(3)
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = ARISA,
@@ -285,7 +285,7 @@ class ReopenAwaitingModuleTest : StringSpec({
             author = REPORTER
         ) { emptyList() }
         val updated = RIGHT_NOW.plusSeconds(3)
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -302,7 +302,7 @@ class ReopenAwaitingModuleTest : StringSpec({
         var hasCommented = false
 
         val updated = RIGHT_NOW.plusSeconds(3)
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -326,7 +326,7 @@ class ReopenAwaitingModuleTest : StringSpec({
         val updated = RIGHT_NOW.plusSeconds(3)
         val commentFail = getComment(visibilityType = "group", visibilityValue = "staff")
         val commentSuccess = getComment()
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -350,7 +350,7 @@ class ReopenAwaitingModuleTest : StringSpec({
         val updated = RIGHT_NOW.plusSeconds(3)
         val commentFail = getComment(visibilityType = "group", visibilityValue = "staff")
         val commentSuccess = getComment()
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -378,7 +378,7 @@ class ReopenAwaitingModuleTest : StringSpec({
             changedFromString = "",
             changedToString = "Confirmed"
         ) { emptyList() }
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -401,7 +401,7 @@ class ReopenAwaitingModuleTest : StringSpec({
 
         val updated = RIGHT_NOW.plusSeconds(3)
         val comment = getComment()
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -423,7 +423,7 @@ class ReopenAwaitingModuleTest : StringSpec({
         val updated = RIGHT_NOW.plusSeconds(3)
         val comment = getComment()
         val keep = getComment(body = "ARISA_REOPEN_OP", visibilityType = "group", visibilityValue = "staff")
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -444,7 +444,7 @@ class ReopenAwaitingModuleTest : StringSpec({
         val updated = RIGHT_NOW.plusSeconds(3)
         val comment = getComment(author = REPORTER)
         val keep = getComment(body = "ARISA_REOPEN_OP", visibilityType = "group", visibilityValue = "staff")
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -472,7 +472,7 @@ class ReopenAwaitingModuleTest : StringSpec({
         )
         val reopenOpComment = getComment(body = "ARISA_REOPEN_OP", visibilityType = "group", visibilityValue = "staff")
         val updated = RIGHT_NOW.plusSeconds(3)
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -495,7 +495,7 @@ class ReopenAwaitingModuleTest : StringSpec({
 
         val updated = RIGHT_NOW.plusSeconds(3)
         val comment = getComment()
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -520,7 +520,7 @@ class ReopenAwaitingModuleTest : StringSpec({
         val comment = getComment(
             author = REPORTER
         )
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -543,7 +543,7 @@ class ReopenAwaitingModuleTest : StringSpec({
 
         val updated = RIGHT_NOW.plusSeconds(3)
         val comment = getComment(body = "MEQS_KEEP_AR")
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -566,7 +566,7 @@ class ReopenAwaitingModuleTest : StringSpec({
 
         val comment = getComment(RIGHT_NOW.plusSeconds(3), RIGHT_NOW.minusSeconds(5))
         val updated = RIGHT_NOW.plusSeconds(3)
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -589,7 +589,7 @@ class ReopenAwaitingModuleTest : StringSpec({
 
         val updated = RIGHT_NOW.plusSeconds(3)
         val comment = getComment(visibilityType = "not-a-group", visibilityValue = "helper")
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -612,7 +612,7 @@ class ReopenAwaitingModuleTest : StringSpec({
 
         val updated = RIGHT_NOW.plusSeconds(3)
         val comment = getComment(visibilityType = "group", visibilityValue = "users")
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -635,7 +635,7 @@ class ReopenAwaitingModuleTest : StringSpec({
 
         val updated = RIGHT_NOW.plusSeconds(3)
         val comment = getComment(authorGroups = emptyList())
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -658,7 +658,7 @@ class ReopenAwaitingModuleTest : StringSpec({
 
         val updated = RIGHT_NOW.plusSeconds(3)
         val comment = getComment(authorGroups = listOf("Users"))
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -686,7 +686,7 @@ class ReopenAwaitingModuleTest : StringSpec({
             author = REPORTER
         )
         val updated = RIGHT_NOW.plusSeconds(3)
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -714,7 +714,7 @@ class ReopenAwaitingModuleTest : StringSpec({
         )
         val comment = getComment()
         val updated = RIGHT_NOW.plusSeconds(3)
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -737,7 +737,7 @@ class ReopenAwaitingModuleTest : StringSpec({
 
         val comment = getComment(author = NEWBIE)
         val updated = RIGHT_NOW.plusSeconds(3)
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -760,7 +760,7 @@ class ReopenAwaitingModuleTest : StringSpec({
 
         val comment = getComment(author = NEWBIE)
         val updated = RIGHT_NOW.plusSeconds(3)
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = NEWBIE,
@@ -788,7 +788,7 @@ class ReopenAwaitingModuleTest : StringSpec({
             visibilityValue = "staff"
         )
         val normalComment = getComment()
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -812,7 +812,7 @@ class ReopenAwaitingModuleTest : StringSpec({
 
         val updated = RIGHT_NOW.plusSeconds(3)
         val comment = getComment()
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -845,7 +845,7 @@ class ReopenAwaitingModuleTest : StringSpec({
             author = ARISA
         )
         val normalComment = getComment()
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,
@@ -876,7 +876,7 @@ class ReopenAwaitingModuleTest : StringSpec({
             body = NOT_REOPEN_AR_MESSAGE,
             author = RANDOM_USER
         )
-        val issue = mockIssue(
+        val issue = mockCloudIssue(
             resolution = "Awaiting Response",
             updated = updated,
             reporter = REPORTER,

--- a/src/test/kotlin/io/github/mojira/arisa/utils/MockCloudDomain.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/utils/MockCloudDomain.kt
@@ -7,6 +7,7 @@ import io.github.mojira.arisa.domain.ChangeLogItem
 import io.github.mojira.arisa.domain.Comment
 import io.github.mojira.arisa.domain.CommentOptions
 import io.github.mojira.arisa.domain.Project
+import io.github.mojira.arisa.domain.User
 import io.github.mojira.arisa.domain.cloud.CloudIssue
 import io.github.mojira.arisa.domain.cloud.CloudLink
 import io.github.mojira.arisa.domain.cloud.CloudLinkedIssue
@@ -20,37 +21,43 @@ fun mockCloudIssue(
     description: String? = null,
     environment: String? = null,
     securityLevel: String? = null,
+    reporter: User? = null,
     resolution: String? = null,
     created: Instant = RIGHT_NOW,
+    updated: Instant = RIGHT_NOW,
     project: Project = mockProject(),
     attachments: List<Attachment> = emptyList(),
     comments: List<Comment> = emptyList(),
     links: List<CloudLink> = emptyList(),
     changeLog: List<ChangeLogItem> = emptyList(),
+    reopen: () -> Unit = { },
     setPrivate: () -> Unit = { },
     addComment: (options: CommentOptions) -> Unit = { },
     addRawRestrictedComment: (body: String, restriction: String) -> Unit = { _, _ -> },
     addRawBotComment: (rawMessage: String) -> Unit = { },
     addAttachmentFromFile: (file: File, cleanupCallback: () -> Unit) -> Unit = { _, cleanupCallback -> cleanupCallback() }
 ) = CloudIssue(
-    key,
-    summary,
-    status,
-    description,
-    environment,
-    securityLevel,
-    resolution,
-    created,
-    project,
-    attachments,
-    comments,
-    links,
-    changeLog,
-    setPrivate,
-    addComment,
-    addRawRestrictedComment,
-    addRawBotComment,
-    addAttachmentFromFile
+    key = key,
+    summary = summary,
+    status = status,
+    description = description,
+    environment = environment,
+    securityLevel = securityLevel,
+    resolution = resolution,
+    reporter = reporter,
+    created = created,
+    updated = updated,
+    project = project,
+    attachments = attachments,
+    comments = comments,
+    links = links,
+    changeLog = changeLog,
+    reopen = reopen,
+    setPrivate = setPrivate,
+    addComment = addComment,
+    addRawRestrictedComment = addRawRestrictedComment,
+    addRawBotComment = addRawBotComment,
+    addAttachmentFromFile = addAttachmentFromFile
 )
 
 fun mockCloudLinkedIssue(

--- a/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
@@ -256,7 +256,6 @@ fun mockUser(
     name,
     displayName,
     getGroups,
-    isNewUser,
     isBotUser
 )
 

--- a/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/utils/MockDomain.kt
@@ -15,6 +15,7 @@ import io.github.mojira.arisa.domain.Version
 import java.io.File
 import java.io.InputStream
 import java.time.Instant
+import java.util.UUID
 
 val RIGHT_NOW: Instant = Instant.now()
 const val PRIVATE_SECURITY_LEVEL = "private"
@@ -239,8 +240,12 @@ fun mockProject(
     privateSecurity
 )
 
+fun generateUUID(): String {
+    return UUID.randomUUID().toString()
+}
+
 fun mockUser(
-    accountId: String = "712020:33043866-64fe-4184-b28e-32ae8e3bd15f",
+    accountId: String = generateUUID(),
     name: String = "user",
     displayName: String = "User",
     getGroups: () -> List<String>? = { null },


### PR DESCRIPTION
## Purpose

Re-registers the AwaitingResponse module, as it was adapted to the cloud API.

[reopen-by-reporter-comment.webm](https://github.com/user-attachments/assets/123dc4bf-e91a-4b8d-97ec-c8dd498ed847)


## Approach

- Replace deprecated `name` attribute usages with `accountId`,
- Remove the logic of checking whether the user account is new (and accompanied tests),
- Port issue transition logic from old client.

## Future work

#### Checklist

- [x] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md)
  and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
