### PR TITLE
Move out of deprecated search endpoint

### DIFF
--- a/src/main/kotlin/io/github/mojira/arisa/apiclient/JiraClient.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/apiclient/JiraClient.kt
@@ -80,7 +80,7 @@ interface JiraApi {
         @Query("key") key: String?
     ): Call<List<GroupName>>
 
-    @POST("search")
+    @POST("search/jql")
     fun searchIssues(
         @Body request: JiraSearchRequest,
     ): Call<SearchResults>
@@ -226,7 +226,7 @@ class JiraClient(
         fields: List<String> = emptyList(),
         expand: List<String> = emptyList(),
         maxResults: Int = 100,
-        startAt: Int = 0,
+        nextPageToken: String? = null,
     ): SearchResults {
         val payload =
             JiraSearchRequest(
@@ -234,7 +234,7 @@ class JiraClient(
                 fields = fields,
                 jql = jql,
                 maxResults = maxResults,
-                startAt = startAt,
+                nextPageToken = nextPageToken,
             )
 
         return jiraApi.searchIssues(payload).executeOrThrow()

--- a/src/main/kotlin/io/github/mojira/arisa/apiclient/models/SearchResults.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/apiclient/models/SearchResults.kt
@@ -4,8 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class SearchResults(
+    val isLast: Boolean,
     val issues: List<IssueBean>,
-    val maxResults: Int,
-    val startAt: Int,
-    val total: Int
+    val nextPageToken: String? = null
 )

--- a/src/main/kotlin/io/github/mojira/arisa/apiclient/requestModels/JiraSearchRequest.kt
+++ b/src/main/kotlin/io/github/mojira/arisa/apiclient/requestModels/JiraSearchRequest.kt
@@ -9,5 +9,5 @@ data class JiraSearchRequest(
     val fieldsByKeys: Boolean? = null,
     val jql: String,
     val maxResults: Int,
-    val startAt: Int
+    val nextPageToken: String? = null
 )

--- a/src/test/kotlin/io/github/mojira/arisa/ExecutorTest.kt
+++ b/src/test/kotlin/io/github/mojira/arisa/ExecutorTest.kt
@@ -66,7 +66,7 @@ class ExecutorTest : StringSpec({
             searchIssues = { _, _, finishedCallback ->
                 run {
                     finishedCallback()
-                    listOf(mockCloudIssue("MC-1"))
+                    null to listOf(mockCloudIssue("MC-1"))
                 }
             }
         )
@@ -102,10 +102,10 @@ class ExecutorTest : StringSpec({
 
 fun getMockExecutor(
     registries: List<ModuleRegistry<CloudIssue>>,
-    searchIssues: (String, Int, () -> Unit) -> List<CloudIssue> =
+    searchIssues: (String, String?, () -> Unit) -> Pair<String?, List<CloudIssue>> =
         { _, _, finishedCallback ->
             finishedCallback()
-            listOf(mockCloudIssue())
+            null to listOf(mockCloudIssue())
         }
 ): Executor = Executor(
     getConfig(),


### PR DESCRIPTION
In https://developer.atlassian.com/changelog/#CHANGE-2046, Jira removed the endpoint we were using for search. Switch to the replacement

## Purpose

## Approach

## Future work

#### Checklist

- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/mojira/arisa-kt/blob/master/README.md)
  and [`docs` folder](https://github.com/mojira/arisa-kt/blob/master/docs)
- [ ] Tested in MCTEST-xxx
