### PR TITLE
feat: support api token with scopes

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -21,8 +21,7 @@ arisa:
       - Unresolved
       - Won't Fix
       - Works As Intended
-    # End with trailing slash
-    url: https://api.atlassian.com/ex/jira/
+    url: https://api.atlassian.com/ex/jira
 
   customFields:
     linked: customfield_11100

--- a/config/config.yml
+++ b/config/config.yml
@@ -21,7 +21,8 @@ arisa:
       - Unresolved
       - Won't Fix
       - Works As Intended
-    url: https://mojira.atlassian.net/
+    # End with trailing slash
+    url: https://api.atlassian.com/ex/jira/
 
   customFields:
     linked: customfield_11100

--- a/config/local.template.yml
+++ b/config/local.template.yml
@@ -6,6 +6,8 @@ arisa:
     password: <plain text password>
     email: <JIRA email>
     apiToken: <JIRA api token for the user with above email>
+    # Get your cloud ID by visiting https://<your-site-name>.atlassian.net/_edge/tenant_info
+    cloudId: <JIRA cloud ID>
 
     # These configs are optional and can be omitted
     dandelionToken: <Dandelion token>

--- a/docs/ApiToken.md
+++ b/docs/ApiToken.md
@@ -1,0 +1,106 @@
+# API Token
+
+Arisa requires an API token with scopes. The token can be generated 
+in the [Profile Settings > Security > API Tokens](https://id.atlassian.com/manage-profile/security/api-tokens).
+
+## Required Scopes
+
+Classic scopes:
+- `read:jira-work`
+- `write:jira-work`
+- `read:jira-user`
+
+## Cloud ID
+
+Additionally, a [Cloud ID](https://support.atlassian.com/jira/kb/retrieve-my-atlassian-sites-cloud-id/) is required to use the API token.
+A quick and easy method is to visit:
+```http request
+https://<your-site-name>.atlassian.net/_edge/tenant_info
+```
+Save the ID into `local.yml`.
+
+## Used API Endpoints Reference
+
+### [GET /project/{projectIdOrKey}](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-projects/#api-rest-api-2-project-projectidorkey-get)
+
+Scopes (classic): `read:jira-work`
+
+
+### [GET /issue/{issueIdOrKey}](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/#api-rest-api-2-issue-issueidorkey-get)
+
+Scopes (classic): `read:jira-work`
+
+
+### [PUT /issue/{issueIdOrKey}](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/#api-rest-api-2-issue-issueidorkey-put)
+
+Scopes (classic): `write:jira-work`
+
+
+### [GET /myself](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-myself/#api-rest-api-2-myself-get)
+
+Scopes (classic): `read:jira-user`
+
+
+### [GET /user/groups](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-users/#api-rest-api-2-user-groups-get)
+
+Scopes (classic): `read:jira-user`
+
+
+### [POST /search](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-search/#api-rest-api-2-search-post)
+
+Scopes (classic): `read:jira-work`
+
+
+### [GET /attachment/content/{id}](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-attachments/#api-rest-api-2-attachment-content-id-get)
+
+Scopes (classic): `read:jira-work`
+
+
+### [POST /issue/{issueIdOrKey}/attachments](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-attachments/#api-rest-api-2-issue-issueidorkey-attachments-post)
+
+Scopes (classic): `write:jira-work`
+
+
+### [DELETE /attachment/{id}](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-attachments/#api-rest-api-2-attachment-id-delete)
+
+Scopes (classic): `write:jira-work`
+
+
+### [POST /issue/{issueIdOrKey}/comment](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-comments/#api-rest-api-2-issue-issueidorkey-comment-post)
+
+Scopes (classic): `write:jira-work`
+
+
+### [PUT /issue/{issueIdOrKey}/comment/{projectIdOrKey}](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-comments/#api-rest-api-2-issue-issueidorkey-comment-id-put)
+
+Scopes (classic): `write:jira-work`
+
+
+### [DELETE /issue/{issueIdOrKey}/comment/{projectIdOrKey}](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-comments/#api-rest-api-2-issue-issueidorkey-comment-id-delete)
+
+Scopes (classic): `write:jira-work`
+
+
+### [POST /issueLink](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-links/#api-rest-api-2-issuelink-post)
+
+Scopes (classic): `write:jira-work`
+
+
+### [GET /issueLink/{linkId}](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-links/#api-rest-api-2-issuelink-linkid-get)
+
+Scopes (classic): `read:jira-work`
+
+
+### [DELETE /issueLink/{linkId}](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-links/#api-rest-api-2-issuelink-linkid-delete)
+
+Scopes (classic): `write:jira-work`
+
+
+### [GET /issue/{issueIdOrKey}/transitions](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/#api-rest-api-2-issue-issueidorkey-transitions-get)
+
+Scopes (classic): `read:jira-work`
+
+
+### [POST /issue/{issueIdOrKey}/transitions](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/#api-rest-api-2-issue-issueidorkey-transitions-post)
+
+Scopes (classic): `write:jira-work`

--- a/src/main/kotlin/io/github/mojira/arisa/JiraConnectionService.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/JiraConnectionService.kt
@@ -1,8 +1,8 @@
 package io.github.mojira.arisa
 
 import com.uchuhimo.konf.Config
+import io.github.mojira.arisa.apiclient.JiraClient
 import io.github.mojira.arisa.infrastructure.config.Arisa
-import io.github.mojira.arisa.infrastructure.jira.connectToJira
 import java.lang.Long.max
 import java.time.Duration
 import java.time.Instant
@@ -39,11 +39,12 @@ class JiraConnectionService(
     @Suppress("TooGenericExceptionCaught")
     private fun establishConnection(): Exception? {
         return try {
-            val client = connectToJira(
-                config[Arisa.Credentials.email],
-                config[Arisa.Credentials.apiToken],
-                config[Arisa.Issues.url],
-                config[Arisa.Debug.logNetworkRequests]
+            val client = JiraClient(
+                jiraUrl = config[Arisa.Issues.url],
+                email = config[Arisa.Credentials.email],
+                apiToken = config[Arisa.Credentials.apiToken],
+                cloudId = config[Arisa.Credentials.cloudId],
+                logHttpRequests = config[Arisa.Debug.logNetworkRequests]
             )
 
             log.info("Successfully connected to jira")

--- a/src/main/kotlin/io/github/mojira/arisa/apiclient/JiraClient.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/apiclient/JiraClient.kt
@@ -26,6 +26,7 @@ import io.github.mojira.arisa.apiclient.requestModels.UpdateCommentBody
 import io.github.mojira.arisa.apiclient.requestModels.UpdateCommentQueryParams
 import io.github.mojira.arisa.log
 import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
@@ -203,7 +204,9 @@ class JiraClient(
                 }
                 .build()
 
-        val apiBaseUrl = jiraUrl.plus(cloudId).plus("/rest/api/2/")
+        val apiBaseUrl = jiraUrl.toHttpUrl().newBuilder()
+            .addPathSegments("${cloudId}/rest/api/2/")
+            .build()
         val mediaType = "application/json".toMediaType()
         val json = Json { ignoreUnknownKeys = true }
 

--- a/src/main/kotlin/io/github/mojira/arisa/apiclient/JiraClient.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/apiclient/JiraClient.kt
@@ -185,6 +185,7 @@ class JiraClient(
     private val jiraUrl: String,
     private val email: String,
     private val apiToken: String,
+    private val cloudId: String,
     private val logHttpRequests: Boolean?
 ) {
     private val jiraApi: JiraApi
@@ -202,7 +203,7 @@ class JiraClient(
                 }
                 .build()
 
-        val apiBaseUrl = jiraUrl.plus("rest/api/2/")
+        val apiBaseUrl = jiraUrl.plus(cloudId).plus("/rest/api/2/")
         val mediaType = "application/json".toMediaType()
         val json = Json { ignoreUnknownKeys = true }
 

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/config/ArisaConfig.kt
@@ -11,6 +11,7 @@ object Arisa : ConfigSpec() {
         val password by required<String>()
         val email by required<String>()
         val apiToken by required<String>()
+        val cloudId by required<String>()
         val dandelionToken by optional<String?>(
             null,
             description = "Token for dandelion.eu"

--- a/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/infrastructure/jira/Functions.kt
@@ -40,10 +40,6 @@ import io.github.mojira.arisa.jiraClient
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
-fun connectToJira(email: String, apiToken: String, url: String, logNetworkRequests: Boolean? = false): JiraClient {
-    return JiraClient(url, email, apiToken, logNetworkRequests)
-}
-
 /**
  * Get a list of tickets matching a JQL query.
  * TODO: Actually return the tickets themselves instead of only ticket IDs.

--- a/src/test/kotlin/io/github/mojira/arisa/infrastructure/IntegrationTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/infrastructure/IntegrationTest.kt
@@ -20,7 +20,8 @@ class IntegrationTest : StringSpec({
                     "arisa.credentials.password" to "test",
                     "arisa.credentials.email" to "test",
                     "arisa.credentials.apiToken" to "test",
-                    "arisa.credentials.dandelionToken" to "test"
+                    "arisa.credentials.dandelionToken" to "test",
+                    "arisa.credentials.cloudId" to "test"
                 )
             )
             .from.enabled(Feature.FAIL_ON_UNKNOWN_PATH).yaml.watchFile("config/config.yml")


### PR DESCRIPTION
## Purpose

Adds support for API Tokens with Scopes (both classic and granular). Deployment will require recreating [API Token](https://id.atlassian.com/manage-profile/security/api-tokens) with the scopes specified in `ApiToken.md`. I've added all used endpoints for quicker reference in the future if needed, as each has it's own scopes documented.

Additionally, using tokens with scopes requires using different URL to serve requests from. This URL requires using `cloudId` in requests. CloudID can be obtained by visiting https://mojira.atlassian.net/_edge/tenant_info

## Approach

## Future work

~~Improve logic for concatenating URL in `JiraClient.kt`.~~ Done.

#### Checklist

- [x] Included tests
- [x] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md)
  and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
